### PR TITLE
:art: Allow multi-channel let

### DIFF
--- a/include/async/let_error.hpp
+++ b/include/async/let_error.hpp
@@ -13,18 +13,7 @@
 namespace async {
 namespace _let_error {
 template <typename S, typename F>
-class sender : public _let::sender<sender<S, F>, S, F, set_error_t> {
-    using base = _let::sender<sender, S, F, set_error_t>;
-
-    template <typename Env>
-    [[nodiscard]] friend constexpr auto tag_invoke(get_completion_signatures_t,
-                                                   sender const &, Env const &)
-        -> transform_completion_signatures_of<
-            S, Env, typename base::template dependent_signatures<Env>,
-            detail::default_set_value, base::template signatures> {
-        return {};
-    }
-};
+using sender = _let::sender<S, F, set_error_t>;
 } // namespace _let_error
 
 template <stdx::callable F>

--- a/include/async/let_stopped.hpp
+++ b/include/async/let_stopped.hpp
@@ -13,19 +13,7 @@
 namespace async {
 namespace _let_stopped {
 template <typename S, typename F>
-class sender : public _let::sender<sender<S, F>, S, F, set_stopped_t> {
-    using base = _let::sender<sender, S, F, set_stopped_t>;
-
-    template <typename Env>
-    [[nodiscard]] friend constexpr auto tag_invoke(get_completion_signatures_t,
-                                                   sender const &, Env const &)
-        -> transform_completion_signatures_of<
-            S, Env, typename base::template dependent_signatures<Env>,
-            detail::default_set_value, detail::default_set_error,
-            completion_signatures<>> {
-        return {};
-    }
-};
+using sender = _let::sender<S, F, set_stopped_t>;
 } // namespace _let_stopped
 
 template <stdx::callable F>

--- a/include/async/let_value.hpp
+++ b/include/async/let_value.hpp
@@ -13,18 +13,7 @@
 namespace async {
 namespace _let_value {
 template <typename S, typename F>
-class sender : public _let::sender<sender<S, F>, S, F, set_value_t> {
-    using base = _let::sender<sender, S, F, set_value_t>;
-
-    template <typename Env>
-    [[nodiscard]] friend constexpr auto tag_invoke(get_completion_signatures_t,
-                                                   sender const &, Env const &)
-        -> transform_completion_signatures_of<
-            S, Env, typename base::template dependent_signatures<Env>,
-            base::template signatures> {
-        return {};
-    }
-};
+using sender = _let::sender<S, F, set_value_t>;
 } // namespace _let_value
 
 template <stdx::callable F>

--- a/include/async/type_traits.hpp
+++ b/include/async/type_traits.hpp
@@ -38,12 +38,14 @@ using completion_signatures_of_t =
     std::invoke_result_t<get_completion_signatures_t, S, E>;
 
 namespace detail {
-template <typename Tag> struct with_tag {
-    template <typename Sig> using fn = std::is_same<Tag, stdx::return_t<Sig>>;
+template <typename... Tags> struct with_any_tag {
+    template <typename Sig>
+    using fn =
+        std::bool_constant<(... or std::is_same_v<Tags, stdx::return_t<Sig>>)>;
 };
 
 template <typename Sigs, typename Tag>
-using signatures_by_tag = boost::mp11::mp_copy_if_q<Sigs, with_tag<Tag>>;
+using signatures_by_tag = boost::mp11::mp_copy_if_q<Sigs, with_any_tag<Tag>>;
 
 template <bool> struct indirect_meta_apply {
     template <template <typename...> typename T, typename... As>

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -27,6 +27,7 @@ add_tests(
     just_result_of
     just_stopped
     let_error
+    let_multichannel
     let_stopped
     let_value
     on

--- a/test/let_multichannel.cpp
+++ b/test/let_multichannel.cpp
@@ -1,0 +1,123 @@
+#include "detail/common.hpp"
+
+#include <async/concepts.hpp>
+#include <async/just.hpp>
+#include <async/let.hpp>
+#include <async/tags.hpp>
+
+#include <stdx/type_traits.hpp>
+
+#include <catch2/catch_test_macros.hpp>
+
+namespace {
+template <typename S, typename F>
+using multilet_sender =
+    async::_let::sender<S, F, async::set_value_t, async::set_stopped_t>;
+
+template <typename F>
+[[nodiscard]] constexpr auto multilet(F &&f)
+    -> async::_let::pipeable<std::remove_cvref_t<F>, multilet_sender> {
+    return {std::forward<F>(f)};
+}
+struct wrapped_int {
+    int value;
+};
+} // namespace
+
+TEST_CASE("multi-channel let", "[let_multichannel]") {
+    int value{};
+    {
+        [[maybe_unused]] auto l = async::just_stopped() | multilet([] {
+                                      return async::just(wrapped_int{42});
+                                  });
+        auto op = async::connect(
+            l, receiver{[&](wrapped_int i) { value = i.value; }});
+        async::start(op);
+        CHECK(value == 42);
+    }
+    {
+        [[maybe_unused]] auto l = async::just(17) | multilet([](auto i) {
+                                      return async::just(wrapped_int{i});
+                                  });
+        auto op = async::connect(
+            l, receiver{[&](wrapped_int i) { value = i.value; }});
+        async::start(op);
+        CHECK(value == 17);
+    }
+}
+
+TEST_CASE("multi-channel let advertises what it sends", "[let_multichannel]") {
+    [[maybe_unused]] auto l = async::just(42) | multilet([](auto...) {
+                                  return async::just(wrapped_int{42});
+                              });
+    static_assert(
+        async::sender_of<decltype(l), async::set_value_t(wrapped_int)>);
+}
+
+TEST_CASE("multi-channel let advertises pass-through completions",
+          "[let_multichannel]") {
+    [[maybe_unused]] auto l = async::just_error(42) | multilet([](auto) {});
+    static_assert(async::sender_of<decltype(l), async::set_error_t(int)>);
+}
+
+TEST_CASE("multi-channel let can be single shot", "[let_multichannel]") {
+    [[maybe_unused]] auto l = async::just(42) | multilet([](auto i) {
+                                  return async::just(move_only{i});
+                              });
+    static_assert(async::singleshot_sender<decltype(l)>);
+}
+
+TEST_CASE("multi-channel let can be single shot with passthrough",
+          "[let_multichannel]") {
+    [[maybe_unused]] auto l =
+        async::just_error(move_only{42}) | multilet([](auto) { return 42; });
+    static_assert(async::singleshot_sender<decltype(l)>);
+}
+
+namespace {
+template <typename S, typename F>
+using allchannel_sender =
+    async::_let::sender<S, F, async::set_value_t, async::set_error_t,
+                        async::set_stopped_t>;
+
+template <typename F>
+[[nodiscard]] constexpr auto all_let(F &&f)
+    -> async::_let::pipeable<std::remove_cvref_t<F>, allchannel_sender> {
+    return {std::forward<F>(f)};
+}
+} // namespace
+
+TEST_CASE("multi-channel let supports compile-time channel differentiation",
+          "[let_multichannel]") {
+    int value{};
+
+    auto fn = [&]<async::channel_tag Tag>(auto...) {
+        if constexpr (std::is_same_v<Tag, async::set_value_t>) {
+            return async::just(1);
+        } else if constexpr (std::is_same_v<Tag, async::set_error_t>) {
+            return async::just(2);
+        } else if constexpr (std::is_same_v<Tag, async::set_stopped_t>) {
+            return async::just(3);
+        } else {
+            static_assert(stdx::always_false_v<Tag>);
+        }
+    };
+    {
+        auto l = async::just() | all_let(fn);
+        auto op = async::connect(l, receiver{[&](auto i) { value = i; }});
+        async::start(op);
+        CHECK(value == 1);
+    }
+    {
+        auto l = async::just_error(0) | all_let(fn);
+        auto op = async::connect(l, receiver{[&](auto i) { value = i; }});
+        async::start(op);
+        CHECK(value == 2);
+    }
+    {
+        auto l = async::just_stopped() | all_let(fn);
+        auto op = async::connect(l, receiver{[&](auto i) { value = i; }});
+        async::start(op);
+        CHECK(value == 3);
+    }
+}

--- a/test/let_stopped.cpp
+++ b/test/let_stopped.cpp
@@ -118,3 +118,21 @@ TEST_CASE("let_stopped propagates forwarding queries to its child environment",
     auto l = async::let_stopped(s, [] { return async::just(17); });
     CHECK(get_fwd(async::get_env(l)) == 42);
 }
+
+TEST_CASE("let_stopped advertises pass-through completions", "[let_stopped]") {
+    [[maybe_unused]] auto l = async::just(42) | async::let_stopped([] {});
+    static_assert(async::sender_of<decltype(l), async::set_value_t(int)>);
+}
+
+TEST_CASE("let_stopped can be single shot", "[let_stopped]") {
+    [[maybe_unused]] auto l = async::just_stopped() | async::let_stopped([] {
+                                  return async::just(move_only{42});
+                              });
+    static_assert(async::singleshot_sender<decltype(l)>);
+}
+
+TEST_CASE("let_stopped can be single shot with passthrough", "[let_stopped]") {
+    [[maybe_unused]] auto l = async::just(move_only{42}) |
+                              async::let_stopped([](auto) { return 42; });
+    static_assert(async::singleshot_sender<decltype(l)>);
+}


### PR DESCRIPTION
With a parameter pack of channel tags, generic `let` was very close to this.