### PR TITLE
:fire: Remove adaptor-pipeability for retry & repeat

### DIFF
--- a/include/async/repeat.hpp
+++ b/include/async/repeat.hpp
@@ -152,9 +152,10 @@ template <stdx::callable Pred> struct pipeable {
 };
 } // namespace _repeat
 
-template <typename P> [[nodiscard]] constexpr auto repeat_until(P &&p) {
-    return _compose::adaptor{stdx::tuple{
-        _repeat::pipeable<std::remove_cvref_t<P>>{std::forward<P>(p)}}};
+template <typename P>
+[[nodiscard]] constexpr auto repeat_until(P &&p)
+    -> _repeat::pipeable<std::remove_cvref_t<P>> {
+    return {std::forward<P>(p)};
 }
 
 template <sender S, typename P> [[nodiscard]] auto repeat_until(S &&s, P &&p) {

--- a/include/async/retry.hpp
+++ b/include/async/retry.hpp
@@ -155,9 +155,10 @@ template <typename Pred> struct pipeable {
 };
 } // namespace _retry
 
-template <typename P> [[nodiscard]] constexpr auto retry_until(P &&p) {
-    return _compose::adaptor{stdx::tuple{
-        _retry::pipeable<std::remove_cvref_t<P>>{std::forward<P>(p)}}};
+template <typename P>
+[[nodiscard]] constexpr auto retry_until(P &&p)
+    -> _retry::pipeable<std::remove_cvref_t<P>> {
+    return {std::forward<P>(p)};
 }
 
 template <sender S, typename P> [[nodiscard]] auto retry_until(S &&s, P &&p) {

--- a/test/fail/CMakeLists.txt
+++ b/test/fail/CMakeLists.txt
@@ -5,6 +5,8 @@ add_compile_fail_test("just_error_result_of_connect.cpp" LIBRARIES async
 add_compile_fail_test("just_result_of_connect.cpp" LIBRARIES async pthread)
 add_compile_fail_test("just_stopped_connect.cpp" LIBRARIES async pthread)
 add_compile_fail_test("read_env_connect.cpp" LIBRARIES async pthread)
+add_compile_fail_test("repeat_compose.cpp" LIBRARIES async pthread)
+add_compile_fail_test("retry_compose.cpp" LIBRARIES async pthread)
 add_compile_fail_test("sequence_connect.cpp" LIBRARIES async pthread)
 add_compile_fail_test("split_connect.cpp" LIBRARIES async pthread)
 add_compile_fail_test("then_connect.cpp" LIBRARIES async pthread)

--- a/test/fail/repeat_compose.cpp
+++ b/test/fail/repeat_compose.cpp
@@ -1,0 +1,8 @@
+#include <async/repeat.hpp>
+#include <async/then.hpp>
+
+// EXPECT: (invalid operands to binary expression)|(no match for)
+
+auto main() -> int {
+    [[maybe_unused]] auto op = async::then([] { return 42; }) | async::repeat();
+}

--- a/test/fail/retry_compose.cpp
+++ b/test/fail/retry_compose.cpp
@@ -1,0 +1,8 @@
+#include <async/retry.hpp>
+#include <async/then.hpp>
+
+// EXPECT: (invalid operands to binary expression)|(no match for)
+
+auto main() -> int {
+    [[maybe_unused]] auto op = async::then([] { return 42; }) | async::retry();
+}

--- a/test/repeat.cpp
+++ b/test/repeat.cpp
@@ -110,20 +110,6 @@ TEST_CASE("repeat_until is pipeable", "[repeat]") {
     CHECK(var == 43);
 }
 
-TEST_CASE("repeat_until is adaptor-pipeable", "[repeat]") {
-    int var{};
-
-    auto s = async::sequence([&] {
-                 ++var;
-                 return async::just(42);
-             }) |
-             async::repeat_until([&](auto i) { return i == 42; });
-    auto op =
-        async::connect(async::just() | s, receiver{[&](auto i) { var += i; }});
-    async::start(op);
-    CHECK(var == 43);
-}
-
 TEST_CASE("repeat can be cancelled", "[repeat]") {
     int var{};
     only_stoppable_receiver r{[&] { var += 42; }};

--- a/test/retry.cpp
+++ b/test/retry.cpp
@@ -62,21 +62,6 @@ TEST_CASE("retry retries on error", "[retry]") {
     CHECK(var == 44);
 }
 
-TEST_CASE("retry is adapter-pipeable", "[retry]") {
-    int var{};
-
-    auto s = async::sequence([&] {
-                 return async::make_variant_sender(
-                     ++var == 2, [] { return async::just(42); },
-                     [] { return async::just_error(17); });
-             }) |
-             async::retry();
-    auto op =
-        async::connect(async::just() | s, receiver{[&](auto i) { var += i; }});
-    async::start(op);
-    CHECK(var == 44);
-}
-
 TEST_CASE("retry_until advertises what it sends", "[retry]") {
     [[maybe_unused]] auto s =
         async::just_error(42) | async::retry_until([](auto) { return true; });


### PR DESCRIPTION
Problem: it is dangerous to compose retry and repeat in an adaptor chain without a sender, because the resulting adaptor has a "hidden" loop in it.

Solution: remove that ability for retry and repeat algorithms.