### PR TITLE
:sparkles: Add timer manager

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,7 +11,7 @@ project(
 include(cmake/get_cpm.cmake)
 cpmaddpackage("gh:intel/cicd-repo-infrastructure#main")
 
-add_versioned_package("gh:intel/cpp-std-extensions#9a49ddd")
+add_versioned_package("gh:intel/cpp-std-extensions#6fe6ae9")
 add_versioned_package("gh:intel/cpp-baremetal-concurrency#659771e")
 add_versioned_package("gh:boostorg/mp11#boost-1.83.0")
 

--- a/include/async/allocator.hpp
+++ b/include/async/allocator.hpp
@@ -7,25 +7,23 @@
 #include <utility>
 
 namespace async {
-namespace detail {
-struct prototype_constructible {
-    constexpr explicit prototype_constructible(int) {}
+namespace archetypes {
+struct constructible {
+    constexpr explicit constructible(int) {}
 };
-struct prototype_domain;
-} // namespace detail
+struct domain;
+} // namespace archetypes
 
 template <typename T>
-concept allocator =
-    std::is_empty_v<T> and requires(T &, detail::prototype_constructible *p) {
-        {
-            T::template construct<detail::prototype_domain,
-                                  detail::prototype_constructible>(
-                [](detail::prototype_constructible) {}, 0)
-        } -> std::same_as<bool>;
-        {
-            T::template destruct<detail::prototype_domain>(p)
-        } -> std::same_as<void>;
-    };
+concept allocator = std::is_empty_v<T> and requires(
+                                               T &,
+                                               archetypes::constructible *p) {
+    {
+        T::template construct<archetypes::domain, archetypes::constructible>(
+            [](archetypes::constructible) {}, 0)
+    } -> std::same_as<bool>;
+    { T::template destruct<archetypes::domain>(p) } -> std::same_as<void>;
+};
 
 constexpr inline struct get_allocator_t : forwarding_query_t {
     template <typename T>

--- a/include/async/schedulers/priority_scheduler.hpp
+++ b/include/async/schedulers/priority_scheduler.hpp
@@ -15,7 +15,7 @@
 
 namespace async {
 namespace task_mgr {
-template <priority_t P, typename Rcvr> struct op_state : single_linked_task {
+template <priority_t P, typename Rcvr, typename Task> struct op_state : Task {
     template <stdx::same_as_unqualified<Rcvr> R>
     constexpr explicit(true) op_state(R &&r) : rcvr{std::forward<R>(r)} {}
 
@@ -47,7 +47,8 @@ template <priority_t P, typename Rcvr> struct op_state : single_linked_task {
 };
 } // namespace task_mgr
 
-template <priority_t P> class fixed_priority_scheduler {
+template <priority_t P, typename Task = priority_task>
+class fixed_priority_scheduler {
     class env {
         [[nodiscard]] friend constexpr auto
         tag_invoke(get_completion_scheduler_t<set_value_t>, env) noexcept
@@ -62,7 +63,7 @@ template <priority_t P> class fixed_priority_scheduler {
       private:
         template <stdx::same_as_unqualified<sender> S, receiver_from<sender> R>
         [[nodiscard]] friend constexpr auto tag_invoke(connect_t, S &&, R &&r) {
-            return task_mgr::op_state<P, std::remove_cvref_t<R>>{
+            return task_mgr::op_state<P, std::remove_cvref_t<R>, Task>{
                 std::forward<R>(r)};
         }
 

--- a/include/async/schedulers/timer_manager.hpp
+++ b/include/async/schedulers/timer_manager.hpp
@@ -1,0 +1,145 @@
+#pragma once
+
+#include <async/schedulers/timer_manager_interface.hpp>
+#include <conc/concurrency.hpp>
+
+#include <stdx/function_traits.hpp>
+#include <stdx/intrusive_list.hpp>
+#include <stdx/tuple.hpp>
+
+#include <algorithm>
+#include <atomic>
+#include <concepts>
+#include <iterator>
+#include <memory>
+#include <type_traits>
+#include <utility>
+
+namespace async {
+namespace detail {
+// NOLINTNEXTLINE(cppcoreguidelines-virtual-class-destructor)
+template <typename T> struct timer_task : task_base {
+    T expiration_time{};
+
+  private:
+    [[nodiscard]] friend constexpr auto operator<(timer_task const &lhs,
+                                                  timer_task const &rhs) {
+        return lhs.expiration_time < rhs.expiration_time;
+    }
+};
+} // namespace detail
+
+template <typename TimePoint>
+using timer_task = double_linked_task<detail::timer_task<TimePoint>>;
+
+namespace detail {
+template <typename T>
+concept timer_hal =
+    timeable_task<typename T::task_t> and
+    requires(typename T::time_point_t tp, typename T::task_t &task) {
+        { T::now() } -> std::same_as<typename T::time_point_t>;
+        { T::enable() } -> std::same_as<void>;
+        { T::disable() } -> std::same_as<void>;
+        { T::set_event_time(tp) } -> std::same_as<void>;
+        { task.expiration_time } -> std::same_as<typename T::time_point_t &>;
+    };
+} // namespace detail
+
+namespace archetypes {
+struct timer_hal {
+    using time_point_t = int;
+    using task_t = timer_task<time_point_t>;
+
+    static auto now() -> time_point_t { return {}; }
+    static auto enable() -> void {}
+    static auto disable() -> void {}
+    static auto set_event_time(time_point_t) -> void {}
+};
+} // namespace archetypes
+static_assert(detail::timer_hal<archetypes::timer_hal>);
+
+template <detail::timer_hal H> struct generic_timer_manager {
+    using time_point_t = typename H::time_point_t;
+    using duration_t =
+        decltype(std::declval<time_point_t>() - std::declval<time_point_t>());
+    using task_t = typename H::task_t;
+
+  private:
+    struct mutex;
+    stdx::intrusive_list<task_t> task_queue{};
+    std::atomic<int> task_count{};
+
+    auto schedule(task_t *t) -> void {
+        if (std::empty(task_queue)) {
+            task_queue.push_back(t);
+            H::set_event_time(t->expiration_time);
+            H::enable();
+        } else {
+            auto pos = std::find_if(
+                std::begin(task_queue), std::end(task_queue),
+                [&](auto const &task) {
+                    return task.expiration_time > t->expiration_time;
+                });
+            if (pos == std::begin(task_queue)) {
+                H::set_event_time(t->expiration_time);
+            }
+            task_queue.insert(pos, t);
+        }
+    }
+
+    auto compute_next_event() -> void {
+        if (std::empty(task_queue)) {
+            H::disable();
+        } else {
+            H::set_event_time(std::begin(task_queue)->expiration_time);
+        }
+    }
+
+  public:
+    constexpr static auto create_task = async::create_task<task_t>;
+
+    auto run_after(task_t &t, duration_t d) -> bool {
+        return conc::call_in_critical_section<mutex>([&]() -> bool {
+            if (auto const added = not std::exchange(t.pending, true); added) {
+                ++task_count;
+                t.expiration_time = H::now() + d;
+                schedule(std::addressof(t));
+                return true;
+            }
+            return false;
+        });
+    }
+
+    auto cancel(task_t &t) -> bool {
+        return conc::call_in_critical_section<mutex>([&]() -> bool {
+            if (t.pending) {
+                task_queue.remove(std::addressof(t));
+                t.pending = false;
+                --task_count;
+                compute_next_event();
+                return true;
+            }
+            return false;
+        });
+    }
+
+    auto service_task() -> void {
+        if (auto t = conc::call_in_critical_section<mutex>([&]() -> task_t * {
+                if (std::empty(task_queue)) {
+                    return nullptr;
+                }
+                auto n = task_queue.pop_front();
+                n->pending = false;
+                compute_next_event();
+                return n;
+            });
+            t != nullptr) {
+            t->run();
+            --task_count;
+        }
+    }
+
+    [[nodiscard]] auto is_idle() const -> bool { return task_count == 0; }
+};
+static_assert(timer_manager<generic_timer_manager<archetypes::timer_hal>>);
+} // namespace async

--- a/include/async/schedulers/timer_manager_interface.hpp
+++ b/include/async/schedulers/timer_manager_interface.hpp
@@ -1,0 +1,95 @@
+#pragma once
+
+#include <async/schedulers/task.hpp>
+
+#include <stdx/intrusive_list.hpp>
+#include <stdx/type_traits.hpp>
+
+#include <concepts>
+#include <functional>
+
+namespace async {
+template <typename T>
+concept timeable_task =
+    stdx::double_linkable<T> and std::strict_weak_order<std::less<>, T, T> and
+    requires(T *t) {
+        { t->run() } -> std::same_as<void>;
+        { t->pending } -> std::same_as<bool &>;
+        t->expiration_time;
+    };
+
+template <typename T>
+concept timer_manager =
+    timeable_task<typename T::task_t> and
+    requires(T &t, typename T::task_t &task, typename T::duration_t d) {
+        { t.run_after(task, d) } -> std::convertible_to<bool>;
+        { t.service_task() } -> std::same_as<void>;
+        { t.is_idle() } -> std::convertible_to<bool>;
+    };
+
+namespace detail {
+struct undefined_timer_manager {
+    struct task_t {
+        task_t *next{};
+        task_t *prev{};
+        bool pending{};
+        int expiration_time{};
+        auto run() -> void {}
+
+      private:
+        [[nodiscard]] friend constexpr auto operator<(task_t const &lhs,
+                                                      task_t const &rhs) {
+            return lhs.expiration_time < rhs.expiration_time;
+        }
+    };
+    using duration_t = int;
+
+    template <typename... Args> static auto run_after(Args &&...) -> bool {
+        static_assert(stdx::always_false_v<Args...>,
+                      "Inject a timer manager by specializing "
+                      "async::injected_timer_manager.");
+        return false;
+    }
+
+    template <typename... Args> static auto service_task(Args &&...) -> void {
+        static_assert(stdx::always_false_v<Args...>,
+                      "Inject a timer manager by specializing "
+                      "async::injected_timer_manager.");
+    }
+
+    template <typename... Args> static auto is_idle(Args &&...) -> bool {
+        static_assert(
+            stdx::always_false_v<Args...>,
+            "Inject a timer by specializing async::injected_timer_manager.");
+        return true;
+    }
+};
+static_assert(timer_manager<undefined_timer_manager>);
+} // namespace detail
+
+template <typename...>
+inline auto injected_timer_manager = detail::undefined_timer_manager{};
+
+namespace timer_mgr {
+namespace detail {
+template <typename... DummyArgs, typename... Args>
+    requires(sizeof...(DummyArgs) == 0)
+auto run_after(Args &&...args) -> bool {
+    return injected_timer_manager<DummyArgs...>.run_after(
+        std::forward<Args>(args)...);
+}
+} // namespace detail
+
+template <typename... DummyArgs>
+    requires(sizeof...(DummyArgs) == 0)
+auto service_task() -> void {
+    return injected_timer_manager<DummyArgs...>.template service_task();
+}
+
+template <typename... DummyArgs>
+    requires(sizeof...(DummyArgs) == 0)
+auto is_idle() -> bool {
+    return injected_timer_manager<DummyArgs...>.is_idle();
+}
+} // namespace timer_mgr
+} // namespace async

--- a/test/schedulers/CMakeLists.txt
+++ b/test/schedulers/CMakeLists.txt
@@ -1,2 +1,2 @@
 add_tests(inline_scheduler priority_scheduler runloop_scheduler task_manager
-          thread_scheduler)
+          timer_manager thread_scheduler)

--- a/test/schedulers/timer_manager.cpp
+++ b/test/schedulers/timer_manager.cpp
@@ -1,0 +1,359 @@
+#include <async/schedulers/timer_manager.hpp>
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <functional>
+#include <iterator>
+#include <utility>
+#include <vector>
+
+namespace {
+struct hal {
+    using time_point_t = int;
+    using task_t = async::timer_task<time_point_t>;
+
+    static inline time_point_t current_time{};
+    static inline bool enabled{};
+    static inline std::vector<time_point_t> calls{};
+
+    static auto enable() -> void { enabled = true; }
+    static auto disable() -> void { enabled = false; }
+    static auto set_event_time(time_point_t tp) -> void { calls.push_back(tp); }
+    static auto now() -> time_point_t { return current_time; }
+};
+
+using timer_manager_t = async::generic_timer_manager<hal>;
+
+std::function<void()> interrupt_fn{};
+
+struct test_concurrency_policy {
+    struct interrupt {
+        ~interrupt() {
+            if (interrupt_fn) {
+                interrupt_fn();
+            }
+        }
+    };
+
+    template <typename = void, typename F, typename... Pred>
+    static auto call_in_critical_section(F &&f, Pred &&...) -> decltype(auto) {
+        [[maybe_unused]] interrupt raii_interrupt{};
+        return std::forward<F>(f)();
+    }
+};
+} // namespace
+
+template <> inline auto conc::injected_policy<> = test_concurrency_policy{};
+
+TEST_CASE("create task with lvalue", "[timer_manager]") {
+    int var{};
+    auto l = [&] { var = 42; };
+    auto task = timer_manager_t::create_task(l);
+    task.run();
+    CHECK(var == 42);
+}
+
+TEST_CASE("create task with rvalue", "[timer_manager]") {
+    int var{};
+    auto task = timer_manager_t::create_task([&] { var = 42; });
+    task.run();
+    CHECK(var == 42);
+}
+
+TEST_CASE("run a task with bound args", "[timer_manager]") {
+    int var{};
+    auto task = timer_manager_t::create_task([&](int x) { var = x; });
+    task.bind_front(42).run();
+    CHECK(var == 42);
+}
+
+TEST_CASE("tasks have reference equality", "[timer_manager]") {
+    auto t = timer_manager_t::create_task([] {});
+    auto u = timer_manager_t::create_task([] {});
+    CHECK(t == t);
+    CHECK(t != u);
+}
+
+TEST_CASE("nothing pending", "[timer_manager]") {
+    auto m = timer_manager_t{};
+    CHECK(m.is_idle());
+}
+
+TEST_CASE("queue a task", "[timer_manager]") {
+    hal::calls.clear();
+    auto t = timer_manager_t::create_task([] {});
+
+    auto m = timer_manager_t{};
+    m.run_after(t, 3);
+    CHECK(not m.is_idle());
+    REQUIRE(hal::calls.size() == 1);
+    CHECK(hal::calls[0] == 3);
+}
+
+TEST_CASE("run a queued task", "[timer_manager]") {
+    hal::calls.clear();
+
+    auto m = timer_manager_t{};
+    int var{};
+    auto t = timer_manager_t::create_task([&] { var = 42; });
+    m.run_after(t, 3);
+    CHECK(not m.is_idle());
+    REQUIRE(hal::calls.size() == 1);
+    CHECK(hal::calls[0] == 3);
+    m.service_task();
+    CHECK(var == 42);
+    CHECK(m.is_idle());
+}
+
+TEST_CASE("queueing a queued task fails", "[timer_manager]") {
+    hal::calls.clear();
+
+    auto m = timer_manager_t{};
+    int var{};
+    auto task = timer_manager_t::create_task([&] { var = 42; });
+    m.run_after(task, 3);
+    CHECK(not m.run_after(task, 4));
+    REQUIRE(hal::calls.size() == 1);
+    m.service_task();
+    CHECK(var == 42);
+    CHECK(m.is_idle());
+}
+
+TEST_CASE("run tasks in time order", "[timer_manager]") {
+    auto m = timer_manager_t{};
+    int var{};
+    auto t1 = timer_manager_t::create_task([&] { var = 42; });
+    m.run_after(t1, 3);
+    auto t2 = timer_manager_t::create_task([&] { var = 17; });
+    m.run_after(t2, 2);
+
+    m.service_task();
+    CHECK(var == 17);
+    CHECK(not m.is_idle());
+    CHECK(not t2.pending);
+
+    m.service_task();
+    CHECK(var == 42);
+    CHECK(m.is_idle());
+    CHECK(not t1.pending);
+}
+
+TEST_CASE("run tasks with same expiry time in FIFO order", "[timer_manager]") {
+    auto m = timer_manager_t{};
+    int var{};
+    auto t1 = timer_manager_t::create_task([&] { var = 42; });
+    m.run_after(t1, 3);
+    auto t2 = timer_manager_t::create_task([&] { var = 17; });
+    m.run_after(t2, 3);
+
+    m.service_task();
+    CHECK(var == 42);
+    CHECK(not m.is_idle());
+    CHECK(not t1.pending);
+
+    m.service_task();
+    CHECK(var == 17);
+    CHECK(m.is_idle());
+    CHECK(not t2.pending);
+}
+
+TEST_CASE("manager is not idle during a running task", "[timer_manager]") {
+    auto m = timer_manager_t{};
+    int var{};
+    auto task = timer_manager_t::create_task([&] {
+        CHECK(not m.is_idle());
+        var = 42;
+    });
+    m.run_after(task, 1);
+    m.service_task();
+    CHECK(var == 42);
+    CHECK(m.is_idle());
+}
+
+TEST_CASE("task can reschedule itself", "[timer_manager]") {
+    auto m = timer_manager_t{};
+    int var{};
+    auto task = timer_manager_t::create_task([&](hal::task_t *t) {
+        CHECK(m.run_after(*t, 1));
+        ++var;
+    });
+    m.run_after(task.bind_front(&task), 1);
+
+    m.service_task();
+    CHECK(var == 1);
+    CHECK(task.pending);
+    CHECK(not m.is_idle());
+
+    m.service_task();
+    CHECK(var == 2);
+    CHECK(task.pending);
+    CHECK(not m.is_idle());
+}
+
+TEST_CASE("cancel a scheduled task", "[timer_manager]") {
+    auto m = timer_manager_t{};
+    int var{};
+    auto task = timer_manager_t::create_task([&] { var = 42; });
+    m.run_after(task, 1);
+
+    CHECK(m.cancel(task));
+    CHECK(not task.pending);
+    CHECK(m.is_idle());
+}
+
+TEST_CASE("cancelling an unscheduled task fails", "[timer_manager]") {
+    auto m = timer_manager_t{};
+    int var{};
+    auto task = timer_manager_t::create_task([&] { var = 42; });
+    CHECK(not m.cancel(task));
+    CHECK(m.is_idle());
+}
+
+TEST_CASE("cancel with more tasks outstanding", "[timer_manager]") {
+    auto m = timer_manager_t{};
+    int var{};
+    auto t1 = timer_manager_t::create_task([&] { var = 42; });
+    m.run_after(t1, 3);
+    auto t2 = timer_manager_t::create_task([&] { var = 17; });
+    m.run_after(t2, 4);
+
+    m.cancel(t1);
+    CHECK(not m.is_idle());
+    CHECK(not t1.pending);
+
+    m.service_task();
+    CHECK(var == 17);
+    CHECK(m.is_idle());
+    CHECK(not t2.pending);
+}
+
+TEST_CASE("cancel during task run", "[timer_manager]") {
+    auto m = timer_manager_t{};
+    int var{};
+    auto task = timer_manager_t::create_task([&](hal::task_t *t) {
+        CHECK(not m.cancel(*t));
+        var = 42;
+    });
+    m.run_after(task.bind_front(&task), 1);
+
+    m.service_task();
+    CHECK(var == 42);
+    CHECK(not task.pending);
+    CHECK(m.is_idle());
+}
+
+TEST_CASE("interrupt is enabled when a task is queued", "[timer_manager]") {
+    hal::enabled = false;
+    auto m = timer_manager_t{};
+    int var{};
+    auto t = timer_manager_t::create_task([&] { var = 42; });
+    m.run_after(t, 3);
+    CHECK(hal::enabled);
+}
+
+TEST_CASE("interrupt is disabled after running all tasks", "[timer_manager]") {
+    hal::enabled = false;
+    auto m = timer_manager_t{};
+    int var{};
+    auto t = timer_manager_t::create_task([&] { var = 42; });
+    m.run_after(t, 3);
+    CHECK(hal::enabled);
+    m.service_task();
+    CHECK(not hal::enabled);
+}
+
+TEST_CASE("interrupt is disabled after cancelling last task",
+          "[timer_manager]") {
+    hal::enabled = false;
+    auto m = timer_manager_t{};
+    int var{};
+    auto t = timer_manager_t::create_task([&] { var = 42; });
+    m.run_after(t, 3);
+    CHECK(hal::enabled);
+    m.cancel(t);
+    CHECK(not hal::enabled);
+}
+
+TEST_CASE("interrupt is set for nearest time (updated)", "[timer_manager]") {
+    hal::calls.clear();
+
+    auto m = timer_manager_t{};
+    int var{};
+    auto t1 = timer_manager_t::create_task([&] { var = 42; });
+    m.run_after(t1, 3);
+    REQUIRE(not std::empty(hal::calls));
+    CHECK(hal::calls.back() == 3);
+    auto t2 = timer_manager_t::create_task([&] { var = 17; });
+    m.run_after(t2, 2);
+    CHECK(hal::calls.back() == 2);
+}
+
+TEST_CASE("interrupt is set for nearest time (not updated)",
+          "[timer_manager]") {
+    hal::calls.clear();
+
+    auto m = timer_manager_t{};
+    int var{};
+    auto t1 = timer_manager_t::create_task([&] { var = 42; });
+    m.run_after(t1, 3);
+    REQUIRE(not std::empty(hal::calls));
+    CHECK(hal::calls.back() == 3);
+    auto t2 = timer_manager_t::create_task([&] { var = 17; });
+    m.run_after(t2, 4);
+    CHECK(hal::calls.back() == 3);
+}
+
+TEST_CASE("interrupt is reset for nearest time after task is run",
+          "[timer_manager]") {
+    hal::calls.clear();
+
+    auto m = timer_manager_t{};
+    int var{};
+    auto t1 = timer_manager_t::create_task([&] { var = 42; });
+    m.run_after(t1, 3);
+    auto t2 = timer_manager_t::create_task([&] { var = 17; });
+    m.run_after(t2, 4);
+
+    REQUIRE(not std::empty(hal::calls));
+    CHECK(hal::calls.back() == 3);
+    m.service_task();
+    CHECK(hal::calls.back() == 4);
+}
+
+TEST_CASE("interrupt is reset for nearest time after task is cancelled",
+          "[timer_manager]") {
+    hal::calls.clear();
+
+    auto m = timer_manager_t{};
+    int var{};
+    auto t1 = timer_manager_t::create_task([&] { var = 42; });
+    m.run_after(t1, 3);
+    auto t2 = timer_manager_t::create_task([&] { var = 17; });
+    m.run_after(t2, 4);
+
+    REQUIRE(not std::empty(hal::calls));
+    CHECK(hal::calls.back() == 3);
+    m.cancel(t1);
+    CHECK(hal::calls.back() == 4);
+}
+
+TEST_CASE("queue a task on interrupt during servicing", "[timer_manager]") {
+    hal::enabled = false;
+    auto m = timer_manager_t{};
+    int var{};
+    auto t = timer_manager_t::create_task([&] { var = 42; });
+    m.run_after(t, 1);
+
+    interrupt_fn = [&] {
+        interrupt_fn = {};
+        m.run_after(t, 2);
+    };
+
+    CHECK(hal::enabled);
+    m.service_task();
+    CHECK(var == 42);
+    CHECK(not m.is_idle());
+    REQUIRE(not std::empty(hal::calls));
+    CHECK(hal::calls.back() == 2);
+    CHECK(hal::enabled);
+}


### PR DESCRIPTION
`generic_timer_manager` is similar to `priority_task_manager`. It is used to
manage timer tasks. Implementing `timer_manager.hpp` has resulted in a few
changes (mostly for consistency) to `task_manager.hpp` and associated concepts.

Design points of interest:
- symmetry between `timeable_task` and `prioritizable_task` concepts
- symmetry between `timer_manager` and `task_manager` concepts
- symmetry between `timer_hal` and `scheduler_hal` concepts
- for concepts, prototypical types are moved into `prototypes` namespace
- both manager types are parameterized on the task type
- symmetry between global injection patterns for timer/task managers
- the timer task type is defined by the timer HAL, because the time type must be
  parameterizable and is defined by the timer HAL (thus whatever the HW supports
  in terms of timer registers can be abstracted to the HAL's `time_point_t`)
- `create_task` `static` functions are on both manager types.
  `create_priority_task` at the moment is a free function also, but I'd like to
  remove it.
- in general `create_task` can't follow the global injection pattern because its
  return type depends on the injected manager type. (This is true of
  `priority_task_manager` as well as `generic_timer_manager` in the general
  case, which means `create_priority_task` is valid only for a particular instantiation
  of `priority_task_manager`... which is why I want to remove it)