### PR TITLE
:bug: Remove sender attribute propagation from `sequence`

### DIFF
--- a/include/async/sequence.hpp
+++ b/include/async/sequence.hpp
@@ -131,18 +131,6 @@ template <typename S, std::invocable F> struct sender {
             unchanged_completions<Env>, dependent_completions<Env>>> {
         return {};
     }
-
-    [[nodiscard]] friend constexpr auto tag_invoke(async::get_env_t,
-                                                   sender const &sndr)
-        requires detail::has_eager_sender<F> or
-                 std::is_empty_v<env_of_t<dependent_sender>>
-    {
-        if constexpr (detail::has_eager_sender<F>) {
-            return forward_env_of(sndr.f.s);
-        } else {
-            return decltype(forward_env_of(std::declval<dependent_sender>())){};
-        }
-    }
 };
 
 template <std::invocable F> struct pipeable {

--- a/test/allocator.cpp
+++ b/test/allocator.cpp
@@ -29,14 +29,6 @@ TEST_CASE("allocator is forwarded through senders", "[allocator]") {
                        async::static_allocator>);
 }
 
-TEST_CASE("allocator is overridden through senders", "[allocator]") {
-    [[maybe_unused]] auto s = async::thread_scheduler{}.schedule() |
-                              async::seq(async::inline_scheduler{}.schedule());
-    static_assert(
-        std::is_same_v<async::allocator_of_t<async::env_of_t<decltype(s)>>,
-                       async::stack_allocator>);
-}
-
 namespace {
 struct domain;
 struct multi_domain;

--- a/test/sequence.cpp
+++ b/test/sequence.cpp
@@ -139,17 +139,6 @@ TEST_CASE("sequence propagates stopped", "[sequence]") {
     CHECK(value == 17);
 }
 
-TEST_CASE("sequence propagates forwarding queries to its child environment",
-          "[sequence]") {
-    auto s = custom_sender{};
-    CHECK(get_fwd(async::get_env(s)) == 42);
-    CHECK(get_nofwd(async::get_env(s)) == 17);
-
-    auto seq = async::just() | async::sequence([&] { return s; });
-    CHECK(get_fwd(async::get_env(seq)) == 42);
-    CHECK(get_nofwd(async::get_env(seq)) == none{});
-}
-
 TEST_CASE("seq(sender) is shorthand for sequence([] { return sender; })",
           "[sequence]") {
     int value{};
@@ -167,56 +156,4 @@ TEST_CASE("seq(sender) with move-only sender", "[sequence]") {
                              receiver{[&](auto mo) { value = mo.value; }});
     async::start(op);
     CHECK(value == 42);
-}
-
-TEST_CASE("sequence propagates forwarding queries multiple levels",
-          "[sequence]") {
-    auto s = async::just() | async::seq(custom_sender{});
-    auto seq = async::just() | async::seq(s);
-    CHECK(get_fwd(async::get_env(seq)) == 42);
-}
-
-namespace {
-struct stateful_env {
-    [[nodiscard]] friend constexpr auto tag_invoke(get_fwd_t,
-                                                   stateful_env const &e)
-        -> int {
-        return e.state;
-    }
-
-    int state{};
-};
-
-struct stateful_sender {
-    using is_sender = void;
-    using completion_signatures =
-        async::completion_signatures<async::set_value_t()>;
-
-    [[nodiscard]] friend constexpr auto tag_invoke(async::get_env_t,
-                                                   stateful_sender const &s)
-        -> stateful_env {
-        return {s.state};
-    }
-
-    template <typename R> struct op_state {
-        auto start() -> void { async::set_value(std::move(r)); }
-        [[no_unique_address]] R r;
-    };
-
-    template <typename R>
-    [[nodiscard]] friend constexpr auto tag_invoke(async::connect_t,
-                                                   stateful_sender &&, R &&r)
-        -> op_state<std::remove_cvref_t<R>> {
-        return {std::forward<R>(r)};
-    }
-
-    int state{};
-};
-} // namespace
-
-TEST_CASE(
-    "seq (eagerly-constructed sender) propagates state in forwarding queries",
-    "[sequence]") {
-    auto s = async::just() | async::seq(stateful_sender{1337});
-    CHECK(get_fwd(async::get_env(s)) == 1337);
 }


### PR DESCRIPTION
This was ill-conceived - see #71