### PR TITLE
:sparkles: Add composability of sender adaptors

### DIFF
--- a/docs/pipes.adoc
+++ b/docs/pipes.adoc
@@ -13,3 +13,16 @@ auto async_computation =
   | async::continue_on(s2)
   | async::then([] (int i) { return std::to_string(i); });
 ----
+
+It is also possible to compose sender adaptors with pipe syntax, allowing us to
+defer both where the operation runs and how the result is obtained:
+
+[source,cpp]
+----
+auto async_computation =
+  | async::then([] { return 42; })
+  | async::continue_on(s2)
+  | async::then([] (int i) { return std::to_string(i); });
+
+s1.schedule() | async_computation | async::sync_wait();
+----

--- a/docs/sender_adaptors.adoc
+++ b/docs/sender_adaptors.adoc
@@ -146,7 +146,7 @@ given predicate returns true.
 [source,cpp]
 ----
 // this is the same as repeat_n(0), i.e. just run once
-auto s = some_sender | async::repeat_until([] (auto&&...){ return true; });
+auto s = some_sender | async::repeat_until([] (auto&&...) { return true; });
 ----
 
 NOTE: The arguments passed to the predicate are those in the value completion(s)
@@ -175,7 +175,16 @@ xref:schedulers.adoc#_inline_scheduler[`inline_scheduler`].
 Found in the header: `async/retry.hpp`
 
 `retry_until` works like `retry`, but takes a predicate. If the predicate
-returns false, `retry_until` can complete on the error channel.
+returns true, `retry_until` can complete on the error channel.
+
+[source,cpp]
+----
+// this is the same as just running the sender
+auto s = some_sender | async::retry_until([] (auto&&) { return true; });
+----
+
+NOTE: The arguments passed to the predicate are those in the error completion(s)
+of the sender.
 
 === `sequence`
 

--- a/include/async/compose.hpp
+++ b/include/async/compose.hpp
@@ -1,0 +1,39 @@
+#pragma once
+
+#include <async/concepts.hpp>
+
+#include <stdx/concepts.hpp>
+#include <stdx/tuple.hpp>
+#include <stdx/tuple_algorithms.hpp>
+#include <stdx/utility.hpp>
+
+#include <utility>
+
+namespace async {
+namespace _compose {
+template <typename... As> struct adaptor {
+    using is_adaptor_composition = void;
+    stdx::tuple<As...> as;
+
+  private:
+    template <async::sender S, stdx::same_as_unqualified<adaptor> Self>
+    friend constexpr auto operator|(S &&s, Self &&self) -> auto {
+        return std::forward<Self>(self).as.apply(
+            [&]<typename... Ts>(Ts &&...ts) {
+                return (std::forward<S>(s) | ... | std::forward<Ts>(ts));
+            });
+    }
+};
+
+template <typename... Ts> adaptor(stdx::tuple<Ts...>) -> adaptor<Ts...>;
+
+template <typename S>
+concept is_adaptor_composition =
+    requires { typename S::is_adaptor_composition; };
+
+template <is_adaptor_composition A, is_adaptor_composition B>
+constexpr auto operator|(A &&a, B &&b) {
+    return adaptor{stdx::tuple_cat(FWD(a).as, FWD(b).as)};
+}
+} // namespace _compose
+} // namespace async

--- a/include/async/continue_on.hpp
+++ b/include/async/continue_on.hpp
@@ -30,9 +30,10 @@ template <typename Sched> struct pipeable {
 } // namespace _continue_on
 
 template <typename Sched>
-[[nodiscard]] constexpr auto continue_on(Sched &&sched)
-    -> _continue_on::pipeable<std::remove_cvref_t<Sched>> {
-    return {std::forward<Sched>(sched)};
+[[nodiscard]] constexpr auto continue_on(Sched &&sched) {
+    return _compose::adaptor{
+        stdx::tuple{_continue_on::pipeable<std::remove_cvref_t<Sched>>{
+            std::forward<Sched>(sched)}}};
 }
 
 template <sender S, typename Sched>

--- a/include/async/let_error.hpp
+++ b/include/async/let_error.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <async/compose.hpp>
 #include <async/concepts.hpp>
 #include <async/let.hpp>
 #include <async/tags.hpp>
@@ -16,10 +17,10 @@ template <typename S, typename F>
 using sender = _let::sender<S, F, set_error_t>;
 } // namespace _let_error
 
