### PR TITLE
:art: Change `set_value` etc to `tag_invoke` style

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,7 +11,7 @@ project(
 include(cmake/get_cpm.cmake)
 cpmaddpackage("gh:intel/cicd-repo-infrastructure#main")
 
-add_versioned_package("gh:intel/cpp-std-extensions#b6a7c67")
+add_versioned_package("gh:intel/cpp-std-extensions#fc9d0c4")
 add_versioned_package("gh:intel/cpp-baremetal-concurrency#659771e")
 add_versioned_package("gh:boostorg/mp11#boost-1.83.0")
 

--- a/include/async/concepts.hpp
+++ b/include/async/concepts.hpp
@@ -115,11 +115,14 @@ concept sender_of =
 
 namespace detail {
 template <typename E = empty_env> struct universal_receiver : receiver_base {
-    auto set_value(auto &&...) const -> void;
-    auto set_error(auto &&...) const -> void;
-    auto set_stopped() const -> void;
-
-    constexpr auto tag_invoke(get_env_t, universal_receiver const &self) -> E;
+  private:
+    friend constexpr auto tag_invoke(channel_tag auto,
+                                     universal_receiver const &, auto &&...)
+        -> void {}
+    friend constexpr auto tag_invoke(get_env_t, universal_receiver const &)
+        -> E {
+        return {};
+    }
 };
 
 template <typename S, typename R>

--- a/include/async/let.hpp
+++ b/include/async/let.hpp
@@ -18,21 +18,20 @@
 namespace async::_let {
 template <typename Ops, typename Rcvr> struct second_receiver {
     using is_receiver = void;
-    template <typename... Args> auto set_value(Args &&...args) const -> void {
-        ops->rcvr.set_value(std::forward<Args>(args)...);
+    Ops *ops;
+
+  private:
+    template <channel_tag Tag, typename... Args>
+    friend auto tag_invoke(Tag, second_receiver const &self, Args &&...args)
+        -> void {
+        Tag{}(self.ops->rcvr, std::forward<Args>(args)...);
     }
-    template <typename... Args> auto set_error(Args &&...args) const -> void {
-        ops->rcvr.set_error(std::forward<Args>(args)...);
-    }
-    auto set_stopped() const -> void { ops->rcvr.set_stopped(); }
 
     [[nodiscard]] friend constexpr auto tag_invoke(async::get_env_t,
                                                    second_receiver const &r)
         -> detail::forwarding_env<env_of_t<Rcvr>> {
         return forward_env_of(r.ops->rcvr);
     }
-
-    Ops *ops;
 };
 
 template <typename Sndr, typename Rcvr, typename Func,

--- a/include/async/let_error.hpp
+++ b/include/async/let_error.hpp
@@ -14,14 +14,15 @@ namespace async {
 namespace _let_error {
 template <typename F, typename Ops, typename Rcvr>
 struct first_receiver : _let::second_receiver<Ops, Rcvr> {
-    template <typename... Args> auto set_error(Args &&...args) const & -> void {
-        this->ops->complete_first(f(std::forward<Args>(args)...));
-    }
-    template <typename... Args> auto set_error(Args &&...args) && -> void {
-        this->ops->complete_first(std::move(f)(std::forward<Args>(args)...));
-    }
-
     [[no_unique_address]] F f;
+
+  private:
+    template <typename Self, typename... Args>
+        requires std::same_as<first_receiver, std::remove_cvref_t<Self>>
+    friend auto tag_invoke(set_error_t, Self &&self, Args &&...args) -> void {
+        self.ops->complete_first(
+            std::forward<Self>(self).f(std::forward<Args>(args)...));
+    }
 };
 
 template <typename S, typename F>

--- a/include/async/let_stopped.hpp
+++ b/include/async/let_stopped.hpp
@@ -14,10 +14,14 @@ namespace async {
 namespace _let_stopped {
 template <typename F, typename Ops, typename Rcvr>
 struct first_receiver : _let::second_receiver<Ops, Rcvr> {
-    auto set_stopped() const & -> void { this->ops->complete_first(f()); }
-    auto set_stopped() && -> void { this->ops->complete_first(std::move(f)()); }
-
     [[no_unique_address]] F f;
+
+  private:
+    template <typename Self>
+        requires std::same_as<first_receiver, std::remove_cvref_t<Self>>
+    friend auto tag_invoke(set_stopped_t, Self &&self) -> void {
+        self.ops->complete_first(std::forward<Self>(self).f());
+    }
 };
 
 template <typename S, typename F>

--- a/include/async/let_value.hpp
+++ b/include/async/let_value.hpp
@@ -14,14 +14,15 @@ namespace async {
 namespace _let_value {
 template <typename F, typename Ops, typename Rcvr>
 struct first_receiver : _let::second_receiver<Ops, Rcvr> {
-    template <typename... Args> auto set_value(Args &&...args) const & -> void {
-        this->ops->complete_first(f(std::forward<Args>(args)...));
-    }
-    template <typename... Args> auto set_value(Args &&...args) && -> void {
-        this->ops->complete_first(std::move(f)(std::forward<Args>(args)...));
-    }
-
     [[no_unique_address]] F f;
+
+  private:
+    template <typename Self, typename... Args>
+        requires std::same_as<first_receiver, std::remove_cvref_t<Self>>
+    friend auto tag_invoke(set_value_t, Self &&self, Args &&...args) -> void {
+        self.ops->complete_first(
+            std::forward<Self>(self).f(std::forward<Args>(args)...));
+    }
 };
 
 template <typename S, typename F>

--- a/include/async/read.hpp
+++ b/include/async/read.hpp
@@ -13,7 +13,7 @@
 namespace async {
 namespace _read {
 template <typename R, typename Tag> struct op_state {
-    auto start() -> void { receiver.set_value(Tag{}(get_env(receiver))); }
+    auto start() -> void { set_value(receiver, Tag{}(get_env(receiver))); }
 
     [[no_unique_address]] R receiver;
     [[no_unique_address]] Tag t;

--- a/include/async/retry.hpp
+++ b/include/async/retry.hpp
@@ -2,6 +2,7 @@
 
 #include <async/concepts.hpp>
 #include <async/env.hpp>
+#include <async/tags.hpp>
 #include <async/type_traits.hpp>
 
 #include <stdx/functional.hpp>
@@ -17,23 +18,28 @@ namespace _retry {
 template <typename Ops, typename Rcvr> struct receiver {
     using is_receiver = void;
 
+    Ops *ops;
+
+  private:
     template <typename... Args>
-    constexpr auto set_value(Args &&...args) const -> void {
-        ops->rcvr.set_value(std::forward<Args>(args)...);
+    friend constexpr auto tag_invoke(set_value_t, receiver const &r,
+                                     Args &&...args) -> void {
+        set_value(r.ops->rcvr, std::forward<Args>(args)...);
     }
     template <typename... Args>
-    constexpr auto set_error(Args &&...args) const -> void {
-        ops->retry(std::forward<Args>(args)...);
+    friend constexpr auto tag_invoke(set_error_t, receiver const &r,
+                                     Args &&...args) -> void {
+        r.ops->retry(std::forward<Args>(args)...);
     }
-    constexpr auto set_stopped() const -> void { ops->rcvr.set_stopped(); }
+    friend constexpr auto tag_invoke(set_stopped_t, receiver const &r) -> void {
+        set_stopped(r.ops->rcvr);
+    }
 
     [[nodiscard]] friend constexpr auto tag_invoke(async::get_env_t,
                                                    receiver const &self)
         -> detail::forwarding_env<env_of_t<Rcvr>> {
         return forward_env_of(self.ops->rcvr);
     }
-
-    Ops *ops;
 };
 
 constexpr auto never_stop = [] { return false; };
@@ -60,7 +66,7 @@ template <typename Sndr, typename Rcvr, typename Pred> struct op_state {
         if constexpr (not std::same_as<
                           Pred, std::remove_cvref_t<decltype(never_stop)>>) {
             if (pred()) {
-                rcvr.set_error(std::forward<Args>(args)...);
+                set_error(rcvr, std::forward<Args>(args)...);
                 return;
             }
         }

--- a/include/async/schedulers/inline_scheduler.hpp
+++ b/include/async/schedulers/inline_scheduler.hpp
@@ -13,7 +13,7 @@
 namespace async {
 class inline_scheduler {
     template <typename R> struct op_state {
-        auto start() -> void { std::move(receiver).set_value(); }
+        auto start() -> void { set_value(std::move(receiver)); }
         [[no_unique_address]] R receiver;
     };
 

--- a/include/async/schedulers/priority_scheduler.hpp
+++ b/include/async/schedulers/priority_scheduler.hpp
@@ -20,7 +20,7 @@ template <priority_t P, typename Rcvr> struct op_state : single_linked_task {
 
     auto run() -> void final {
         if (not check_stopped()) {
-            std::move(rcvr).set_value();
+            set_value(std::move(rcvr));
         }
     }
 
@@ -36,7 +36,7 @@ template <priority_t P, typename Rcvr> struct op_state : single_linked_task {
     auto check_stopped() -> bool {
         if constexpr (not unstoppable_token<stop_token_of_t<env_of_t<Rcvr>>>) {
             if (get_stop_token(get_env(rcvr)).stop_requested()) {
-                std::move(rcvr).set_stopped();
+                set_stopped(std::move(rcvr));
                 return true;
             }
         }

--- a/include/async/schedulers/runloop_scheduler.hpp
+++ b/include/async/schedulers/runloop_scheduler.hpp
@@ -42,9 +42,9 @@ template <typename Uniq = decltype([] {})> class run_loop {
 
         auto execute() -> void override {
             if (get_stop_token(get_env(rcvr)).stop_requested()) {
-                std::move(rcvr).set_stopped();
+                set_stopped(std::move(rcvr));
             } else {
-                std::move(rcvr).set_value();
+                set_value(std::move(rcvr));
             }
         }
 

--- a/include/async/schedulers/thread_scheduler.hpp
+++ b/include/async/schedulers/thread_scheduler.hpp
@@ -19,7 +19,7 @@ namespace async {
 class thread_scheduler {
     template <typename R> struct op_state {
         auto start() -> void {
-            std::thread{[&] { std::move(receiver).set_value(); }}.detach();
+            std::thread{[&] { set_value(std::move(receiver)); }}.detach();
         }
 
         [[no_unique_address]] R receiver;

--- a/include/async/start_detached.hpp
+++ b/include/async/start_detached.hpp
@@ -13,13 +13,13 @@ namespace _start_detached {
 template <typename Ops> struct receiver {
     using is_receiver = void;
 
-    template <typename... Args> auto set_value(Args &&...) const -> void {
-        ops->die();
-    }
-    auto set_error(auto &&...) const -> void { ops->die(); }
-    auto set_stopped() const -> void { ops->die(); }
-
     Ops *ops;
+
+  private:
+    friend auto tag_invoke(channel_tag auto, receiver const &r, auto &&...)
+        -> void {
+        r.ops->die();
+    }
 };
 
 template <typename Uniq, typename Sndr>

--- a/include/async/tags.hpp
+++ b/include/async/tags.hpp
@@ -7,6 +7,41 @@
 #include <utility>
 
 namespace async {
+constexpr inline struct set_value_t {
+    template <typename... Ts>
+    constexpr auto operator()(Ts &&...ts) const
+        noexcept(noexcept(tag_invoke(std::declval<set_value_t>(),
+                                     std::forward<Ts>(ts)...)))
+            -> decltype(tag_invoke(*this, std::forward<Ts>(ts)...)) {
+        return tag_invoke(*this, std::forward<Ts>(ts)...);
+    }
+} set_value{};
+
+constexpr inline struct set_error_t {
+    template <typename... Ts>
+    constexpr auto operator()(Ts &&...ts) const
+        noexcept(noexcept(tag_invoke(std::declval<set_error_t>(),
+                                     std::forward<Ts>(ts)...)))
+            -> decltype(tag_invoke(*this, std::forward<Ts>(ts)...)) {
+        return tag_invoke(*this, std::forward<Ts>(ts)...);
+    }
+} set_error{};
+
+constexpr inline struct set_stopped_t {
+    template <typename... Ts>
+    constexpr auto operator()(Ts &&...ts) const
+        noexcept(noexcept(tag_invoke(std::declval<set_stopped_t>(),
+                                     std::forward<Ts>(ts)...)))
+            -> decltype(tag_invoke(*this, std::forward<Ts>(ts)...)) {
+        return tag_invoke(*this, std::forward<Ts>(ts)...);
+    }
+} set_stopped{};
+
+template <typename T>
+concept channel_tag =
+    std::same_as<set_value_t, T> or std::same_as<set_error_t, T> or
+    std::same_as<set_stopped_t, T>;
+
 constexpr inline struct connect_t {
     template <typename... Ts>
         requires true

--- a/include/async/type_traits.hpp
+++ b/include/async/type_traits.hpp
@@ -14,31 +14,6 @@
 #include <utility>
 
 namespace async {
-struct set_value_t {
-    template <typename R, typename... Args>
-    constexpr auto operator()(R &&r, Args &&...args) const
-        -> decltype(std::forward<R>(r).set_value(std::forward<Args>(args)...)) {
-        return std::forward<R>(r).set_value(std::forward<Args>(args)...);
-    }
-};
-
-struct set_error_t {
-    template <typename R, typename... Args>
-    constexpr auto operator()(R &&r, Args &&...args) const
-        -> decltype(std::forward<R>(r).set_error(std::forward<Args>(args)...)) {
-        return std::forward<R>(r).set_error(std::forward<Args>(args)...);
-    }
-};
-
-struct set_stopped_t {
-    template <typename R, typename... Args>
-    constexpr auto operator()(R &&r, Args &&...args) const
-        -> decltype(std::forward<R>(r).set_stopped(
-            std::forward<Args>(args)...)) {
-        return std::forward<R>(r).set_stopped(std::forward<Args>(args)...);
-    }
-};
-
 template <typename...> struct completion_signatures {};
 
 constexpr inline struct get_completion_signatures_t {

--- a/test/concepts.cpp
+++ b/test/concepts.cpp
@@ -39,9 +39,13 @@ struct error {};
 
 template <typename E = error, typename... Ts>
 struct receiver : async::receiver_base {
-    auto set_value(std::same_as<Ts> auto...) -> void {}
-    auto set_error(E) -> void {}
-    auto set_stopped() -> void {}
+  private:
+    friend auto tag_invoke(async::set_value_t, receiver const &,
+                           std::same_as<Ts> auto...) -> void;
+    friend auto tag_invoke(async::set_error_t, receiver const &,
+                           std::same_as<E> auto) -> void;
+    template <std::same_as<receiver> R>
+    friend auto tag_invoke(async::set_stopped_t, R const &) -> void;
 };
 } // namespace
 
@@ -124,8 +128,11 @@ struct sender : async::sender_base {
 };
 
 template <typename... Ts> struct value_receiver : async::receiver_base {
-    auto set_value(Ts...) -> void {}
-    auto set_error(auto) -> void {}
+  private:
+    template <std::same_as<value_receiver> R>
+    friend auto tag_invoke(async::set_value_t, R const &, Ts...) -> void;
+    friend auto tag_invoke(async::set_error_t, value_receiver const &, auto)
+        -> void;
 };
 } // namespace
 

--- a/test/just.cpp
+++ b/test/just.cpp
@@ -10,7 +10,8 @@
 TEST_CASE("one value", "[just]") {
     int value{};
     auto s = async::just(42);
-    auto op = async::connect(s, receiver{[&](auto i) { value = i; }});
+    auto r = receiver{[&](auto i) { value = i; }};
+    auto op = async::connect(s, r);
     op.start();
     CHECK(value == 42);
 }

--- a/test/transfer.cpp
+++ b/test/transfer.cpp
@@ -4,6 +4,7 @@
 #include <async/just.hpp>
 #include <async/on.hpp>
 #include <async/schedulers/inline_scheduler.hpp>
+#include <async/tags.hpp>
 #include <async/then.hpp>
 #include <async/transfer.hpp>
 
@@ -12,7 +13,7 @@
 namespace {
 template <auto> class test_scheduler {
     template <typename R> struct op_state {
-        auto start() -> void { receiver.set_value(); }
+        auto start() -> void { async::set_value(receiver); }
         [[no_unique_address]] R receiver;
     };
 


### PR DESCRIPTION
Calling `set_value`, `set_error`, `set_stopped` with tag invocation has two advantages:
 - a single place to add telemetry/logging
 - better handling of value categories