### PR TITLE
:sparkles: Allow `start_detached` to be cancelled

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,7 +11,7 @@ project(
 include(cmake/get_cpm.cmake)
 cpmaddpackage("gh:intel/cicd-repo-infrastructure#main")
 
-add_versioned_package("gh:intel/cpp-std-extensions#4d60120")
+add_versioned_package("gh:intel/cpp-std-extensions#9a49ddd")
 add_versioned_package("gh:intel/cpp-baremetal-concurrency#659771e")
 add_versioned_package("gh:boostorg/mp11#boost-1.83.0")
 

--- a/docs/attributes.adoc
+++ b/docs/attributes.adoc
@@ -8,6 +8,8 @@ NOTE: Don't blame me for the name: it's in https://wg21.link/p2300[P2300].
 Receivers have environments. Senders have attributes. Both are obtained by
 calling `get_env`.
 
+== completion_scheduler
+
 A sender's attributes often include its _completion scheduler_. In particular, a
 sender obtained from calling `schedule` on a scheduler will always have that
 scheduler as its completion scheduler. Perhaps that's clearer in code:
@@ -16,10 +18,65 @@ scheduler as its completion scheduler. Perhaps that's clearer in code:
 ----
 auto orig_sched = /* some scheduler */;
 auto sndr = orig_sched.schedule();
-auto sched = async::get_completion_scheduler(sndr);
+auto sched = async::get_completion_scheduler(async::get_env(sndr));
 
 assert(sched == orig_sched);
 ----
 
 `get_completion_scheduler` uses `tag_invoke(get_completion_scheduler_t, S)` to
 find the completion scheduler for a sender type `S`.
+
+== allocator
+
+A sender's attributes also include an allocator, that is used when
+`start_detached` is called.
+
+[source,cpp]
+----
+auto sched = /* some scheduler */;
+auto sndr = orig_sched.schedule();
+auto alloc = async::get_allocator(async::get_env(sndr));
+----
+Given a class `T`, an `allocator` supports two operations:
+
+[source,cpp]
+----
+template <typename T>
+struct allocator {
+  // allocate space for a T and construct it with Args...
+  // then, call F with the (rvalue) T
+  // return false if unable to allocate T, otherwise true
+  template <typename F, typename... Args> auto construct(F&&, Args &&...) -> bool;
+
+  // destroy and deallocate a T
+  auto destruct(T const *) -> void;
+};
+----
+
+NOTE: `construct` is a little different from what you might expect: it doesn't
+return a pointer-to-T, it calls a given function with the constructed T. This
+allows easier support for stack allocators with non-movable objects (like
+operation states).
+
+The default allocator, if a sender doesn't otherwise specify one, is a
+`static_allocator`. A `static_allocator` is parameterized with a tag
+representing the allocation domain for a particular call site. This tag can be
+passed to `start_detached` and used to specialize the variable template
+`async::allocation_limit` in order to control static allocation.
+
+[source,cpp]
+----
+// a tag type to indicate the allocation domain
+struct my_alloc_domain;
+
+// specialize the limit for the domain (if left unspecialized, the default is 1)
+template <>
+constexpr inline auto async::allocation_limit<my_alloc_domain> = std::size_t{8};
+
+// when I call start_detached, the static allocator for the domain will be used
+auto result = async::start_detached<my_alloc_domain>(sndr);
+----
+
+NOTE: The default allocation strategy for a sender is static allocation, but
+some senders are synchronous by nature: for example `just` or the sender
+produced by an `inline_scheduler`. These senders use stack allocators.

--- a/docs/sender_consumers.adoc
+++ b/docs/sender_consumers.adoc
@@ -4,8 +4,11 @@
 === `start_detached`
 
 `start_detached` takes a sender, connects and starts it, and returns, leaving
-the work running detached. The return value is a `bool` indicating whether or
-not the sender was started.
+the work running detached. The return value is a
+https://intel.github.io/cpp-std-extensions/#_optional_hpp[`stdx::optional`]. If
+the optional is empty, the sender was not started. Otherwise, it contains a
+pointer to an xref:cancellation.adoc#_cancellation[`in_place_stop_source`] that
+can be used to cancel the operation.
 
 [source,cpp]
 ----
@@ -15,44 +18,37 @@ auto started = async::start_detached(sndr);
 ----
 
 If a sender starts detached, its operation state has to be allocated somewhere.
-That is achieved through an allocator. Given a class T, an allocator supports two
-operations:
+That is achieved through an xref:attributes.adoc#_allocator[allocator]
+determined from the sender's attributes.
+
+To hook into the static xref:attributes.adoc#_allocator[allocation strategy], a
+template argument (representing the name of the allocation domain) can be given
+to `start_detached`.
 
 [source,cpp]
 ----
-template <typename T>
-struct allocator {
-  // allocate space for a T and construct it with Args
-  template <typename... Args> auto construct(Args &&...) -> T *;
-  // destroy and deallocate
-  auto destruct(T const *) -> void;
-};
-----
-
-The variable templates `async::alloc` and `async::allocation_limit` can be
-specialized to control how detached operation states are handled:
-
-[source,cpp]
-----
-template <typename Name>
-constexpr inline auto allocation_limit = std::size_t{1};
-
-template <typename Name, typename T, std::size_t N>
-inline auto alloc = static_allocator<T, N>{};
-----
-
-To hook into these allocation strategies, a template argument (representing the
-name of the allocation domain) can be given to `start_detached`.
-
-[source,cpp]
-----
-async::start_detached<struct Name>(s);
+auto result = async::start_detached<struct Name>(s);
 ----
 
 The default template argument results in a different `static_allocator` for each
-call site, with an allocation limit of 1. `start_detached` returns `false` when
-the allocator's `construct` method returns a `nullptr` (presumably because the
-allocation limit has been reached).
+call site, with a default allocation limit of 1. If the allocator's `construct` method
+returns `false` (presumably because the allocation limit has been reached),
+the result of `start_detached` is an empty optional.
+
+=== `start_detached_unstoppable`
+
+`start_detached_unstoppable` behaves identically to `start_detached`, except
+that the returned optional value contains a pointer to a `never_stop_source`,
+which has the same interface as an
+xref:cancellation.adoc#_cancellation[`in_place_stop_source`] but never actually
+cancels the operation. So `start_detached_unstoppable` is slightly more
+efficient than `start_detached` for the cases where cancellation is not
+required.
+
+[source,cpp]
+----
+auto result = async::start_detached_unstoppable<struct Name>(s);
+----
 
 === `sync_wait`
 