-template <stdx::callable F>
-[[nodiscard]] constexpr auto let_error(F &&f)
-    -> _let::pipeable<std::remove_cvref_t<F>, _let_error::sender> {
-    return {std::forward<F>(f)};
+template <stdx::callable F> [[nodiscard]] constexpr auto let_error(F &&f) {
+    return _compose::adaptor{
+        stdx::tuple{_let::pipeable<std::remove_cvref_t<F>, _let_error::sender>{
+            std::forward<F>(f)}}};
 }
 
 template <sender S, stdx::callable F>

--- a/include/async/let_stopped.hpp
+++ b/include/async/let_stopped.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <async/compose.hpp>
 #include <async/concepts.hpp>
 #include <async/let.hpp>
 #include <async/tags.hpp>
@@ -16,10 +17,10 @@ template <typename S, typename F>
 using sender = _let::sender<S, F, set_stopped_t>;
 } // namespace _let_stopped
 
-template <stdx::callable F>
-[[nodiscard]] constexpr auto let_stopped(F &&f)
-    -> _let::pipeable<std::remove_cvref_t<F>, _let_stopped::sender> {
-    return {std::forward<F>(f)};
+template <stdx::callable F> [[nodiscard]] constexpr auto let_stopped(F &&f) {
+    return _compose::adaptor{stdx::tuple{
+        _let::pipeable<std::remove_cvref_t<F>, _let_stopped::sender>{
+            std::forward<F>(f)}}};
 }
 
 template <sender S, stdx::callable F>

--- a/include/async/let_value.hpp
+++ b/include/async/let_value.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <async/compose.hpp>
 #include <async/concepts.hpp>
 #include <async/let.hpp>
 #include <async/tags.hpp>
@@ -16,10 +17,10 @@ template <typename S, typename F>
 using sender = _let::sender<S, F, set_value_t>;
 } // namespace _let_value
 
-template <stdx::callable F>
-[[nodiscard]] constexpr auto let_value(F &&f)
-    -> _let::pipeable<std::remove_cvref_t<F>, _let_value::sender> {
-    return {std::forward<F>(f)};
+template <stdx::callable F> [[nodiscard]] constexpr auto let_value(F &&f) {
+    return _compose::adaptor{
+        stdx::tuple{_let::pipeable<std::remove_cvref_t<F>, _let_value::sender>{
+            std::forward<F>(f)}}};
 }
 
 template <sender S, stdx::callable F>

--- a/include/async/repeat.hpp
+++ b/include/async/repeat.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <async/compose.hpp>
 #include <async/concepts.hpp>
 #include <async/env.hpp>
 #include <async/type_traits.hpp>
@@ -151,10 +152,9 @@ template <stdx::callable Pred> struct pipeable {
 };
 } // namespace _repeat
 
