### PR TITLE
:art: Rename `in_place_*` to `inplace_*`

### DIFF
--- a/docs/cancellation.adoc
+++ b/docs/cancellation.adoc
@@ -30,11 +30,11 @@ https://en.cppreference.com/w/cpp/header/stop_token[cppreference.com]. In the
 senders and receivers framework, the following implementations are in
 the `stop_token.hpp` header:
 
-- `async::in_place_stop_source` - a non-movable type that keeps the state
-- `async::in_place_stop_token` - lightweight and copyable
-- `async::in_place_stop_callback` - also non-movable
+- `async::inplace_stop_source` - a non-movable type that keeps the state
+- `async::inplace_stop_token` - lightweight and copyable
+- `async::inplace_stop_callback` - also non-movable
 
-None of these types causes allocation. `in_place_stop_callback` is similar to
+None of these types causes allocation. `inplace_stop_callback` is similar to
 the scheduler and timer task types, implemented as an intrusive list (hence it
 is non-movable).
 

--- a/docs/environments.adoc
+++ b/docs/environments.adoc
@@ -21,10 +21,10 @@ struct custom_receiver {
 
   struct env {
     [[nodiscard]] friend constexpr auto tag_invoke(async::get_stop_token_t,
-                                                   env const& e) -> async::in_place_stop_token {
+                                                   env const& e) -> async::inplace_stop_token {
       return e.token;
     }
-    async::in_place_stop_token token;
+    async::inplace_stop_token token;
   };
 
   [[nodiscard]] friend constexpr auto tag_invoke(async::get_env_t,
@@ -32,13 +32,13 @@ struct custom_receiver {
     return {r.stop_source->get_token()};
   }
 
-  in_place_stop_source* stop_source;
+  inplace_stop_source* stop_source;
 };
 ----
 
 Given this, we can construct an arbitrary composition of senders with this as
 the final receiver. If we want to cancel the operation, we call `request_stop()`
-on the (external) `in_place_stop_source`. The internal senders, receivers and
+on the (external) `inplace_stop_source`. The internal senders, receivers and
 operation states in the composition can observe this request by querying the
 stop token in the environment for the final receiver, and this knowledge can
 propagate through the sender-receiver chain.

--- a/docs/sender_consumers.adoc
+++ b/docs/sender_consumers.adoc
@@ -7,7 +7,7 @@
 the work running detached. The return value is a
 https://intel.github.io/cpp-std-extensions/#_optional_hpp[`stdx::optional`]. If
 the optional is empty, the sender was not started. Otherwise, it contains a
-pointer to an xref:cancellation.adoc#_cancellation[`in_place_stop_source`] that
+pointer to an xref:cancellation.adoc#_cancellation[`inplace_stop_source`] that
 can be used to cancel the operation.
 
 [source,cpp]
@@ -40,7 +40,7 @@ the result of `start_detached` is an empty optional.
 `start_detached_unstoppable` behaves identically to `start_detached`, except
 that the returned optional value contains a pointer to a `never_stop_source`,
 which has the same interface as an
-xref:cancellation.adoc#_cancellation[`in_place_stop_source`] but never actually
+xref:cancellation.adoc#_cancellation[`inplace_stop_source`] but never actually
 cancels the operation. So `start_detached_unstoppable` is slightly more
 efficient than `start_detached` for the cases where cancellation is not
 required.

--- a/include/async/split.hpp
+++ b/include/async/split.hpp
@@ -71,7 +71,7 @@ template <typename S, typename Uniq> struct single_receiver {
 
     [[nodiscard]] friend constexpr auto tag_invoke(get_env_t,
                                                    single_receiver const &)
-        -> detail::singleton_env<get_stop_token_t, in_place_stop_token> {
+        -> detail::singleton_env<get_stop_token_t, inplace_stop_token> {
         return {op_state_t::stop_source.get_token()};
     }
 };
@@ -95,7 +95,7 @@ template <typename S, typename Uniq> struct op_state_base {
         std::monostate>;
     static inline completions_t values{};
     static inline op_state_base *linked_ops{};
-    static inline in_place_stop_source stop_source{};
+    static inline inplace_stop_source stop_source{};
 
     using single_op_state_t = connect_result_t<S &&, single_receiver<S, Uniq>>;
     static inline std::optional<single_op_state_t> single_ops{};
@@ -111,7 +111,7 @@ struct op_state : op_state_base<S, Uniq> {
 
     struct stop_callback_fn {
         auto operator()() -> void { stop_source->request_stop(); }
-        in_place_stop_source *stop_source;
+        inplace_stop_source *stop_source;
     };
 
     template <stdx::same_as_unqualified<Rcvr> R>

--- a/include/async/start_detached.hpp
+++ b/include/async/start_detached.hpp
@@ -85,7 +85,7 @@ template <typename Uniq, typename StopSource> struct pipeable {
 
 template <typename Uniq = decltype([] {})>
 [[nodiscard]] constexpr auto start_detached()
-    -> _start_detached::pipeable<Uniq, in_place_stop_source> {
+    -> _start_detached::pipeable<Uniq, inplace_stop_source> {
     return {};
 }
 

--- a/include/async/when_all.hpp
+++ b/include/async/when_all.hpp
@@ -48,7 +48,7 @@ template <typename SubOps> struct sub_receiver {
 
     [[nodiscard]] friend constexpr auto tag_invoke(get_env_t,
                                                    sub_receiver const &self)
-        -> detail::overriding_env<get_stop_token_t, in_place_stop_token,
+        -> detail::overriding_env<get_stop_token_t, inplace_stop_token,
                                   typename SubOps::receiver_t> {
         return override_env_with<get_stop_token_t>(self.ops->get_stop_token(),
                                                    self.ops->get_receiver());
@@ -109,7 +109,7 @@ struct sub_op_state : sub_op_storage<env_of_t<R>, S> {
         return static_cast<Ops const &>(*this).rcvr;
     }
 
-    [[nodiscard]] auto get_stop_token() const -> in_place_stop_token {
+    [[nodiscard]] auto get_stop_token() const -> inplace_stop_token {
         return static_cast<Ops const &>(*this).stop_source.get_token();
     }
 
@@ -156,7 +156,7 @@ struct op_state
       sub_op_state<op_state<Rcvr, Sndrs...>, Rcvr, Sndrs>... {
     struct stop_callback_fn {
         auto operator()() -> void { stop_source->request_stop(); }
-        in_place_stop_source *stop_source;
+        inplace_stop_source *stop_source;
     };
 
     template <typename S, typename R>
@@ -216,7 +216,7 @@ struct op_state
 
     [[no_unique_address]] Rcvr rcvr;
     std::atomic<std::size_t> count{};
-    in_place_stop_source stop_source{};
+    inplace_stop_source stop_source{};
     std::optional<stop_callback_t> stop_cb{};
     std::atomic<bool> have_error{};
 
@@ -253,7 +253,7 @@ template <typename... Sndrs> struct sender : Sndrs... {
             ... and
             multishot_sender<typename Sndrs::sender_t,
                              detail::universal_receiver<detail::overriding_env<
-                                 get_stop_token_t, in_place_stop_token,
+                                 get_stop_token_t, inplace_stop_token,
                                  std::remove_cvref_t<R>>>>)
     [[nodiscard]] friend constexpr auto tag_invoke(connect_t, Self &&self,
                                                    R &&r)

--- a/include/async/when_any.hpp
+++ b/include/async/when_any.hpp
@@ -38,7 +38,7 @@ template <typename SubOps> struct sub_receiver {
 
     [[nodiscard]] friend constexpr auto tag_invoke(get_env_t,
                                                    sub_receiver const &self)
-        -> detail::overriding_env<get_stop_token_t, in_place_stop_token,
+        -> detail::overriding_env<get_stop_token_t, inplace_stop_token,
                                   typename SubOps::receiver_t> {
         return override_env_with<get_stop_token_t>(self.ops->get_stop_token(),
                                                    self.ops->get_receiver());
@@ -69,7 +69,7 @@ struct sub_op_state {
         return static_cast<Ops const &>(*this).rcvr;
     }
 
-    [[nodiscard]] auto get_stop_token() const -> in_place_stop_token {
+    [[nodiscard]] auto get_stop_token() const -> inplace_stop_token {
         return static_cast<Ops const &>(*this).stop_source.get_token();
     }
 
@@ -183,7 +183,7 @@ struct op_state
     : sub_op_state<op_state<StopPolicy, Rcvr, Sndrs...>, Rcvr, Sndrs>... {
     struct stop_callback_fn {
         auto operator()() -> void { stop_source->request_stop(); }
-        in_place_stop_source *stop_source;
+        inplace_stop_source *stop_source;
     };
 
     template <typename S, typename R>
@@ -200,7 +200,7 @@ struct op_state
     using apply_tag = boost::mp11::mp_transform_q<prepend<Tag>, L>;
 
     using env_t =
-        detail::overriding_env<get_stop_token_t, in_place_stop_token, Rcvr>;
+        detail::overriding_env<get_stop_token_t, inplace_stop_token, Rcvr>;
 
     using completions_t = boost::mp11::mp_unique<boost::mp11::mp_append<
         std::variant<std::monostate>,
@@ -248,7 +248,7 @@ struct op_state
     [[no_unique_address]] Rcvr rcvr;
     completions_t completions{};
     std::atomic<std::size_t> count{};
-    in_place_stop_source stop_source{};
+    inplace_stop_source stop_source{};
     std::optional<stop_callback_t> stop_cb{};
 
   private:
@@ -292,7 +292,7 @@ template <typename StopPolicy, typename... Sndrs> struct sender : Sndrs... {
             ... and
             multishot_sender<typename Sndrs::sender_t,
                              detail::universal_receiver<detail::overriding_env<
-                                 get_stop_token_t, in_place_stop_token,
+                                 get_stop_token_t, inplace_stop_token,
                                  std::remove_cvref_t<R>>>>)
     [[nodiscard]] friend constexpr auto tag_invoke(connect_t, Self &&self,
                                                    R &&r)

--- a/test/detail/common.hpp
+++ b/test/detail/common.hpp
@@ -75,7 +75,7 @@ template <typename F> struct stopped_receiver : F {
 };
 template <typename F> stopped_receiver(F) -> stopped_receiver<F>;
 
-template <typename T> std::optional<async::in_place_stop_source> stop_source{};
+template <typename T> std::optional<async::inplace_stop_source> stop_source{};
 
 template <typename F> struct stoppable_receiver : F {
     using is_receiver = void;
@@ -88,7 +88,7 @@ template <typename F> struct stoppable_receiver : F {
     auto request_stop() { stop_source<stoppable_receiver>->request_stop(); }
 
     struct env {
-        async::in_place_stop_token stop_token;
+        async::inplace_stop_token stop_token;
 
       private:
         [[nodiscard]] friend constexpr auto tag_invoke(async::get_stop_token_t,

--- a/test/read.cpp
+++ b/test/read.cpp
@@ -33,7 +33,7 @@ TEST_CASE("read sends a value", "[read]") {
     auto r = stoppable_receiver{[&] { ++value; }};
 
     auto s = async::get_stop_token() |
-             async::then([&](async::in_place_stop_token) { value = 42; });
+             async::then([&](async::inplace_stop_token) { value = 42; });
     auto op = async::connect(s, r);
     async::start(op);
     CHECK(value == 43);

--- a/test/stop_token.cpp
+++ b/test/stop_token.cpp
@@ -7,11 +7,11 @@
 #include <memory>
 
 TEST_CASE("concepts", "[stop_token]") {
-    static_assert(async::stoppable_token<async::in_place_stop_token>);
+    static_assert(async::stoppable_token<async::inplace_stop_token>);
     static_assert(async::stoppable_token<async::never_stop_token>);
     static_assert(async::unstoppable_token<async::never_stop_token>);
-    static_assert(async::stoppable_token_for<async::in_place_stop_token,
-                                             decltype([] {})>);
+    static_assert(
+        async::stoppable_token_for<async::inplace_stop_token, decltype([] {})>);
 }
 
 TEST_CASE("never_stop_token", "[stop_token]") {
@@ -21,7 +21,7 @@ TEST_CASE("never_stop_token", "[stop_token]") {
 }
 
 TEST_CASE("request_stop returns true once", "[stop_token]") {
-    auto s = async::in_place_stop_source{};
+    auto s = async::inplace_stop_source{};
 
     REQUIRE(s.stop_possible());
     CHECK(s.request_stop());
@@ -31,7 +31,7 @@ TEST_CASE("request_stop returns true once", "[stop_token]") {
 }
 
 TEST_CASE("stop request is visible to all tokens", "[stop_token]") {
-    auto s = async::in_place_stop_source{};
+    auto s = async::inplace_stop_source{};
 
     auto const t1 = s.get_token();
     CHECK(s.request_stop());
@@ -42,27 +42,27 @@ TEST_CASE("stop request is visible to all tokens", "[stop_token]") {
 }
 
 TEST_CASE("stop callbacks are called on request_stop", "[stop_token]") {
-    auto s = async::in_place_stop_source{};
+    auto s = async::inplace_stop_source{};
     auto const t = s.get_token();
 
     auto stopped = false;
-    auto cb = async::in_place_stop_callback{t, [&] { stopped = true; }};
+    auto cb = async::inplace_stop_callback{t, [&] { stopped = true; }};
 
     CHECK(s.request_stop());
     CHECK(stopped);
 }
 
 TEST_CASE("destroyed stop callbacks are handled properly", "[stop_token]") {
-    auto s = async::in_place_stop_source{};
+    auto s = async::inplace_stop_source{};
     auto const t = s.get_token();
 
     auto stopped = 2;
     auto l = [&] { --stopped; };
 
-    auto cb1 = async::in_place_stop_callback{t, l};
+    auto cb1 = async::inplace_stop_callback{t, l};
     auto cb2 =
-        std::make_unique<async::in_place_stop_callback<decltype(l)>>(t, l);
-    auto cb3 = async::in_place_stop_callback{t, l};
+        std::make_unique<async::inplace_stop_callback<decltype(l)>>(t, l);
+    auto cb3 = async::inplace_stop_callback{t, l};
 
     cb2.reset();
     CHECK(s.request_stop());
@@ -71,29 +71,29 @@ TEST_CASE("destroyed stop callbacks are handled properly", "[stop_token]") {
 
 TEST_CASE("after request_stop, stop callback construction causes callback",
           "[stop_token]") {
-    auto s = async::in_place_stop_source{};
+    auto s = async::inplace_stop_source{};
     auto const t = s.get_token();
 
     auto stopped = 2;
     auto l = [&] { --stopped; };
 
-    auto cb1 = async::in_place_stop_callback{t, l};
+    auto cb1 = async::inplace_stop_callback{t, l};
     CHECK(s.request_stop());
     CHECK(stopped == 1);
 
-    auto cb2 = async::in_place_stop_callback{t, l};
+    auto cb2 = async::inplace_stop_callback{t, l};
     CHECK(stopped == 0);
 }
 
 TEST_CASE("stop callback can register another callback", "[stop_token]") {
-    auto s = async::in_place_stop_source{};
+    auto s = async::inplace_stop_source{};
     auto const t = s.get_token();
 
     auto stopped = 2;
-    auto cb1 = async::in_place_stop_callback{
+    auto cb1 = async::inplace_stop_callback{
         t, [&] {
             --stopped;
-            auto cb2 = async::in_place_stop_callback{t, [&] { --stopped; }};
+            auto cb2 = async::inplace_stop_callback{t, [&] { --stopped; }};
         }};
     CHECK(s.request_stop());
     CHECK(stopped == 0);


### PR DESCRIPTION
This is the currently favoured name, and matches other standard things like `std::inplace_merge` and the potentially forthcoming `std::inplace_vector`. But notably at odds with `std::in_place_t` and friends. The standard is already inconsistent...