--- a/include/async/stop_token.hpp
+++ b/include/async/stop_token.hpp
@@ -138,6 +138,26 @@ struct never_stop_token {
         -> bool = default;
 };
 
+struct never_stop_source {
+    [[nodiscard]] constexpr static auto stop_requested() noexcept -> bool {
+        return false;
+    }
+    [[nodiscard]] constexpr static auto stop_possible() noexcept -> bool {
+        return false;
+    }
+
+    [[nodiscard]] constexpr static auto get_token() noexcept
+        -> never_stop_token {
+        return {};
+    }
+
+    constexpr static auto request_stop() -> bool { return false; }
+    constexpr static auto register_callback(stop_callback_base *) -> bool {
+        return false;
+    }
+    constexpr static auto unregister_callback(stop_callback_base *) -> void {}
+};
+
 // NOLINTNEXTLINE(cppcoreguidelines-special-member-functions)
 template <typename F> struct in_place_stop_callback final : stop_callback_base {
     in_place_stop_callback(never_stop_token, F const &f) : callback(f) {}


### PR DESCRIPTION
Problem:
 - `start_detached` returns a `bool`, which tells the caller whether the operation was started, but does not provide for cancelling the in-progress operation.

Solution:
 - return an optional pointer-to-stop-source that can be used to cancel the operation.
 - empty optional means the operation wasn't started, because allocation failed for the operation state.
 - `start_detached_unstoppable` can be used for the case where cancellation is not required.