### PR TITLE
:bug: Store results of `let_value`'s input sender

### DIFF
--- a/test/let_value.cpp
+++ b/test/let_value.cpp
@@ -3,6 +3,7 @@
 #include <async/concepts.hpp>
 #include <async/env.hpp>
 #include <async/just.hpp>
+#include <async/just_result_of.hpp>
 #include <async/let_value.hpp>
 #include <async/schedulers/inline_scheduler.hpp>
 #include <async/tags.hpp>
@@ -207,4 +208,14 @@ TEST_CASE("let_value can be single shot with passthrough", "[let_value]") {
     [[maybe_unused]] auto l = async::just_error(move_only{42}) |
                               async::let_value([](auto) { return 42; });
     static_assert(async::singleshot_sender<decltype(l)>);
+}
+
+TEST_CASE("let_value stores result of input sender", "[let_value]") {
+    int value{};
+    auto s = async::just_result_of([] { return 42; }) |
+             async::let_value([](int &v) { return async::just(&v); });
+
+    auto op = async::connect(s, receiver{[&](int const *i) { value = *i; }});
+    async::start(op);
+    CHECK(value == 42);
 }


### PR DESCRIPTION
Addresses #76 - `let_value` needs to offer stable storage for the results of the input sender, so that the returned sender can safely use references to the results.