### PR TITLE
:sparkles: Add start_detached

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,7 +11,7 @@ project(
 include(cmake/get_cpm.cmake)
 cpmaddpackage("gh:intel/cicd-repo-infrastructure#main")
 
-add_versioned_package("gh:intel/cpp-std-extensions#8cebc04")
+add_versioned_package("gh:intel/cpp-std-extensions#b6a7c67")
 add_versioned_package("gh:intel/cpp-baremetal-concurrency#659771e")
 add_versioned_package("gh:boostorg/mp11#boost-1.83.0")
 

--- a/include/async/allocator.hpp
+++ b/include/async/allocator.hpp
@@ -1,0 +1,52 @@
+#pragma once
+
+#include <stdx/bit.hpp>
+#include <stdx/bitset.hpp>
+
+#include <array>
+#include <cstddef>
+#include <iterator>
+#include <memory>
+#include <utility>
+
+namespace async {
+template <typename T, std::size_t N> struct static_allocator {
+    constexpr static inline auto alignment = alignof(T);
+    constexpr static inline auto size = sizeof(T);
+    constexpr static inline auto aligned_size =
+        size % alignment == 0 ? size : size + alignment - (size % alignment);
+
+    using storage_t = std::array<std::byte, aligned_size * N>;
+
+    alignas(alignment) storage_t data{};
+    stdx::bitset<N> used{};
+
+    template <typename... Args> auto construct(Args &&...args) -> T * {
+        auto const idx = used.lowest_unset();
+        if (idx == N) {
+            return nullptr;
+        }
+        auto const ptr = std::data(data) + idx * aligned_size;
+        used.set(idx);
+        return std::construct_at(stdx::bit_cast<T *>(ptr),
+                                 std::forward<Args>(args)...);
+    }
+
+    auto destruct(T const *t) -> void {
+        std::destroy_at(t);
+        auto const ptr = stdx::bit_cast<std::byte *>(t);
+        auto const idx =
+            static_cast<std::size_t>(ptr - std::data(data)) / aligned_size;
+        used.reset(idx);
+    }
+};
+
+template <typename Name>
+constexpr inline auto allocation_limit = std::size_t{1};
+template <typename T, std::size_t N>
+static inline static_allocator<T, N> alloc{};
+
+template <typename Name, typename T> constexpr auto get_allocator() -> auto & {
+    return alloc<T, allocation_limit<Name>>;
+}
+} // namespace async

--- a/include/async/start_detached.hpp
+++ b/include/async/start_detached.hpp
@@ -1,0 +1,75 @@
+#pragma once
+
+#include <async/allocator.hpp>
+#include <async/concepts.hpp>
+#include <async/tags.hpp>
+
+#include <concepts>
+#include <type_traits>
+#include <utility>
+
+namespace async {
+namespace _start_detached {
+template <typename Ops> struct receiver {
+    using is_receiver = void;
+
+    template <typename... Args> auto set_value(Args &&...) const -> void {
+        ops->die();
+    }
+    auto set_error(auto &&...) const -> void { ops->die(); }
+    auto set_stopped() const -> void { ops->die(); }
+
+    Ops *ops;
+};
+
+template <typename Uniq, typename Sndr>
+// NOLINTNEXTLINE(cppcoreguidelines-special-member-functions)
+struct op_state {
+    using Ops = connect_result_t<Sndr, receiver<op_state>>;
+
+    template <typename S>
+    constexpr explicit(true) op_state(S &&s)
+        : ops{connect(std::forward<S>(s), receiver<op_state>{this})} {}
+    constexpr op_state(op_state &&) = delete;
+
+    auto start() -> void { ops.start(); }
+
+    auto die() {
+        auto &alloc = get_allocator<Uniq, op_state>();
+        alloc.destruct(this);
+    }
+
+    Ops ops;
+};
+
+template <typename Uniq, sender S> [[nodiscard]] auto start(S &&s) -> bool {
+    using O = op_state<Uniq, std::remove_cvref_t<S>>;
+    auto &alloc = get_allocator<Uniq, O>();
+    if (auto op_state = alloc.construct(std::forward<S>(s)); op_state) {
+        op_state->start();
+        return true;
+    }
+    return false;
+}
+
+template <typename Uniq> struct pipeable {
+  private:
+    template <async::sender S, typename Self>
+        requires std::same_as<pipeable, std::remove_cvref_t<Self>>
+    friend auto operator|(S &&s, Self &&) {
+        return start<Uniq>(std::forward<S>(s));
+    }
+};
+} // namespace _start_detached
+
+template <typename Uniq = decltype([] {}), sender S>
+[[nodiscard]] auto start_detached(S &&s) {
+    return _start_detached::start<Uniq>(std::forward<S>(s));
+}
+
+template <typename Uniq = decltype([] {})>
+[[nodiscard]] constexpr auto start_detached()
+    -> _start_detached::pipeable<Uniq> {
+    return {};
+}
+} // namespace async

--- a/include/async/then.hpp
+++ b/include/async/then.hpp
@@ -188,7 +188,7 @@ template <typename Tag, typename S, typename... Fs> class sender {
 
     template <typename Self, receiver_from<sender> R>
         requires std::same_as<sender, std::remove_cvref_t<Self>> and
-                 multishot_sender<S, R>
+                 multishot_sender<S>
     [[nodiscard]] friend constexpr auto tag_invoke(connect_t, Self &&self,
                                                    R &&r) {
         return connect(

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -15,6 +15,7 @@ function(add_tests)
 endfunction()
 
 add_tests(
+    allocator
     concepts
     env
     forwarding_query
@@ -33,6 +34,7 @@ add_tests(
     repeat
     retry
     split
+    start_detached
     stop_token
     then
     transfer

--- a/test/allocator.cpp
+++ b/test/allocator.cpp
@@ -1,0 +1,66 @@
+#include "detail/common.hpp"
+
+#include <async/allocator.hpp>
+
+#include <stdx/functional.hpp>
+
+#include <catch2/catch_test_macros.hpp>
+
+namespace {
+struct domain;
+struct multi_domain;
+
+struct S {
+    S(int x) : i{x} {}
+    int i;
+};
+} // namespace
+
+TEST_CASE("allocate with default limit 1", "[allocator]") {
+    auto &alloc = async::get_allocator<domain, S>();
+    auto p = alloc.construct(42);
+    REQUIRE(p);
+    CHECK(p->i == 42);
+    alloc.destruct(p);
+}
+
+TEST_CASE("allocate fails when static limit is reached", "[allocator]") {
+    auto &alloc = async::get_allocator<domain, S>();
+    auto p = alloc.construct(42);
+    REQUIRE(p);
+    auto q = alloc.construct(17);
+    CHECK(not q);
+    alloc.destruct(p);
+}
+
+template <>
+constexpr inline auto async::allocation_limit<multi_domain> = std::size_t{2};
+
+TEST_CASE("allocate more than 1", "[allocator]") {
+    auto &alloc = async::get_allocator<multi_domain, S>();
+    auto p = alloc.construct(42);
+    REQUIRE(p);
+    auto q = alloc.construct(17);
+    REQUIRE(q);
+    auto x = alloc.construct(1);
+    CHECK(not x);
+
+    CHECK(p->i == 42);
+    CHECK(q->i == 17);
+    alloc.destruct(p);
+    alloc.destruct(q);
+}
+
+namespace {
+struct nm : non_moveable {
+    int i;
+};
+} // namespace
+
+TEST_CASE("allocate non-movable objects", "[allocator]") {
+    auto &alloc = async::get_allocator<domain, nm>();
+    auto p = alloc.construct(stdx::with_result_of{[] { return nm{{}, 42}; }});
+    REQUIRE(p);
+    CHECK(p->i == 42);
+    alloc.destruct(p);
+}

--- a/test/start_detached.cpp
+++ b/test/start_detached.cpp
@@ -1,0 +1,74 @@
+#include "detail/common.hpp"
+
+#include <async/just_result_of.hpp>
+#include <async/schedulers/priority_scheduler.hpp>
+#include <async/schedulers/task_manager.hpp>
+#include <async/start_detached.hpp>
+#include <async/then.hpp>
+
+#include <catch2/catch_test_macros.hpp>
+
+TEST_CASE("basic operation", "[start_detached]") {
+    int var{};
+    auto s = async::just_result_of([&] { var = 42; });
+    CHECK(async::start_detached(s));
+    CHECK(var == 42);
+}
+
+namespace {
+struct hal {
+    static auto schedule(async::priority_t) {}
+};
+
+using task_manager_t = async::priority_task_manager<hal, 8>;
+} // namespace
+
+template <> inline auto async::injected_task_manager<> = task_manager_t{};
+
+TEST_CASE("start_detached starts the operation", "[start_detached]") {
+    int var{};
+    using S = async::fixed_priority_scheduler<0>;
+    auto s = S::schedule() | async::then([&] { var = 42; });
+    CHECK(async::start_detached(s));
+    CHECK(var == 0);
+    async::task_mgr::service_tasks<0>();
+    CHECK(var == 42);
+}
+
+TEST_CASE("start_detached fails when allocation limit is reached",
+          "[start_detached]") {
+    int var{};
+    using S = async::fixed_priority_scheduler<0>;
+    auto s = S::schedule() | async::then([&] { ++var; });
+
+    using Name = decltype([] {});
+    CHECK(async::start_detached<Name>(s));
+    CHECK(not async::start_detached<Name>(s));
+    async::task_mgr::service_tasks<0>();
+    CHECK(var == 1);
+}
+
+TEST_CASE("state is freed on completion", "[start_detached]") {
+    int var{};
+    using S = async::fixed_priority_scheduler<0>;
+    auto s = S::schedule() | async::then([&] { ++var; });
+
+    using Name = decltype([] {});
+    CHECK(async::start_detached<Name>(s));
+    async::task_mgr::service_tasks<0>();
+    CHECK(async::start_detached<Name>(s));
+    async::task_mgr::service_tasks<0>();
+    CHECK(var == 2);
+}
+
+TEST_CASE("start_detached is actually detached", "[start_detached]") {
+    int var{};
+    using S = async::fixed_priority_scheduler<0>;
+    {
+        auto s = S::schedule() | async::then([&] { var = 42; });
+        CHECK(async::start_detached(s));
+    }
+    CHECK(var == 0);
+    async::task_mgr::service_tasks<0>();
+    CHECK(var == 42);
+}


### PR DESCRIPTION
`start_detached` uses an allocator, by default a static allocator that is named according to the "allocation domain". And the default name is unique per call site.

`start_detached` enables interrupt scheduler tasks to be fire-and-forget.