-template <typename P>
-[[nodiscard]] constexpr auto repeat_until(P &&p)
-    -> _repeat::pipeable<std::remove_cvref_t<P>> {
-    return {std::forward<P>(p)};
+template <typename P> [[nodiscard]] constexpr auto repeat_until(P &&p) {
+    return _compose::adaptor{stdx::tuple{
+        _repeat::pipeable<std::remove_cvref_t<P>>{std::forward<P>(p)}}};
 }
 
 template <sender S, typename P> [[nodiscard]] auto repeat_until(S &&s, P &&p) {

--- a/include/async/retry.hpp
+++ b/include/async/retry.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <async/compose.hpp>
 #include <async/concepts.hpp>
 #include <async/env.hpp>
 #include <async/tags.hpp>
@@ -7,6 +8,8 @@
 
 #include <stdx/concepts.hpp>
 #include <stdx/functional.hpp>
+
+#include <boost/mp11/algorithm.hpp>
 
 #include <concepts>
 #include <optional>
@@ -43,10 +46,27 @@ template <typename Ops, typename Rcvr> struct receiver {
     }
 };
 
-constexpr auto never_stop = [] { return false; };
+constexpr auto never_stop = [](auto &&...) { return false; };
+
+template <typename Pred, typename Sig, typename = void>
+struct is_callable : std::false_type {};
+template <typename Pred, typename... Args>
+struct is_callable<Pred, set_error_t(Args...),
+                   std::void_t<std::invoke_result_t<Pred, Args...>>>
+    : std::true_type {};
+
+template <typename Pred> struct callable_with {
+    template <typename Sig> using fn = is_callable<Pred, Sig>;
+};
 
 // NOLINTNEXTLINE(cppcoreguidelines-special-member-functions)
 template <typename Sndr, typename Rcvr, typename Pred> struct op_state {
+    using receiver_t = receiver<op_state, Rcvr>;
+    using value_completions = error_signatures_of_t<Sndr, env_of_t<receiver_t>>;
+    static_assert(
+        boost::mp11::mp_all_of_q<value_completions, callable_with<Pred>>::value,
+        "Predicate is not callable with error completions of sender");
+
     template <stdx::same_as_unqualified<Sndr> S,
               stdx::same_as_unqualified<Rcvr> R,
               stdx::same_as_unqualified<Pred> P>
@@ -58,14 +78,14 @@ template <typename Sndr, typename Rcvr, typename Pred> struct op_state {
 
     auto restart() -> void {
         auto &op = state.emplace(stdx::with_result_of{
-            [&] { return connect(sndr, receiver<op_state, Rcvr>{this}); }});
+            [&] { return connect(sndr, receiver_t{this}); }});
         start(std::move(op));
     }
 
     template <typename... Args> auto retry(Args &&...args) -> void {
         if constexpr (not std::same_as<
                           Pred, std::remove_cvref_t<decltype(never_stop)>>) {
-            if (pred()) {
+            if (pred(args...)) {
                 set_error(rcvr, std::forward<Args>(args)...);
                 return;
             }
@@ -77,7 +97,7 @@ template <typename Sndr, typename Rcvr, typename Pred> struct op_state {
     [[no_unique_address]] Rcvr rcvr;
     [[no_unique_address]] Pred pred;
 
-    using state_t = async::connect_result_t<Sndr &, receiver<op_state, Rcvr>>;
+    using state_t = async::connect_result_t<Sndr &, receiver_t>;
     std::optional<state_t> state{};
 
   private:
@@ -123,7 +143,7 @@ template <typename Sndr, typename Pred> struct sender {
     }
 };
 
-template <stdx::predicate Pred> struct pipeable {
+template <typename Pred> struct pipeable {
     Pred p;
 
   private:
@@ -135,15 +155,13 @@ template <stdx::predicate Pred> struct pipeable {
 };
 } // namespace _retry
 
-template <stdx::predicate P>
-[[nodiscard]] constexpr auto retry_until(P &&p)
-    -> _retry::pipeable<std::remove_cvref_t<P>> {
-    return {std::forward<P>(p)};
+template <typename P> [[nodiscard]] constexpr auto retry_until(P &&p) {
+    return _compose::adaptor{stdx::tuple{
+        _retry::pipeable<std::remove_cvref_t<P>>{std::forward<P>(p)}}};
 }
 
-template <sender S, stdx::predicate P>
-[[nodiscard]] auto retry_until(S &&s, P &&p) {
-    return std::forward<S>(s) | retry(std::forward<P>(p));
+template <sender S, typename P> [[nodiscard]] auto retry_until(S &&s, P &&p) {
+    return std::forward<S>(s) | retry_until(std::forward<P>(p));
 }
 
 [[nodiscard]] constexpr auto retry() { return retry_until(_retry::never_stop); }

--- a/include/async/sequence.hpp
+++ b/include/async/sequence.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <async/compose.hpp>
 #include <async/concepts.hpp>
 #include <async/tags.hpp>
 
@@ -156,10 +157,9 @@ template <std::invocable F> struct pipeable {
 };
 } // namespace _sequence
 
-template <std::invocable F>
-[[nodiscard]] constexpr auto sequence(F &&f)
-    -> _sequence::pipeable<std::remove_cvref_t<F>> {
-    return {std::forward<F>(f)};
+template <std::invocable F> [[nodiscard]] constexpr auto sequence(F &&f) {
+    return _compose::adaptor{stdx::tuple{
+        _sequence::pipeable<std::remove_cvref_t<F>>{std::forward<F>(f)}}};
 }
 
 template <sender S, std::invocable F>

--- a/include/async/then.hpp
+++ b/include/async/then.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <async/compose.hpp>
 #include <async/concepts.hpp>
 #include <async/env.hpp>
 #include <async/forwarding_query.hpp>
@@ -243,10 +244,10 @@ template <typename Tag, typename... Fs> struct pipeable {
 };
 } // namespace _then
 
-template <stdx::callable... Fs>
-[[nodiscard]] constexpr auto then(Fs &&...fs)
-    -> _then::pipeable<set_value_t, std::remove_cvref_t<Fs>...> {
-    return {std::forward<Fs>(fs)...};
+template <stdx::callable... Fs> [[nodiscard]] constexpr auto then(Fs &&...fs) {
+    return _compose::adaptor<
+        _then::pipeable<set_value_t, std::remove_cvref_t<Fs>...>>{
+        std::forward<Fs>(fs)...};
 }
 
 template <sender S, stdx::callable... Fs>
@@ -254,10 +255,10 @@ template <sender S, stdx::callable... Fs>
     return std::forward<S>(s) | then(std::forward<Fs>(fs)...);
 }
 
-template <stdx::callable F>
-[[nodiscard]] constexpr auto upon_error(F &&f)
-    -> _then::pipeable<set_error_t, std::remove_cvref_t<F>> {
-    return {std::forward<F>(f)};
+template <stdx::callable F> [[nodiscard]] constexpr auto upon_error(F &&f) {
+    return _compose::adaptor<
+        _then::pipeable<set_error_t, std::remove_cvref_t<F>>>{
+        std::forward<F>(f)};
 }
 
 template <sender S, stdx::callable F>
@@ -265,14 +266,15 @@ template <sender S, stdx::callable F>
     return std::forward<S>(s) | upon_error(std::forward<F>(f));
 }
 
-template <stdx::callable F>
-[[nodiscard]] constexpr auto upon_stopped(F &&f)
-    -> _then::pipeable<set_stopped_t, std::remove_cvref_t<F>> {
-    return {std::forward<F>(f)};
+template <stdx::callable F> [[nodiscard]] constexpr auto upon_stopped(F &&f) {
+    return _compose::adaptor<
+        _then::pipeable<set_stopped_t, std::remove_cvref_t<F>>>{
+        std::forward<F>(f)};
 }
 
 template <sender S, stdx::callable F>
 [[nodiscard]] constexpr auto upon_stopped(S &&s, F &&f) -> sender auto {
     return std::forward<S>(s) | upon_stopped(std::forward<F>(f));
 }
+
 } // namespace async

--- a/include/async/when_any.hpp
+++ b/include/async/when_any.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <async/compose.hpp>
 #include <async/concepts.hpp>
 #include <async/env.hpp>
 #include <async/stop_token.hpp>
@@ -379,10 +380,11 @@ template <sender... Sndrs>
     return when_any<_when_any::first_successful>(std::forward<Sndrs>(sndrs)...);
 }
 
-template <sender Trigger>
-[[nodiscard]] constexpr auto stop_when(Trigger &&t)
-    -> _when_any::pipeable<std::remove_cvref_t<Trigger>> {
-    return {std::forward<Trigger>(t)};
+template <typename Trigger>
+[[nodiscard]] constexpr auto stop_when(Trigger &&t) {
+    return _compose::adaptor{
+        stdx::tuple{_when_any::pipeable<std::remove_cvref_t<Trigger>>{
+            std::forward<Trigger>(t)}}};
 }
 
 template <sender Sndr, sender Trigger>

--- a/test/let_error.cpp
+++ b/test/let_error.cpp
@@ -72,6 +72,17 @@ TEST_CASE("let_error is pipeable", "[let_error]") {
     CHECK(value == 42);
 }
 
+TEST_CASE("let_error is adaptor-pipeable", "[let_error]") {
+    int value{};
+
+    auto l = async::let_error([](int) { return async::just_error(42); }) |
+             async::let_error([](int i) { return async::just(i * 2); });
+    auto op = async::connect(async::just_error(0) | l,
+                             receiver{[&](auto i) { value = i; }});
+    async::start(op);
+    CHECK(value == 84);
+}
+
 TEST_CASE("move-only value", "[let_error]") {
     int value{};
 

--- a/test/let_stopped.cpp
+++ b/test/let_stopped.cpp
@@ -55,6 +55,17 @@ TEST_CASE("let_stopped is pipeable", "[let_stopped]") {
     CHECK(value == 42);
 }
 
+TEST_CASE("let_stopped is adaptor-pipeable", "[let_stopped]") {
+    int value{};
+
+    auto l = async::let_stopped([] { return async::just_stopped(); }) |
+             async::let_stopped([] { return async::just(42); });
+    auto op = async::connect(async::just_stopped() | l,
+                             receiver{[&](auto i) { value = i; }});
+    async::start(op);
+    CHECK(value == 42);
+}
+
 TEST_CASE("move-only value", "[let_stopped]") {
     int value{};
 

--- a/test/let_value.cpp
+++ b/test/let_value.cpp
@@ -79,6 +79,18 @@ TEST_CASE("let_value is pipeable", "[let_value]") {
     CHECK(value == 42);
 }
 
+TEST_CASE("let_value is adaptor-pipeable", "[let_value]") {
+    int value{};
+
+    auto l = async::let_value([] { return async::just(42); }) |
+             async::let_value([](int i) { return async::just(i * 2); });
+    auto sched = async::inline_scheduler{};
+    auto op = async::connect(sched.schedule() | l,
+                             receiver{[&](auto i) { value = i; }});
+    async::start(op);
+    CHECK(value == 84);
+}
+
 TEST_CASE("move-only value", "[let_value]") {
     int value{};
 

--- a/test/sequence.cpp
+++ b/test/sequence.cpp
@@ -75,6 +75,16 @@ TEST_CASE("sequence is pipeable", "[sequence]") {
     CHECK(value == 42);
 }
 
+TEST_CASE("sequence is adaptor-pipeable", "[sequence]") {
+    int value{};
+    auto s = async::sequence([] { return async::just(17); }) |
+             async::sequence([] { return async::just(42); });
+    auto op =
+        async::connect(async::just() | s, receiver{[&](auto i) { value = i; }});
+    async::start(op);
+    CHECK(value == 42);
+}
+
 TEST_CASE("move-only first sender", "[sequence]") {
     int value{};
     auto s = async::sequence(async::just(move_only{17}),

--- a/test/then.cpp
+++ b/test/then.cpp
@@ -55,6 +55,18 @@ TEST_CASE("then is pipeable", "[then]") {
     CHECK(value == 42);
 }
 
+TEST_CASE("then is adaptor-pipeable", "[then]") {
+    int value{};
+
+    auto n = async::then([] { return 42; }) |
+             async::then([](int i) { return i * 2; });
+    auto sched = async::inline_scheduler{};
+    auto op = async::connect(sched.schedule() | n,
+                             receiver{[&](auto i) { value = i; }});
+    async::start(op);
+    CHECK(value == 84);
+}
+
 TEST_CASE("then can send nothing", "[then]") {
     int value{};
 

--- a/test/when_any.cpp
+++ b/test/when_any.cpp
@@ -237,6 +237,17 @@ TEST_CASE("stop_when is pipeable", "[when_any]") {
     CHECK(value == 42);
 }
 
+TEST_CASE("stop_when is adaptor-pipeable", "[when_any]") {
+    int value{};
+    auto w = async::then([] { return 42; }) | async::stop_when(async::just(17));
+    auto op = async::connect(async::just() | w, receiver{[&](auto i) {
+                                 CHECK(value == 0);
+                                 value = i;
+                             }});
+    async::start(op);
+    CHECK(value == 42);
+}
+
 TEST_CASE("when_any with zero args never completes", "[when_any]") {
     int value{};
     [[maybe_unused]] auto w = async::when_any();


### PR DESCRIPTION
- Most pipeable things can now be piped separately from having a sender at the front.
- Exceptions: `sync_wait`, `start_detached` and `split`.
- Also alter `retry_until` to match `repeat_until`, with the predicate taking the values on the error channel.