### PR TITLE
:art: Allow allocator to be customized by sender

### DIFF
--- a/include/async/schedulers/inline_scheduler.hpp
+++ b/include/async/schedulers/inline_scheduler.hpp
@@ -1,8 +1,10 @@
 #pragma once
 
+#include <async/allocator.hpp>
 #include <async/completion_scheduler.hpp>
 #include <async/concepts.hpp>
 #include <async/env.hpp>
+#include <async/stack_allocator.hpp>
 #include <async/tags.hpp>
 #include <async/type_traits.hpp>
 
@@ -25,6 +27,12 @@ class inline_scheduler {
     };
 
     class env {
+        [[nodiscard]] friend constexpr auto tag_invoke(get_allocator_t,
+                                                       env) noexcept
+            -> stack_allocator {
+            return {};
+        }
+
         [[nodiscard]] friend constexpr auto
         tag_invoke(get_completion_scheduler_t<set_value_t>, env) noexcept
             -> inline_scheduler {

--- a/include/async/stack_allocator.hpp
+++ b/include/async/stack_allocator.hpp
@@ -1,0 +1,23 @@
+#pragma once
+
+#include <utility>
+
+namespace async {
+struct stack_allocator {
+    template <typename, typename T, typename F, typename... Args>
+        requires std::is_constructible_v<T, Args...>
+    static auto construct(F &&f, Args &&...args) -> bool {
+        if constexpr (requires {
+                          std::forward<F>(f)(T{std::forward<Args>(args)...});
+                      }) {
+            std::forward<F>(f)(T{std::forward<Args>(args)...});
+        } else {
+            T t{std::forward<Args>(args)...};
+            std::forward<F>(f)(t);
+        }
+        return true;
+    }
+
+    template <typename, typename T> static auto destruct(T const *) -> void {}
+};
+} // namespace async

--- a/include/async/static_allocator.hpp
+++ b/include/async/static_allocator.hpp
@@ -1,0 +1,70 @@
+#pragma once
+
+#include <stdx/bit.hpp>
+#include <stdx/bitset.hpp>
+
+#include <array>
+#include <cstddef>
+#include <iterator>
+#include <memory>
+#include <type_traits>
+#include <utility>
+
+namespace async {
+namespace detail {
+template <typename T, std::size_t N> struct static_allocator_t {
+    constexpr static inline auto alignment = alignof(T);
+    constexpr static inline auto size = sizeof(T);
+    constexpr static inline auto aligned_size =
+        size % alignment == 0 ? size : size + alignment - (size % alignment);
+
+    using storage_t = std::array<std::byte, aligned_size * N>;
+
+    alignas(alignment) storage_t data{};
+    stdx::bitset<N> used{};
+
+    template <typename... Args> auto construct(Args &&...args) -> T * {
+        auto const idx = used.lowest_unset();
+        if (idx == N) {
+            return nullptr;
+        }
+        auto const ptr = std::data(data) + idx * aligned_size;
+        used.set(idx);
+        return std::construct_at(stdx::bit_cast<T *>(ptr),
+                                 std::forward<Args>(args)...);
+    }
+
+    auto destruct(T const *t) -> void {
+        std::destroy_at(t);
+        auto const ptr = stdx::bit_cast<std::byte *>(t);
+        auto const idx =
+            static_cast<std::size_t>(ptr - std::data(data)) / aligned_size;
+        used.reset(idx);
+    }
+};
+template <typename T, std::size_t N>
+inline auto static_allocator_v = static_allocator_t<T, N>{};
+} // namespace detail
+
+template <typename Name>
+constexpr inline auto static_allocation_limit = std::size_t{1};
+
+struct static_allocator {
+    template <typename Name, typename T, typename F, typename... Args>
+        requires std::is_constructible_v<T, Args...>
+    static auto construct(F &&f, Args &&...args) -> bool {
+        auto &a = detail::static_allocator_v<T, static_allocation_limit<Name>>;
+        if (auto t = a.construct(std::forward<Args>(args)...); t != nullptr) {
+            std::forward<F>(f)(*t);
+            return true;
+        }
+        return false;
+    }
+
+    template <typename Name, typename T>
+    static auto destruct(T const *t) -> void {
+        auto &a = detail::static_allocator_v<T, static_allocation_limit<Name>>;
+        a.destruct(t);
+    }
+};
+} // namespace async

--- a/test/allocator.cpp
+++ b/test/allocator.cpp
@@ -1,10 +1,41 @@
 #include "detail/common.hpp"
 
 #include <async/allocator.hpp>
-
-#include <stdx/functional.hpp>
+#include <async/schedulers/inline_scheduler.hpp>
+#include <async/schedulers/thread_scheduler.hpp>
+#include <async/stack_allocator.hpp>
+#include <async/static_allocator.hpp>
+#include <async/then.hpp>
+#include <async/transfer.hpp>
 
 #include <catch2/catch_test_macros.hpp>
+
+TEST_CASE("default allocator is static_allocator", "[allocator]") {
+    static_assert(std::is_same_v<async::allocator_of_t<async::empty_env>,
+                                 async::static_allocator>);
+}
+
+TEST_CASE("allocator is forwarded through senders", "[allocator]") {
+    [[maybe_unused]] auto s1 =
+        async::inline_scheduler{}.schedule() | async::then([] {});
+    static_assert(
+        std::is_same_v<async::allocator_of_t<async::env_of_t<decltype(s1)>>,
+                       async::stack_allocator>);
+
+    [[maybe_unused]] auto s2 =
+        async::thread_scheduler{}.schedule() | async::then([] {});
+    static_assert(
+        std::is_same_v<async::allocator_of_t<async::env_of_t<decltype(s2)>>,
+                       async::static_allocator>);
+}
+
+TEST_CASE("allocator is overridden through senders", "[allocator]") {
+    [[maybe_unused]] auto s = async::inline_scheduler{}.schedule() |
+                              async::transfer(async::thread_scheduler{});
+    static_assert(
+        std::is_same_v<async::allocator_of_t<async::env_of_t<decltype(s)>>,
+                       async::static_allocator>);
+}
 
 namespace {
 struct domain;
@@ -16,51 +47,97 @@ struct S {
 };
 } // namespace
 
-TEST_CASE("allocate with default limit 1", "[allocator]") {
-    auto &alloc = async::get_allocator<domain, S>();
-    auto p = alloc.construct(42);
-    REQUIRE(p);
-    CHECK(p->i == 42);
-    alloc.destruct(p);
+TEST_CASE("static allocate with default limit 1", "[allocator]") {
+    auto alloc = async::static_allocator{};
+    CHECK(alloc.construct<domain, S>(
+        [&](auto &&s) {
+            CHECK(s.i == 42);
+            alloc.destruct<domain>(&s);
+        },
+        42));
 }
 
-TEST_CASE("allocate fails when static limit is reached", "[allocator]") {
-    auto &alloc = async::get_allocator<domain, S>();
-    auto p = alloc.construct(42);
-    REQUIRE(p);
-    auto q = alloc.construct(17);
-    CHECK(not q);
-    alloc.destruct(p);
+TEST_CASE("static allocate fails when limit is reached", "[allocator]") {
+    auto alloc = async::static_allocator{};
+    CHECK(alloc.construct<domain, S>(
+        [&](auto &&s) {
+            CHECK(s.i == 42);
+            auto q =
+                alloc.construct<domain, S>([](auto &&) { CHECK(false); }, 17);
+            CHECK(not q);
+            alloc.destruct<domain>(&s);
+        },
+        42));
 }
 
 template <>
-constexpr inline auto async::allocation_limit<multi_domain> = std::size_t{2};
+constexpr inline auto async::static_allocation_limit<multi_domain> =
+    std::size_t{2};
 
-TEST_CASE("allocate more than 1", "[allocator]") {
-    auto &alloc = async::get_allocator<multi_domain, S>();
-    auto p = alloc.construct(42);
-    REQUIRE(p);
-    auto q = alloc.construct(17);
-    REQUIRE(q);
-    auto x = alloc.construct(1);
-    CHECK(not x);
+TEST_CASE("static allocate more than 1", "[allocator]") {
+    auto alloc = async::static_allocator{};
+    CHECK(alloc.construct<multi_domain, S>(
+        [&](auto &&p) {
+            CHECK(p.i == 42);
 
-    CHECK(p->i == 42);
-    CHECK(q->i == 17);
-    alloc.destruct(p);
-    alloc.destruct(q);
+            CHECK(alloc.construct<multi_domain, S>(
+                [&](auto &&q) {
+                    CHECK(q.i == 17);
+                    auto x = alloc.construct<multi_domain, S>(
+                        [](auto &&) { CHECK(false); }, 0);
+                    CHECK(not x);
+                    alloc.destruct<domain>(&q);
+                },
+                17));
+            alloc.destruct<domain>(&p);
+        },
+        42));
 }
 
 namespace {
 struct nm : non_moveable {
+    nm(int x) : i{x} {}
+    nm(nm &&) = delete;
     int i;
 };
 } // namespace
 
-TEST_CASE("allocate non-movable objects", "[allocator]") {
-    auto &alloc = async::get_allocator<domain, nm>();
-    auto p = alloc.construct(stdx::with_result_of{[] { return nm{{}, 42}; }});
-    REQUIRE(p);
-    CHECK(p->i == 42);
-    alloc.destruct(p);
+TEST_CASE("static allocate non-movable objects", "[allocator]") {
+    auto alloc = async::static_allocator{};
+    CHECK(alloc.construct<domain, nm>(
+        [&](auto &&n) {
+            CHECK(n.i == 42);
+            alloc.destruct<domain>(&n);
+        },
+        42));
+}
+
+namespace {
+int construction_count{};
+struct counter {
+    counter(int x) : i{x} { ++construction_count; }
+    int i;
+};
+} // namespace
+
+TEST_CASE("stack allocate lvalues", "[allocator]") {
+    construction_count = 0;
+    auto alloc = async::stack_allocator{};
+    CHECK(alloc.construct<domain, counter>(
+        [&](counter &) { CHECK(construction_count == 1); }, 42));
+}
+
+TEST_CASE("stack allocate rvalues", "[allocator]") {
+    construction_count = 0;
+    auto alloc = async::stack_allocator{};
+    CHECK(alloc.construct<domain, counter>(
+        [&](counter) { CHECK(construction_count == 1); }, 42));
+}
+
+TEST_CASE("static allocator is an allocator", "[allocator]") {
+    static_assert(async::allocator<async::static_allocator>);
+}
+
+TEST_CASE("stack allocator is an allocator", "[allocator]") {
+    static_assert(async::allocator<async::stack_allocator>);
 }

--- a/test/just.cpp
+++ b/test/just.cpp
@@ -1,6 +1,8 @@
 #include "detail/common.hpp"
 
+#include <async/allocator.hpp>
 #include <async/concepts.hpp>
+#include <async/env.hpp>
 #include <async/just.hpp>
 #include <async/tags.hpp>
 
@@ -66,4 +68,11 @@ TEST_CASE("void sender", "[just]") {
     auto op = async::connect(s, receiver{[&] { rcvd = true; }});
     async::start(op);
     CHECK(rcvd);
+}
+
+TEST_CASE("just has a stack allocator", "[just]") {
+    static_assert(
+        std::is_same_v<
+            async::allocator_of_t<async::env_of_t<decltype(async::just(42))>>,
+            async::stack_allocator>);
 }

--- a/test/just_error.cpp
+++ b/test/just_error.cpp
@@ -1,6 +1,8 @@
 #include "detail/common.hpp"
 
+#include <async/allocator.hpp>
 #include <async/concepts.hpp>
+#include <async/env.hpp>
 #include <async/just.hpp>
 #include <async/tags.hpp>
 
@@ -49,4 +51,11 @@ TEST_CASE("move sender", "[just_error]") {
                              error_receiver{[&](auto i) { value = i; }});
     async::start(op);
     CHECK(value == 42);
+}
+
+TEST_CASE("just_error has a stack allocator", "[just_error]") {
+    static_assert(
+        std::is_same_v<async::allocator_of_t<
+                           async::env_of_t<decltype(async::just_error(42))>>,
+                       async::stack_allocator>);
 }

--- a/test/just_error_result_of.cpp
+++ b/test/just_error_result_of.cpp
@@ -1,7 +1,10 @@
 #include "detail/common.hpp"
 
+#include <async/allocator.hpp>
 #include <async/concepts.hpp>
+#include <async/env.hpp>
 #include <async/just_result_of.hpp>
+#include <async/stack_allocator.hpp>
 #include <async/tags.hpp>
 
 #include <catch2/catch_test_macros.hpp>
@@ -87,4 +90,13 @@ TEST_CASE("copyable lambda", "[just_error_result_of]") {
     static_assert(async::multishot_sender<decltype(async::just_error_result_of(
                                               [] { return 42; })),
                                           universal_receiver>);
+}
+
+TEST_CASE("just_error_result_of has a stack allocator",
+          "[just_error_result_of]") {
+    static_assert(
+        std::is_same_v<
+            async::allocator_of_t<async::env_of_t<
+                decltype(async::just_error_result_of([] { return 42; }))>>,
+            async::stack_allocator>);
 }

--- a/test/just_result_of.cpp
+++ b/test/just_result_of.cpp
@@ -1,7 +1,10 @@
 #include "detail/common.hpp"
 
+#include <async/allocator.hpp>
 #include <async/concepts.hpp>
+#include <async/env.hpp>
 #include <async/just_result_of.hpp>
+#include <async/stack_allocator.hpp>
 #include <async/tags.hpp>
 
 #include <catch2/catch_test_macros.hpp>
@@ -87,4 +90,11 @@ TEST_CASE("copyable lambda", "[just_result_of]") {
     static_assert(async::multishot_sender<decltype(async::just_result_of(
                                               [] { return 42; })),
                                           universal_receiver>);
+}
+
+TEST_CASE("just_result_of has a stack allocator", "[just_result_of]") {
+    static_assert(
+        std::is_same_v<async::allocator_of_t<async::env_of_t<
+                           decltype(async::just_result_of([] { return 42; }))>>,
+                       async::stack_allocator>);
 }

--- a/test/just_stopped.cpp
+++ b/test/just_stopped.cpp
@@ -1,6 +1,8 @@
 #include "detail/common.hpp"
 
+#include <async/allocator.hpp>
 #include <async/concepts.hpp>
+#include <async/env.hpp>
 #include <async/just.hpp>
 #include <async/tags.hpp>
 
@@ -38,4 +40,11 @@ TEST_CASE("move sender", "[just_stopped]") {
         async::connect(std::move(s), stopped_receiver{[&] { value = 42; }});
     async::start(op);
     CHECK(value == 42);
+}
+
+TEST_CASE("just_stopped has a stack allocator", "[just_stopped]") {
+    static_assert(
+        std::is_same_v<async::allocator_of_t<
+                           async::env_of_t<decltype(async::just_stopped())>>,
+                       async::stack_allocator>);
 }

--- a/test/schedulers/inline_scheduler.cpp
+++ b/test/schedulers/inline_scheduler.cpp
@@ -1,9 +1,11 @@
 #include "detail/common.hpp"
 
+#include <async/allocator.hpp>
 #include <async/completion_scheduler.hpp>
 #include <async/concepts.hpp>
 #include <async/env.hpp>
 #include <async/schedulers/inline_scheduler.hpp>
+#include <async/stack_allocator.hpp>
 
 #include <catch2/catch_test_macros.hpp>
 
@@ -54,4 +56,11 @@ TEST_CASE("sender has the inline_scheduler as its completion scheduler",
     auto cs2 =
         async::get_completion_scheduler<async::set_value_t>(async::get_env(s2));
     static_assert(std::same_as<decltype(cs2), async::inline_scheduler>);
+}
+
+TEST_CASE("sender has a stack allocator", "[inline_scheduler]") {
+    static_assert(
+        std::is_same_v<async::allocator_of_t<async::env_of_t<
+                           decltype(async::inline_scheduler::schedule())>>,
+                       async::stack_allocator>);
 }

--- a/test/schedulers/thread_scheduler.cpp
+++ b/test/schedulers/thread_scheduler.cpp
@@ -1,5 +1,6 @@
 #include "detail/common.hpp"
 
+#include <async/allocator.hpp>
 #include <async/completion_scheduler.hpp>
 #include <async/concepts.hpp>
 #include <async/env.hpp>
@@ -51,4 +52,11 @@ TEST_CASE("sender has the thread_scheduler as its completion scheduler",
     auto cs =
         async::get_completion_scheduler<async::set_value_t>(async::get_env(s));
     static_assert(std::same_as<decltype(cs), async::thread_scheduler>);
+}
+
+TEST_CASE("sender has a static allocator", "[inline_scheduler]") {
+    static_assert(
+        std::is_same_v<async::allocator_of_t<async::env_of_t<
+                           decltype(async::thread_scheduler::schedule())>>,
+                       async::static_allocator>);
 }


### PR DESCRIPTION
Some senders complete inline; these can have simple stack allocators. Other senders behave asynchronously and need separate storage.