### PR TITLE
:art: Rework `transform_completion_signatures_of`

### DIFF
--- a/include/async/let_error.hpp
+++ b/include/async/let_error.hpp
@@ -19,7 +19,7 @@ class sender : public _let::sender<sender<S, F>, S, F, set_error_t> {
     template <typename Env>
     [[nodiscard]] friend constexpr auto tag_invoke(get_completion_signatures_t,
                                                    sender const &, Env const &)
-        -> make_completion_signatures<
+        -> transform_completion_signatures_of<
             S, Env, typename base::template dependent_signatures<Env>,
             detail::default_set_value, base::template signatures> {
         return {};

--- a/include/async/let_stopped.hpp
+++ b/include/async/let_stopped.hpp
@@ -19,7 +19,7 @@ class sender : public _let::sender<sender<S, F>, S, F, set_stopped_t> {
     template <typename Env>
     [[nodiscard]] friend constexpr auto tag_invoke(get_completion_signatures_t,
                                                    sender const &, Env const &)
-        -> make_completion_signatures<
+        -> transform_completion_signatures_of<
             S, Env, typename base::template dependent_signatures<Env>,
             detail::default_set_value, detail::default_set_error,
             completion_signatures<>> {

--- a/include/async/let_value.hpp
+++ b/include/async/let_value.hpp
@@ -19,7 +19,7 @@ class sender : public _let::sender<sender<S, F>, S, F, set_value_t> {
     template <typename Env>
     [[nodiscard]] friend constexpr auto tag_invoke(get_completion_signatures_t,
                                                    sender const &, Env const &)
-        -> make_completion_signatures<
+        -> transform_completion_signatures_of<
             S, Env, typename base::template dependent_signatures<Env>,
             base::template signatures> {
         return {};

--- a/include/async/repeat.hpp
+++ b/include/async/repeat.hpp
@@ -98,7 +98,7 @@ template <typename Sndr, typename Pred> struct sender {
     tag_invoke(get_completion_signatures_t, sender const &, Env const &) {
         if constexpr (std::same_as<Pred,
                                    std::remove_cvref_t<decltype(never_stop)>>) {
-            return make_completion_signatures<
+            return transform_completion_signatures_of<
                 Sndr, Env, completion_signatures<>, signatures>{};
         } else {
             return completion_signatures_of_t<Sndr, Env>{};

--- a/include/async/retry.hpp
+++ b/include/async/retry.hpp
@@ -100,7 +100,7 @@ template <typename Sndr, typename Pred> struct sender {
     tag_invoke(get_completion_signatures_t, sender const &, Env const &) {
         if constexpr (std::same_as<Pred,
                                    std::remove_cvref_t<decltype(never_stop)>>) {
-            return make_completion_signatures<
+            return transform_completion_signatures_of<
                 Sndr, Env, completion_signatures<>, detail::default_set_value,
                 signatures>{};
         } else {

--- a/include/async/then.hpp
+++ b/include/async/then.hpp
@@ -201,24 +201,24 @@ template <typename Tag, typename S, typename... Fs> class sender {
         requires std::same_as<Tag, set_value_t>
     [[nodiscard]] friend constexpr auto
     tag_invoke(get_completion_signatures_t, sender const &, Env const &) {
-        return make_completion_signatures<S, Env, completion_signatures<>,
-                                          signatures>{};
+        return transform_completion_signatures_of<
+            S, Env, completion_signatures<>, signatures>{};
     }
 
     template <typename Env>
         requires std::same_as<Tag, set_error_t>
     [[nodiscard]] friend constexpr auto
     tag_invoke(get_completion_signatures_t, sender const &, Env const &) {
-        return make_completion_signatures<S, Env, completion_signatures<>,
-                                          ::async::detail::default_set_value,
-                                          signatures>{};
+        return transform_completion_signatures_of<
+            S, Env, completion_signatures<>, ::async::detail::default_set_value,
+            signatures>{};
     }
 
     template <typename Env>
         requires std::same_as<Tag, set_stopped_t>
     [[nodiscard]] friend constexpr auto tag_invoke(get_completion_signatures_t,
                                                    sender const &, Env const &)
-        -> make_completion_signatures<S, Env> {
+        -> transform_completion_signatures_of<S, Env> {
         return {};
     }
 

--- a/include/async/transfer.hpp
+++ b/include/async/transfer.hpp
@@ -143,7 +143,7 @@ template <typename Sched, typename S> class sender {
     template <typename Env>
     [[nodiscard]] friend constexpr auto tag_invoke(get_completion_signatures_t,
                                                    sender const &, Env const &)
-        -> make_completion_signatures<S, Env> {
+        -> completion_signatures_of_t<S, Env> {
         return {};
     }
 

--- a/include/async/variant_sender.hpp
+++ b/include/async/variant_sender.hpp
@@ -165,7 +165,7 @@ template <typename... Sndrs> struct sender : std::variant<Sndrs...> {
     [[nodiscard]] friend constexpr auto tag_invoke(get_completion_signatures_t,
                                                    sender const &, Env const &)
         -> boost::mp11::mp_unique<
-            boost::mp11::mp_append<make_completion_signatures<Sndrs, Env>...>> {
+            boost::mp11::mp_append<completion_signatures_of_t<Sndrs, Env>...>> {
         return {};
     }
 

--- a/include/async/when_any.hpp
+++ b/include/async/when_any.hpp
@@ -276,7 +276,7 @@ template <typename StopPolicy, typename... Sndrs> struct sender : Sndrs... {
     [[nodiscard]] friend constexpr auto tag_invoke(get_completion_signatures_t,
                                                    sender const &, Env const &)
         -> boost::mp11::mp_unique<
-            boost::mp11::mp_append<make_completion_signatures<Sndrs, Env>...>> {
+            boost::mp11::mp_append<completion_signatures_of_t<Sndrs, Env>...>> {
         return {};
     }
 


### PR DESCRIPTION
To match P2300, `make_completion_signatures` becomes `transform_completion_signatures_of`, which is implemented in terms of `transform_completion_signatures`.