### PR TITLE
:art: Make `get_env` a query

### DIFF
--- a/docs/environments.adoc
+++ b/docs/environments.adoc
@@ -4,7 +4,7 @@
 An important mechanism for customization is the idea of an _environment_.
 Environments are usually associated with receivers and the framework looks up
 values in the environment by using https://wg21.link/p1895[tag_invoke]. In particular, the
-framework calls `tag_invoke(get_env_t, R)` to find the environment of a receiver type
+framework calls `R::query(get_env_t)` to find the environment of a receiver type
 `R`, and `tag_invoke(get_stop_token_t, E)` to find the stop token of an environment
 type E. `async::get_env_t` and `async::get_stop_token_t` are the tag types used for this
 purpose.
@@ -27,9 +27,8 @@ struct custom_receiver {
     async::inplace_stop_token token;
   };
 
-  [[nodiscard]] friend constexpr auto tag_invoke(async::get_env_t,
-                                                 custom_receiver const& r) -> env {
-    return {r.stop_source->get_token()};
+  [[nodiscard]] constexpr auto query(async::get_env_t) const -> env {
+    return {stop_source->get_token()};
   }
 
   inplace_stop_source* stop_source;

--- a/include/async/concepts.hpp
+++ b/include/async/concepts.hpp
@@ -121,14 +121,14 @@ concept sender_of =
 
 namespace detail {
 template <typename E = empty_env> struct universal_receiver : receiver_base {
+    [[nodiscard]] constexpr auto query(get_env_t) const noexcept -> E {
+        return {};
+    }
+
   private:
     friend constexpr auto tag_invoke(channel_tag auto,
                                      universal_receiver const &,
                                      auto &&...) -> void {}
-    friend constexpr auto tag_invoke(get_env_t,
-                                     universal_receiver const &) -> E {
-        return {};
-    }
 };
 
 template <typename S, typename R>

--- a/include/async/env.hpp
+++ b/include/async/env.hpp
@@ -12,14 +12,15 @@ struct empty_env {};
 constexpr inline struct get_env_t {
     template <typename T>
         requires true // more constrained
-    constexpr auto operator()(T &&t) const
-        noexcept(noexcept(tag_invoke(std::declval<get_env_t>(),
-                                     std::forward<T>(t))))
-            -> decltype(tag_invoke(*this, std::forward<T>(t))) {
-        return tag_invoke(*this, std::forward<T>(t));
+    [[nodiscard]] constexpr auto operator()(T &&t) const
+        noexcept(noexcept(std::forward<T>(t).query(std::declval<get_env_t>())))
+            -> decltype(std::forward<T>(t).query(*this)) {
+        return std::forward<T>(t).query(*this);
     }
 
-    constexpr auto operator()(auto &&) const -> empty_env { return {}; }
+    [[nodiscard]] constexpr auto operator()(auto &&) const -> empty_env {
+        return {};
+    }
 } get_env{};
 
 template <typename T> using env_of_t = decltype(get_env(std::declval<T>()));

--- a/include/async/just.hpp
+++ b/include/async/just.hpp
@@ -65,8 +65,8 @@ template <typename Tag, typename... Vs> struct sender {
         return {std::forward<R>(r), std::forward<Self>(self).values};
     }
 
-    [[nodiscard]] friend constexpr auto
-    tag_invoke(get_env_t, sender const &) noexcept -> env {
+  public:
+    [[nodiscard]] constexpr auto query(get_env_t) const noexcept -> env {
         return {};
     }
 };

--- a/include/async/just_result_of.hpp
+++ b/include/async/just_result_of.hpp
@@ -69,11 +69,6 @@ template <typename Tag, std::invocable... Fs> class sender : public Fs... {
                 std::forward<R>(r)};
     }
 
-    [[nodiscard]] friend constexpr auto
-    tag_invoke(get_env_t, sender const &) noexcept -> env {
-        return {};
-    }
-
     template <typename... Ts>
     using make_signature = async::completion_signatures<Tag(Ts...)>;
 
@@ -84,6 +79,10 @@ template <typename Tag, std::invocable... Fs> class sender : public Fs... {
         boost::mp11::mp_copy_if_q<
             async::completion_signatures<std::invoke_result_t<Fs>...>,
             boost::mp11::mp_not_fn<std::is_void>>>;
+
+    [[nodiscard]] constexpr auto query(get_env_t) const noexcept -> env {
+        return {};
+    }
 };
 } // namespace _just_result_of
 

--- a/include/async/retry.hpp
+++ b/include/async/retry.hpp
@@ -24,6 +24,11 @@ template <typename Ops, typename Rcvr> struct receiver {
 
     Ops *ops;
 
+    [[nodiscard]] constexpr auto
+    query(async::get_env_t) const -> detail::forwarding_env<env_of_t<Rcvr>> {
+        return forward_env_of(ops->rcvr);
+    }
+
   private:
     template <typename... Args>
     friend constexpr auto tag_invoke(set_value_t, receiver const &r,
@@ -37,12 +42,6 @@ template <typename Ops, typename Rcvr> struct receiver {
     }
     friend constexpr auto tag_invoke(set_stopped_t, receiver const &r) -> void {
         set_stopped(r.ops->rcvr);
-    }
-
-    [[nodiscard]] friend constexpr auto
-    tag_invoke(async::get_env_t,
-               receiver const &self) -> detail::forwarding_env<env_of_t<Rcvr>> {
-        return forward_env_of(self.ops->rcvr);
     }
 };
 
@@ -112,6 +111,10 @@ template <typename Sndr, typename Pred> struct sender {
     [[no_unique_address]] Sndr sndr;
     [[no_unique_address]] Pred p;
 
+    [[nodiscard]] constexpr auto query(get_env_t) const {
+        return forward_env_of(sndr);
+    }
+
   private:
     template <typename...> using signatures = completion_signatures<>;
 
@@ -126,11 +129,6 @@ template <typename Sndr, typename Pred> struct sender {
         } else {
             return completion_signatures_of_t<Sndr, Env>{};
         }
-    }
-
-    [[nodiscard]] friend constexpr auto tag_invoke(async::get_env_t,
-                                                   sender const &self) {
-        return forward_env_of(self.sndr);
     }
 
     template <stdx::same_as_unqualified<sender> Self, receiver_from<Sndr> R>

--- a/include/async/schedulers/inline_scheduler.hpp
+++ b/include/async/schedulers/inline_scheduler.hpp
@@ -44,8 +44,7 @@ class inline_scheduler {
         using completion_signatures =
             async::completion_signatures<set_value_t()>;
 
-        [[nodiscard]] friend constexpr auto
-        tag_invoke(get_env_t, sender_base) noexcept -> env {
+        [[nodiscard]] static constexpr auto query(get_env_t) noexcept -> env {
             return {};
         }
     };

--- a/include/async/schedulers/priority_scheduler.hpp
+++ b/include/async/schedulers/priority_scheduler.hpp
@@ -62,17 +62,16 @@ class fixed_priority_scheduler {
     struct sender {
         using is_sender = void;
 
+        [[nodiscard]] constexpr auto query(get_env_t) const noexcept -> env {
+            return {};
+        }
+
       private:
         template <stdx::same_as_unqualified<sender> S, receiver R>
         [[nodiscard]] friend constexpr auto tag_invoke(connect_t, S &&, R &&r) {
             check_connect<S, R>();
             return task_mgr::op_state<P, std::remove_cvref_t<R>, Task>{
                 std::forward<R>(r)};
-        }
-
-        [[nodiscard]] friend constexpr auto tag_invoke(get_env_t,
-                                                       sender) noexcept -> env {
-            return {};
         }
 
         template <typename Env>

--- a/include/async/schedulers/runloop_scheduler.hpp
+++ b/include/async/schedulers/runloop_scheduler.hpp
@@ -72,9 +72,9 @@ template <typename Uniq = decltype([] {})> class run_loop {
             using completion_signatures =
                 async::completion_signatures<set_value_t(), set_stopped_t()>;
 
-            [[nodiscard]] friend constexpr auto
-            tag_invoke(get_env_t, sender s) noexcept -> env {
-                return {s.loop};
+            [[nodiscard]] constexpr auto
+            query(get_env_t) const noexcept -> env {
+                return {loop};
             }
 
             template <stdx::same_as_unqualified<sender> S, receiver R>

--- a/include/async/schedulers/thread_scheduler.hpp
+++ b/include/async/schedulers/thread_scheduler.hpp
@@ -44,12 +44,11 @@ class thread_scheduler {
         using completion_signatures =
             async::completion_signatures<set_value_t()>;
 
-      private:
-        [[nodiscard]] friend constexpr auto tag_invoke(get_env_t,
-                                                       sender) noexcept -> env {
+        [[nodiscard]] constexpr static auto query(get_env_t) noexcept -> env {
             return {};
         }
 
+      private:
         template <stdx::same_as_unqualified<sender> S, receiver R>
         [[nodiscard]] friend constexpr auto tag_invoke(connect_t, S &&,
                                                        R &&r) -> op_state<R> {

--- a/include/async/schedulers/time_scheduler.hpp
+++ b/include/async/schedulers/time_scheduler.hpp
@@ -101,6 +101,10 @@ class time_scheduler {
         using is_sender = void;
         [[no_unique_address]] Duration d{};
 
+        [[nodiscard]] constexpr auto query(get_env_t) const noexcept -> env {
+            return {d};
+        }
+
       private:
         template <stdx::same_as_unqualified<sender> S, receiver R>
         [[nodiscard]] friend constexpr auto tag_invoke(connect_t, S &&s,
@@ -108,11 +112,6 @@ class time_scheduler {
             check_connect<S, R>();
             return timer_mgr::op_state<Domain, Duration, std::remove_cvref_t<R>,
                                        Task>{std::forward<R>(r), s.d};
-        }
-
-        [[nodiscard]] friend constexpr auto
-        tag_invoke(get_env_t, sender s) noexcept -> env {
-            return {s.d};
         }
 
         template <typename Env>

--- a/include/async/sequence.hpp
+++ b/include/async/sequence.hpp
@@ -18,6 +18,11 @@ template <typename Ops, typename Rcvr> struct receiver {
 
     Ops *ops;
 
+    [[nodiscard]] constexpr auto query(async::get_env_t) const
+        -> ::async::detail::forwarding_env<env_of_t<Rcvr>> {
+        return forward_env_of(ops->rcvr);
+    }
+
   private:
     friend auto tag_invoke(set_value_t, receiver const &self,
                            auto &&...) -> void {
@@ -27,12 +32,6 @@ template <typename Ops, typename Rcvr> struct receiver {
     template <channel_tag Tag, typename... Args>
     friend auto tag_invoke(Tag, receiver const &self, Args &&...args) -> void {
         Tag{}(self.ops->rcvr, std::forward<Args>(args)...);
-    }
-
-    [[nodiscard]] friend constexpr auto tag_invoke(async::get_env_t,
-                                                   receiver const &r)
-        -> ::async::detail::forwarding_env<env_of_t<Rcvr>> {
-        return forward_env_of(r.ops->rcvr);
     }
 };
 

--- a/include/async/split.hpp
+++ b/include/async/split.hpp
@@ -39,6 +39,11 @@ template <typename S, typename Uniq> struct single_receiver {
             std::forward<Args>(args)...);
     }
 
+    [[nodiscard]] constexpr auto query(get_env_t) const
+        -> detail::singleton_env<get_stop_token_t, inplace_stop_token> {
+        return {op_state_t::stop_source.get_token()};
+    }
+
   private:
     template <typename... Args>
     friend auto tag_invoke(set_value_t, single_receiver const &,
@@ -67,12 +72,6 @@ template <typename S, typename Uniq> struct single_receiver {
             store_values<tuple_t>();
             op_state_t::linked_ops->notify();
         }
-    }
-
-    [[nodiscard]] friend constexpr auto tag_invoke(get_env_t,
-                                                   single_receiver const &)
-        -> detail::singleton_env<get_stop_token_t, inplace_stop_token> {
-        return {op_state_t::stop_source.get_token()};
     }
 };
 
@@ -180,8 +179,7 @@ template <typename Sndr, typename Uniq> struct sender {
         }
     }
 
-    [[nodiscard]] friend constexpr auto tag_invoke(async::get_env_t,
-                                                   sender const &) ->
+    [[nodiscard]] constexpr auto query(get_env_t) const ->
         typename op_state_t::env_t & {
         return *op_state_t::env;
     }

--- a/include/async/start_detached.hpp
+++ b/include/async/start_detached.hpp
@@ -20,18 +20,17 @@ template <typename Ops> struct receiver {
 
     Ops *ops;
 
+    [[nodiscard]] constexpr auto query(get_env_t) const
+        -> detail::singleton_env<
+            get_stop_token_t,
+            decltype(std::declval<typename Ops::stop_source_t>().get_token())> {
+        return singleton_env<get_stop_token_t>(ops->stop_src.get_token());
+    }
+
   private:
     friend auto tag_invoke(channel_tag auto, receiver const &r,
                            auto &&...) -> void {
         r.ops->die();
-    }
-
-    [[nodiscard]] friend constexpr auto tag_invoke(get_env_t,
-                                                   receiver const &self)
-        -> detail::singleton_env<
-            get_stop_token_t,
-            decltype(std::declval<typename Ops::stop_source_t>().get_token())> {
-        return singleton_env<get_stop_token_t>(self.ops->stop_src.get_token());
     }
 };
 

--- a/include/async/sync_wait.hpp
+++ b/include/async/sync_wait.hpp
@@ -33,6 +33,11 @@ template <typename V, typename RL> struct receiver {
     RL &loop;
     // NOLINTEND(cppcoreguidelines-avoid-const-or-ref-data-members)
 
+    [[nodiscard]] constexpr auto query(get_env_t) const noexcept
+        -> env<decltype(std::declval<RL>().get_scheduler())> {
+        return {loop.get_scheduler()};
+    }
+
   private:
     template <typename... Args>
     friend auto tag_invoke(set_value_t, receiver const &r,
@@ -45,12 +50,6 @@ template <typename V, typename RL> struct receiver {
     }
     friend auto tag_invoke(set_stopped_t, receiver const &r) -> void {
         r.loop.finish();
-    }
-
-    [[nodiscard]] friend constexpr auto tag_invoke(get_env_t,
-                                                   receiver const &r) noexcept
-        -> env<decltype(std::declval<RL>().get_scheduler())> {
-        return {r.loop.get_scheduler()};
     }
 };
 

--- a/include/async/then.hpp
+++ b/include/async/then.hpp
@@ -101,6 +101,11 @@ template <typename Tag, typename R, typename... Fs> struct receiver {
     [[no_unique_address]] R r;
     [[no_unique_address]] stdx::tuple<Fs...> fs;
 
+    [[nodiscard]] constexpr auto
+    query(get_env_t) const -> ::async::detail::forwarding_env<env_of_t<R>> {
+        return forward_env_of(r);
+    }
+
   private:
     template <stdx::same_as_unqualified<receiver> Self, typename... Args>
     friend auto tag_invoke(Tag, Self &&self, Args &&...args) -> void {
@@ -191,11 +196,6 @@ template <typename Tag, typename S, typename... Fs> class sender {
                            std::forward<R>(r), std::forward<Self>(self).fs});
     }
 
-    [[nodiscard]] friend constexpr auto tag_invoke(async::get_env_t,
-                                                   sender const &sndr) {
-        return forward_env_of(sndr.s);
-    }
-
     template <typename... Ts>
     using signatures =
         typename detail::to_signature<Tag, Fs...>::template type<Ts...>;
@@ -230,6 +230,10 @@ template <typename Tag, typename S, typename... Fs> class sender {
 
     [[no_unique_address]] S s;
     [[no_unique_address]] stdx::tuple<Fs...> fs;
+
+    [[nodiscard]] constexpr auto query(get_env_t) const {
+        return forward_env_of(s);
+    }
 };
 
 template <typename Tag, typename... Fs> struct pipeable {

--- a/include/async/when_all.hpp
+++ b/include/async/when_all.hpp
@@ -31,6 +31,13 @@ template <typename SubOps> struct sub_receiver {
 
     SubOps *ops;
 
+    [[nodiscard]] constexpr auto query(get_env_t) const
+        -> detail::overriding_env<get_stop_token_t, inplace_stop_token,
+                                  typename SubOps::receiver_t> {
+        return override_env_with<get_stop_token_t>(ops->get_stop_token(),
+                                                   ops->get_receiver());
+    }
+
   private:
     template <typename... Args>
     friend auto tag_invoke(set_value_t, sub_receiver const &r,
@@ -44,14 +51,6 @@ template <typename SubOps> struct sub_receiver {
     }
     friend auto tag_invoke(set_stopped_t, sub_receiver const &r) -> void {
         r.ops->emplace_stopped();
-    }
-
-    [[nodiscard]] friend constexpr auto tag_invoke(get_env_t,
-                                                   sub_receiver const &self)
-        -> detail::overriding_env<get_stop_token_t, inplace_stop_token,
-                                  typename SubOps::receiver_t> {
-        return override_env_with<get_stop_token_t>(self.ops->get_stop_token(),
-                                                   self.ops->get_receiver());
     }
 };
 

--- a/include/async/when_any.hpp
+++ b/include/async/when_any.hpp
@@ -31,18 +31,17 @@ template <typename SubOps> struct sub_receiver {
 
     SubOps *ops;
 
+    [[nodiscard]] constexpr auto query(get_env_t) const
+        -> detail::overriding_env<get_stop_token_t, inplace_stop_token,
+                                  typename SubOps::receiver_t> {
+        return override_env_with<get_stop_token_t>(ops->get_stop_token(),
+                                                   ops->get_receiver());
+    }
+
   private:
     template <channel_tag Tag, typename... Args>
     friend auto tag_invoke(Tag, sub_receiver const &r, Args &&...args) -> void {
         r.ops->template emplace<Tag>(std::forward<Args>(args)...);
-    }
-
-    [[nodiscard]] friend constexpr auto tag_invoke(get_env_t,
-                                                   sub_receiver const &self)
-        -> detail::overriding_env<get_stop_token_t, inplace_stop_token,
-                                  typename SubOps::receiver_t> {
-        return override_env_with<get_stop_token_t>(self.ops->get_stop_token(),
-                                                   self.ops->get_receiver());
     }
 };
 

--- a/test/continue_on.cpp
+++ b/test/continue_on.cpp
@@ -39,12 +39,12 @@ template <auto> class test_scheduler {
         using completion_signatures =
             async::completion_signatures<async::set_value_t()>;
 
-      private:
-        [[nodiscard]] friend constexpr auto tag_invoke(async::get_env_t,
-                                                       sender) noexcept -> env {
+        [[nodiscard]] constexpr auto
+        query(async::get_env_t) const noexcept -> env {
             return {};
         }
 
+      private:
         template <stdx::same_as_unqualified<sender> S,
                   async::receiver_from<sender> R>
         [[nodiscard]] friend constexpr auto tag_invoke(async::connect_t, S &&,

--- a/test/detail/common.hpp
+++ b/test/detail/common.hpp
@@ -97,12 +97,11 @@ template <typename F> struct stoppable_receiver : F {
         }
     };
 
-  private:
-    [[nodiscard]] friend constexpr auto
-    tag_invoke(async::get_env_t, stoppable_receiver const &) -> env {
+    [[nodiscard]] constexpr auto query(async::get_env_t) const -> env {
         return {stop_source<stoppable_receiver>->get_token()};
     }
 
+  private:
     template <stdx::same_as_unqualified<stoppable_receiver> R>
     friend constexpr auto tag_invoke(async::channel_tag auto, R &&r,
                                      auto &&...) -> void {
@@ -153,12 +152,12 @@ class singleshot_scheduler {
         using completion_signatures =
             async::completion_signatures<async::set_value_t()>;
 
-      private:
-        [[nodiscard, maybe_unused]] friend constexpr auto
-        tag_invoke(async::get_env_t, sender) noexcept -> env {
+        [[nodiscard, maybe_unused]] constexpr static auto
+        query(async::get_env_t) noexcept -> env {
             return {};
         }
 
+      private:
         template <async::receiver_from<sender> R>
         [[nodiscard]] friend constexpr auto
         tag_invoke(async::connect_t, sender &&, R &&r) -> op_state<R> {
@@ -218,8 +217,8 @@ struct custom_sender {
     using completion_signatures =
         async::completion_signatures<async::set_value_t()>;
 
-    [[nodiscard]] friend constexpr auto
-    tag_invoke(async::get_env_t, custom_sender const &) -> custom_env {
+    [[nodiscard]] constexpr static auto
+    query(async::get_env_t) noexcept -> custom_env {
         return {};
     }
 

--- a/test/env.cpp
+++ b/test/env.cpp
@@ -19,8 +19,8 @@ TEST_CASE("non-empty env", "[env]") {
 
 namespace {
 struct test_receiver {
-    [[nodiscard]] friend constexpr auto
-    tag_invoke(async::get_env_t, test_receiver const &) -> custom_env {
+    [[nodiscard]] constexpr static auto
+    query(async::get_env_t) noexcept -> custom_env {
         return {};
     }
 };

--- a/test/split.cpp
+++ b/test/split.cpp
@@ -147,8 +147,8 @@ struct test_sender {
     using completion_signatures =
         async::completion_signatures<async::set_value_t()>;
 
-    [[nodiscard]] friend constexpr auto
-    tag_invoke(async::get_env_t, test_sender const &) -> custom_env {
+    [[nodiscard]] constexpr static auto
+    query(async::get_env_t) noexcept -> custom_env {
         return {};
     }
 


### PR DESCRIPTION
Moving away from `tag_invoke` and towards the member-function based approach. This is currently in P2300 and we don't gain much from `tag_invoke`. Member functions should compile quicker than `tag_invoke` too.