### PR TITLE
Remove `tag_invoke` from `set_*` and `start`

### DIFF
--- a/docs/environments.adoc
+++ b/docs/environments.adoc
@@ -3,7 +3,7 @@
 
 An important mechanism for customization is the idea of an _environment_.
 Environments are usually associated with receivers and the framework looks up
-values in the environment by using https://wg21.link/p1895[tag_invoke]. In particular, the
+values in the environment by using an overloaded `query` function. In particular, the
 framework calls `R::query(get_env_t)` to find the environment of a receiver type
 `R`, and `E::query(get_stop_token_t)` to find the stop token of an environment
 type E. `async::get_env_t` and `async::get_stop_token_t` are the tag types used for this
@@ -15,9 +15,9 @@ that supports cancellation:
 [source,cpp]
 ----
 struct custom_receiver {
-  friend auto tag_invoke(async::set_value_t, auto&&...) { ... }
-  friend auto tag_invoke(async::set_error_t, auto&&) { ... }
-  friend auto tag_invoke(async::set_stopped_t) { ... }
+  auto set_value(auto&&...) { ... }
+  auto set_error(auto&&) { ... }
+  auto set_stopped() { ... }
 
   struct env {
     [[nodiscard]] constexpr auto query(async::get_stop_token_t) const

--- a/include/async/completion_tags.hpp
+++ b/include/async/completion_tags.hpp
@@ -4,32 +4,29 @@
 
 namespace async {
 constexpr inline struct set_value_t {
-    template <typename... Ts>
-    constexpr auto operator()(Ts &&...ts) const
-        noexcept(noexcept(tag_invoke(std::declval<set_value_t>(),
-                                     std::forward<Ts>(ts)...)))
-            -> decltype(tag_invoke(*this, std::forward<Ts>(ts)...)) {
-        return tag_invoke(*this, std::forward<Ts>(ts)...);
+    template <typename R, typename... Ts>
+    constexpr auto operator()(R &&r, Ts &&...ts) const noexcept(
+        noexcept(std::forward<R>(r).set_value(std::forward<Ts>(ts)...)))
+        -> decltype(std::forward<R>(r).set_value(std::forward<Ts>(ts)...)) {
+        return std::forward<R>(r).set_value(std::forward<Ts>(ts)...);
     }
 } set_value{};
 
 constexpr inline struct set_error_t {
-    template <typename... Ts>
-    constexpr auto operator()(Ts &&...ts) const
-        noexcept(noexcept(tag_invoke(std::declval<set_error_t>(),
-                                     std::forward<Ts>(ts)...)))
-            -> decltype(tag_invoke(*this, std::forward<Ts>(ts)...)) {
-        return tag_invoke(*this, std::forward<Ts>(ts)...);
+    template <typename R, typename... Ts>
+    constexpr auto operator()(R &&r, Ts &&...ts) const noexcept(
+        noexcept(std::forward<R>(r).set_error(std::forward<Ts>(ts)...)))
+        -> decltype(std::forward<R>(r).set_error(std::forward<Ts>(ts)...)) {
+        return std::forward<R>(r).set_error(std::forward<Ts>(ts)...);
     }
 } set_error{};
 
 constexpr inline struct set_stopped_t {
-    template <typename... Ts>
-    constexpr auto operator()(Ts &&...ts) const
-        noexcept(noexcept(tag_invoke(std::declval<set_stopped_t>(),
-                                     std::forward<Ts>(ts)...)))
-            -> decltype(tag_invoke(*this, std::forward<Ts>(ts)...)) {
-        return tag_invoke(*this, std::forward<Ts>(ts)...);
+    template <typename R>
+    constexpr auto operator()(R &&r) const
+        noexcept(noexcept(std::forward<R>(r).set_stopped()))
+            -> decltype(std::forward<R>(r).set_stopped()) {
+        return std::forward<R>(r).set_stopped();
     }
 } set_stopped{};
 } // namespace async

--- a/include/async/completion_tags.hpp
+++ b/include/async/completion_tags.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <type_traits>
 #include <utility>
 
 namespace async {
@@ -8,6 +9,8 @@ constexpr inline struct set_value_t {
     constexpr auto operator()(R &&r, Ts &&...ts) const noexcept(
         noexcept(std::forward<R>(r).set_value(std::forward<Ts>(ts)...)))
         -> decltype(std::forward<R>(r).set_value(std::forward<Ts>(ts)...)) {
+        static_assert(std::is_rvalue_reference_v<R &&>,
+                      "set_value must be called on an rvalue reference");
         return std::forward<R>(r).set_value(std::forward<Ts>(ts)...);
     }
 } set_value{};
@@ -17,6 +20,8 @@ constexpr inline struct set_error_t {
     constexpr auto operator()(R &&r, Ts &&...ts) const noexcept(
         noexcept(std::forward<R>(r).set_error(std::forward<Ts>(ts)...)))
         -> decltype(std::forward<R>(r).set_error(std::forward<Ts>(ts)...)) {
+        static_assert(std::is_rvalue_reference_v<R &&>,
+                      "set_error must be called on an rvalue reference");
         return std::forward<R>(r).set_error(std::forward<Ts>(ts)...);
     }
 } set_error{};
@@ -26,6 +31,8 @@ constexpr inline struct set_stopped_t {
     constexpr auto operator()(R &&r) const
         noexcept(noexcept(std::forward<R>(r).set_stopped()))
             -> decltype(std::forward<R>(r).set_stopped()) {
+        static_assert(std::is_rvalue_reference_v<R &&>,
+                      "set_stopped must be called on an rvalue reference");
         return std::forward<R>(r).set_stopped();
     }
 } set_stopped{};

--- a/include/async/concepts.hpp
+++ b/include/async/concepts.hpp
@@ -135,9 +135,9 @@ template <typename E = empty_env> struct universal_receiver : receiver_base {
         return {};
     }
 
-    constexpr auto set_value(auto &&...) const noexcept -> void {}
-    constexpr auto set_error(auto &&...) const noexcept -> void {}
-    constexpr auto set_stopped() const noexcept -> void {}
+    constexpr auto set_value(auto &&...) const && noexcept -> void {}
+    constexpr auto set_error(auto &&...) const && noexcept -> void {}
+    constexpr auto set_stopped() const && noexcept -> void {}
 };
 
 template <typename S, typename R>

--- a/include/async/concepts.hpp
+++ b/include/async/concepts.hpp
@@ -135,10 +135,9 @@ template <typename E = empty_env> struct universal_receiver : receiver_base {
         return {};
     }
 
-  private:
-    friend constexpr auto tag_invoke(channel_tag auto,
-                                     universal_receiver const &,
-                                     auto &&...) -> void {}
+    constexpr auto set_value(auto &&...) const noexcept -> void {}
+    constexpr auto set_error(auto &&...) const noexcept -> void {}
+    constexpr auto set_stopped() const noexcept -> void {}
 };
 
 template <typename S, typename R>

--- a/include/async/concepts.hpp
+++ b/include/async/concepts.hpp
@@ -30,8 +30,8 @@ concept queryable = std::destructible<T>;
 
 template <typename O>
 concept operation_state =
-    queryable<O> and std::is_object_v<O> and requires(O &&o) {
-        { start(std::move(o)) } -> std::same_as<void>;
+    queryable<O> and std::is_object_v<O> and requires(O &o) {
+        { start(o) } -> std::same_as<void>;
     };
 
 namespace detail {

--- a/include/async/just.hpp
+++ b/include/async/just.hpp
@@ -32,7 +32,7 @@ template <typename Tag, typename R, typename... Vs> struct op_state {
         requires(... and std::copy_constructible<Vs>)
     friend constexpr auto tag_invoke(start_t, O &&o) -> void {
         std::forward<O>(o).values.apply([&]<typename... Ts>(Ts &&...ts) {
-            Tag{}(std::forward<O>(o).receiver, std::forward<Ts>(ts)...);
+            Tag{}(std::move(o).receiver, std::forward<Ts>(ts)...);
         });
     }
 };

--- a/include/async/just.hpp
+++ b/include/async/just.hpp
@@ -21,18 +21,9 @@ template <typename Tag, typename R, typename... Vs> struct op_state {
     [[no_unique_address]] R receiver;
     [[no_unique_address]] stdx::tuple<Vs...> values;
 
-  private:
-    friend constexpr auto tag_invoke(start_t, op_state &&o) -> void {
-        std::move(o).values.apply([&]<typename... Ts>(Ts &&...ts) {
-            Tag{}(std::move(o).receiver, std::forward<Ts>(ts)...);
-        });
-    }
-
-    template <stdx::same_as_unqualified<op_state> O>
-        requires(... and std::copy_constructible<Vs>)
-    friend constexpr auto tag_invoke(start_t, O &&o) -> void {
-        std::forward<O>(o).values.apply([&]<typename... Ts>(Ts &&...ts) {
-            Tag{}(std::move(o).receiver, std::forward<Ts>(ts)...);
+    constexpr auto start() & -> void {
+        std::move(values).apply([&]<typename... Ts>(Ts &&...ts) {
+            Tag{}(std::move(receiver), std::forward<Ts>(ts)...);
         });
     }
 };

--- a/include/async/just_result_of.hpp
+++ b/include/async/just_result_of.hpp
@@ -38,7 +38,7 @@ template <typename Tag, typename R, typename... Fs> struct op_state : Fs... {
         }(boost::mp11::mp_front<split_returns>{});
 
         [&]<typename... Ts>(boost::mp11::mp_list<Ts...>) {
-            Tag{}(std::forward<O>(o).receiver,
+            Tag{}(std::move(o).receiver,
                   static_cast<stdx::forward_like_t<O, Ts>>(o)()...);
         }(boost::mp11::mp_back<split_returns>{});
     }

--- a/include/async/just_result_of.hpp
+++ b/include/async/just_result_of.hpp
@@ -26,20 +26,17 @@ template <typename Tag, typename R, typename... Fs> struct op_state : Fs... {
 
     [[no_unique_address]] R receiver;
 
-  private:
-    template <stdx::same_as_unqualified<op_state> O>
-    friend auto tag_invoke(start_t, O &&o) -> void {
+    auto start() & -> void {
         using split_returns =
             boost::mp11::mp_partition<boost::mp11::mp_list<Fs...>,
                                       has_void_result>;
 
         [&]<typename... Ts>(boost::mp11::mp_list<Ts...>) {
-            (static_cast<stdx::forward_like_t<O, Ts>>(o)(), ...);
+            (static_cast<Ts &>(*this)(), ...);
         }(boost::mp11::mp_front<split_returns>{});
 
         [&]<typename... Ts>(boost::mp11::mp_list<Ts...>) {
-            Tag{}(std::move(o).receiver,
-                  static_cast<stdx::forward_like_t<O, Ts>>(o)()...);
+            Tag{}(std::move(receiver), static_cast<Ts &>(*this)()...);
         }(boost::mp11::mp_back<split_returns>{});
     }
 };

--- a/include/async/let.hpp
+++ b/include/async/let.hpp
@@ -81,19 +81,25 @@ template <typename Ops, typename Rcvr, channel_tag... Tags> struct receiver {
         return forward_env_of(ops->rcvr);
     }
 
-  private:
-    template <channel_tag OtherTag, typename... Args>
-    friend auto tag_invoke(OtherTag, receiver const &self,
-                           Args &&...args) -> void {
-        OtherTag{}(self.ops->rcvr, std::forward<Args>(args)...);
+    template <typename... Args>
+    constexpr auto set_value(Args &&...args) -> void {
+        handle<set_value_t>(std::forward<Args>(args)...);
     }
+    template <typename... Args>
+    constexpr auto set_error(Args &&...args) -> void {
+        handle<set_error_t>(std::forward<Args>(args)...);
+    }
+    constexpr auto set_stopped() -> void { handle<set_stopped_t>(); }
 
-    template <channel_tag Tag, stdx::same_as_unqualified<receiver> Self,
-              typename... Args>
-        requires(... or std::same_as<Tag, Tags>)
-    friend auto tag_invoke(Tag, Self &&self, Args &&...args) -> void {
-        self.ops->template complete_first<Tag, Tag(Args...)>(
-            std::forward<Args>(args)...);
+  private:
+    template <channel_tag T, typename... Args>
+    auto handle(Args &&...args) -> void {
+        if constexpr ((... or std::same_as<T, Tags>)) {
+            ops->template complete_first<T, T(Args...)>(
+                std::forward<Args>(args)...);
+        } else {
+            T{}(ops->rcvr, std::forward<Args>(args)...);
+        }
     }
 };
 

--- a/include/async/let.hpp
+++ b/include/async/let.hpp
@@ -82,14 +82,14 @@ template <typename Ops, typename Rcvr, channel_tag... Tags> struct receiver {
     }
 
     template <typename... Args>
-    constexpr auto set_value(Args &&...args) -> void {
+    constexpr auto set_value(Args &&...args) && -> void {
         handle<set_value_t>(std::forward<Args>(args)...);
     }
     template <typename... Args>
-    constexpr auto set_error(Args &&...args) -> void {
+    constexpr auto set_error(Args &&...args) && -> void {
         handle<set_error_t>(std::forward<Args>(args)...);
     }
-    constexpr auto set_stopped() -> void { handle<set_stopped_t>(); }
+    constexpr auto set_stopped() && -> void { handle<set_stopped_t>(); }
 
   private:
     template <channel_tag T, typename... Args>
@@ -98,7 +98,7 @@ template <typename Ops, typename Rcvr, channel_tag... Tags> struct receiver {
             ops->template complete_first<T, T(Args...)>(
                 std::forward<Args>(args)...);
         } else {
-            T{}(ops->rcvr, std::forward<Args>(args)...);
+            T{}(std::move(ops->rcvr), std::forward<Args>(args)...);
         }
     }
 };

--- a/include/async/let.hpp
+++ b/include/async/let.hpp
@@ -141,11 +141,13 @@ struct op_state {
 
         if constexpr (std::is_copy_constructible_v<
                           std::remove_cvref_t<decltype(sent_args)>>) {
-            start(std::move(make_op_state(sent_args)));
+            async::start(make_op_state(sent_args));
         } else {
-            start(std::move(make_op_state(std::move(sent_args))));
+            async::start(make_op_state(std::move(sent_args)));
         }
     }
+
+    constexpr auto start() & -> void { async::start(std::get<0>(state)); }
 
     template <typename Sig>
     using dependent_connect_result_t =
@@ -168,12 +170,6 @@ struct op_state {
     [[no_unique_address]] Func fn;
     results_t results;
     state_t state;
-
-  private:
-    template <stdx::same_as_unqualified<op_state> O>
-    friend constexpr auto tag_invoke(start_t, O &&o) -> void {
-        start(std::get<0>(std::forward<O>(o).state));
-    }
 };
 
 template <typename S, typename F, channel_tag... Tags> struct sender {

--- a/include/async/read_env.hpp
+++ b/include/async/read_env.hpp
@@ -23,7 +23,7 @@ template <typename R, typename Tag> struct op_state {
   private:
     template <stdx::same_as_unqualified<op_state> O>
     friend constexpr auto tag_invoke(start_t, O &&o) -> void {
-        set_value(std::forward<O>(o).receiver, Tag{}(get_env(o.receiver)));
+        set_value(std::move(o).receiver, Tag{}(get_env(o.receiver)));
     }
 };
 

--- a/include/async/read_env.hpp
+++ b/include/async/read_env.hpp
@@ -18,12 +18,9 @@ namespace async {
 namespace _read_env {
 template <typename R, typename Tag> struct op_state {
     [[no_unique_address]] R receiver;
-    [[no_unique_address]] Tag t;
 
-  private:
-    template <stdx::same_as_unqualified<op_state> O>
-    friend constexpr auto tag_invoke(start_t, O &&o) -> void {
-        set_value(std::move(o).receiver, Tag{}(get_env(o.receiver)));
+    constexpr auto start() & -> void {
+        set_value(std::move(receiver), Tag{}(get_env(receiver)));
     }
 };
 
@@ -49,31 +46,19 @@ template <typename Tag> struct sender {
         return {};
     }
 
-    [[no_unique_address]] Tag t;
-
   private:
-    template <receiver R>
-    [[nodiscard]] friend constexpr auto
-    tag_invoke(connect_t, sender &&self,
-               R &&r) -> op_state<std::remove_cvref_t<R>, Tag> {
-        check_connect<sender &&, R>();
-        return {std::forward<R>(r), std::move(self).t};
-    }
-
     template <stdx::same_as_unqualified<sender> Self, receiver R>
-        requires std::copy_constructible<Tag>
-    [[nodiscard]] friend constexpr auto
-    tag_invoke(connect_t, Self &&self,
-               R &&r) -> op_state<std::remove_cvref_t<R>, Tag> {
+    [[nodiscard]] friend constexpr auto tag_invoke(connect_t, Self &&, R &&r)
+        -> op_state<std::remove_cvref_t<R>, Tag> {
         check_connect<Self, R>();
-        return {std::forward<R>(r), std::forward<Self>(self).t};
+        return {std::forward<R>(r)};
     }
 };
 } // namespace _read_env
 
 template <typename Tag>
-[[nodiscard]] constexpr auto read_env(Tag &&t) -> sender auto {
-    return _read_env::sender<Tag>{{std::forward<Tag>(t)}};
+[[nodiscard]] constexpr auto read_env(Tag) -> sender auto {
+    return _read_env::sender<Tag>{};
 }
 
 [[nodiscard]] constexpr auto get_stop_token() -> sender auto {

--- a/include/async/repeat.hpp
+++ b/include/async/repeat.hpp
@@ -28,20 +28,13 @@ template <typename Ops, typename Rcvr> struct receiver {
         return forward_env_of(ops->rcvr);
     }
 
-  private:
-    template <typename... Args>
-    friend constexpr auto tag_invoke(set_value_t, receiver const &r,
-                                     Args &&...args) -> void {
-        r.ops->repeat(std::forward<Args>(args)...);
+    template <typename... Args> auto set_value(Args &&...args) const -> void {
+        ops->repeat(std::forward<Args>(args)...);
     }
-    template <typename... Args>
-    friend constexpr auto tag_invoke(set_error_t, receiver const &r,
-                                     Args &&...args) -> void {
-        set_error(r.ops->rcvr, std::forward<Args>(args)...);
+    template <typename... Args> auto set_error(Args &&...args) const -> void {
+        async::set_error(ops->rcvr, std::forward<Args>(args)...);
     }
-    friend constexpr auto tag_invoke(set_stopped_t, receiver const &r) -> void {
-        set_stopped(r.ops->rcvr);
-    }
+    auto set_stopped() const -> void { async::set_stopped(ops->rcvr); }
 };
 
 constexpr auto never_stop = [](auto &&...) { return false; };

--- a/include/async/retry.hpp
+++ b/include/async/retry.hpp
@@ -73,10 +73,10 @@ template <typename Sndr, typename Rcvr, typename Pred> struct op_state {
           pred{std::forward<P>(p)} {}
     constexpr op_state(op_state &&) = delete;
 
-    auto restart() -> void {
+    constexpr auto start() & -> void {
         auto &op = state.emplace(stdx::with_result_of{
             [&] { return connect(sndr, receiver_t{this}); }});
-        start(std::move(op));
+        async::start(op);
     }
 
     template <typename... Args> auto retry(Args &&...args) -> void {
@@ -87,7 +87,7 @@ template <typename Sndr, typename Rcvr, typename Pred> struct op_state {
                 return;
             }
         }
-        restart();
+        start();
     }
 
     [[no_unique_address]] Sndr sndr;
@@ -96,12 +96,6 @@ template <typename Sndr, typename Rcvr, typename Pred> struct op_state {
 
     using state_t = async::connect_result_t<Sndr &, receiver_t>;
     std::optional<state_t> state{};
-
-  private:
-    template <stdx::same_as_unqualified<op_state> O>
-    friend constexpr auto tag_invoke(start_t, O &&o) -> void {
-        std::forward<O>(o).restart();
-    }
 };
 
 template <typename Sndr, typename Pred> struct sender {

--- a/include/async/retry.hpp
+++ b/include/async/retry.hpp
@@ -30,20 +30,13 @@ template <typename Ops, typename Rcvr> struct receiver {
         return forward_env_of(ops->rcvr);
     }
 
-  private:
-    template <typename... Args>
-    friend constexpr auto tag_invoke(set_value_t, receiver const &r,
-                                     Args &&...args) -> void {
-        set_value(r.ops->rcvr, std::forward<Args>(args)...);
+    template <typename... Args> auto set_value(Args &&...args) const -> void {
+        async::set_value(ops->rcvr, std::forward<Args>(args)...);
     }
-    template <typename... Args>
-    friend constexpr auto tag_invoke(set_error_t, receiver const &r,
-                                     Args &&...args) -> void {
-        r.ops->retry(std::forward<Args>(args)...);
+    template <typename... Args> auto set_error(Args &&...args) const -> void {
+        ops->retry(std::forward<Args>(args)...);
     }
-    friend constexpr auto tag_invoke(set_stopped_t, receiver const &r) -> void {
-        set_stopped(r.ops->rcvr);
-    }
+    auto set_stopped() const -> void { async::set_stopped(ops->rcvr); }
 };
 
 constexpr auto never_stop = [](auto &&...) { return false; };

--- a/include/async/schedulers/inline_scheduler.hpp
+++ b/include/async/schedulers/inline_scheduler.hpp
@@ -23,7 +23,7 @@ class inline_scheduler {
       private:
         template <stdx::same_as_unqualified<op_state> O>
         friend constexpr auto tag_invoke(start_t, O &&o) -> void {
-            set_value(std::forward<O>(o).receiver);
+            set_value(std::move(o).receiver);
         }
     };
 

--- a/include/async/schedulers/inline_scheduler.hpp
+++ b/include/async/schedulers/inline_scheduler.hpp
@@ -20,11 +20,7 @@ class inline_scheduler {
     template <typename R> struct op_state {
         [[no_unique_address]] R receiver;
 
-      private:
-        template <stdx::same_as_unqualified<op_state> O>
-        friend constexpr auto tag_invoke(start_t, O &&o) -> void {
-            set_value(std::move(o).receiver);
-        }
+        constexpr auto start() & -> void { set_value(std::move(receiver)); }
     };
 
     struct env {

--- a/include/async/schedulers/priority_scheduler.hpp
+++ b/include/async/schedulers/priority_scheduler.hpp
@@ -27,6 +27,12 @@ struct op_state final : Task {
         }
     }
 
+    constexpr auto start() & -> void {
+        if (not check_stopped()) {
+            detail::enqueue_task(*this, P);
+        }
+    }
+
     [[no_unique_address]] Rcvr rcvr;
 
   private:
@@ -38,13 +44,6 @@ struct op_state final : Task {
             }
         }
         return false;
-    }
-
-    template <stdx::same_as_unqualified<op_state> O>
-    friend constexpr auto tag_invoke(start_t, O &&o) -> void {
-        if (not std::forward<O>(o).check_stopped()) {
-            detail::enqueue_task(o, P);
-        }
     }
 };
 } // namespace task_mgr

--- a/include/async/schedulers/runloop_scheduler.hpp
+++ b/include/async/schedulers/runloop_scheduler.hpp
@@ -47,14 +47,10 @@ template <typename Uniq = decltype([] {})> class run_loop {
             }
         }
 
+        constexpr auto start() & -> void { loop->push_back(this); }
+
         run_loop *loop{};
         [[no_unique_address]] Rcvr rcvr;
-
-      private:
-        template <stdx::same_as_unqualified<op_state> O>
-        friend constexpr auto tag_invoke(start_t, O &&o) -> void {
-            std::forward<O>(o).loop->push_back(std::addressof(o));
-        }
     };
 
     struct scheduler {

--- a/include/async/schedulers/thread_scheduler.hpp
+++ b/include/async/schedulers/thread_scheduler.hpp
@@ -25,9 +25,7 @@ class thread_scheduler {
       private:
         template <stdx::same_as_unqualified<op_state> O>
         friend auto tag_invoke(start_t, O &&o) -> void {
-            std::thread{[&] {
-                set_value(std::forward<O>(o).receiver);
-            }}.detach();
+            std::thread{[&] { set_value(std::move(o).receiver); }}.detach();
         }
     };
 

--- a/include/async/schedulers/thread_scheduler.hpp
+++ b/include/async/schedulers/thread_scheduler.hpp
@@ -22,10 +22,8 @@ class thread_scheduler {
     template <typename R> struct op_state {
         [[no_unique_address]] R receiver;
 
-      private:
-        template <stdx::same_as_unqualified<op_state> O>
-        friend auto tag_invoke(start_t, O &&o) -> void {
-            std::thread{[&] { set_value(std::move(o).receiver); }}.detach();
+        auto start() & -> void {
+            std::thread{[&] { set_value(std::move(receiver)); }}.detach();
         }
     };
 

--- a/include/async/schedulers/time_scheduler.hpp
+++ b/include/async/schedulers/time_scheduler.hpp
@@ -71,7 +71,7 @@ struct op_state<Domain, Duration, Rcvr, Task> final
     friend constexpr auto tag_invoke(start_t, O &&o) -> void {
         auto token = get_stop_token(get_env(o.rcvr));
         if (token.stop_requested()) {
-            set_stopped(std::forward<O>(o).rcvr);
+            set_stopped(std::move(o).rcvr);
         } else {
             detail::run_after<Domain>(o, o.d);
             o.stop_cb.emplace(token, stop_callback_fn{std::addressof(o)});

--- a/include/async/sequence.hpp
+++ b/include/async/sequence.hpp
@@ -24,16 +24,11 @@ template <typename Ops, typename Rcvr> struct receiver {
         return forward_env_of(ops->rcvr);
     }
 
-  private:
-    friend auto tag_invoke(set_value_t, receiver const &self,
-                           auto &&...) -> void {
-        self.ops->complete_first();
+    auto set_value(auto &&...) -> void { ops->complete_first(); }
+    template <typename... Args> auto set_error(Args &&...args) -> void {
+        async::set_error(ops->rcvr, std::forward<Args>(args)...);
     }
-
-    template <channel_tag Tag, typename... Args>
-    friend auto tag_invoke(Tag, receiver const &self, Args &&...args) -> void {
-        Tag{}(self.ops->rcvr, std::forward<Args>(args)...);
-    }
+    auto set_stopped() -> void { async::set_stopped(ops->rcvr); }
 };
 
 template <typename Sndr, std::invocable Func, typename Rcvr>

--- a/include/async/sequence.hpp
+++ b/include/async/sequence.hpp
@@ -24,11 +24,14 @@ template <typename Ops, typename Rcvr> struct receiver {
         return forward_env_of(ops->rcvr);
     }
 
-    auto set_value(auto &&...) -> void { ops->complete_first(); }
-    template <typename... Args> auto set_error(Args &&...args) -> void {
-        async::set_error(ops->rcvr, std::forward<Args>(args)...);
+    auto set_value(auto &&...) const && -> void { ops->complete_first(); }
+    template <typename... Args>
+    auto set_error(Args &&...args) const && -> void {
+        async::set_error(std::move(ops->rcvr), std::forward<Args>(args)...);
     }
-    auto set_stopped() -> void { async::set_stopped(ops->rcvr); }
+    auto set_stopped() const && -> void {
+        async::set_stopped(std::move(ops->rcvr));
+    }
 };
 
 template <typename Sndr, std::invocable Func, typename Rcvr>

--- a/include/async/sequence.hpp
+++ b/include/async/sequence.hpp
@@ -50,8 +50,10 @@ struct op_state {
     template <typename... Args> auto complete_first() -> void {
         auto &op = state.template emplace<1>(stdx::with_result_of{
             [&] { return connect(std::move(func)(), std::move(rcvr)); }});
-        start(std::move(op));
+        async::start(op);
     }
+
+    constexpr auto start() & -> void { async::start(std::get<0>(state)); }
 
     [[no_unique_address]] Func func;
     [[no_unique_address]] Rcvr rcvr;
@@ -60,12 +62,6 @@ struct op_state {
     using first_ops = connect_result_t<Sndr, first_rcvr>;
     using second_ops = connect_result_t<dependent_sender, Rcvr>;
     std::variant<first_ops, second_ops> state;
-
-  private:
-    template <stdx::same_as_unqualified<op_state> O>
-    friend constexpr auto tag_invoke(start_t, O &&o) -> void {
-        start(std::get<0>(std::forward<O>(o).state));
-    }
 };
 
 namespace detail {

--- a/include/async/split.hpp
+++ b/include/async/split.hpp
@@ -120,38 +120,35 @@ struct op_state : op_state_base<S, Uniq> {
         }
     }
 
+    constexpr auto start() & -> void {
+        if (op_state_t::values.index() != 0) {
+            complete();
+            return;
+        }
+
+        stop_cb.emplace(get_stop_token(get_env(rcvr)),
+                        stop_callback_fn{std::addressof(this->stop_source)});
+        if (this->stop_source.stop_requested()) {
+            set_stopped(std::move(rcvr));
+            return;
+        }
+
+        if (next_ops = std::exchange(op_state_t::linked_ops, this);
+            not next_ops) {
+            async::start(*op_state_t::single_ops);
+        }
+    }
+
   private:
     auto complete() -> void {
         stop_cb.reset();
         std::visit(
-            [&]<typename T>(T const &t) -> void {
+            [&]<typename T>(T &t) -> void {
                 if constexpr (not std::is_same_v<T, std::monostate>) {
-                    t(std::move(rcvr));
+                    std::move(t)(std::move(rcvr));
                 }
             },
             op_state_t::values);
-    }
-
-    template <stdx::same_as_unqualified<op_state> O>
-    friend constexpr auto tag_invoke(start_t, O &&o) -> void {
-        if (op_state_t::values.index() != 0) {
-            std::forward<O>(o).complete();
-            return;
-        }
-
-        std::forward<O>(o).stop_cb.emplace(
-            get_stop_token(get_env(o.rcvr)),
-            stop_callback_fn{std::addressof(o.stop_source)});
-        if (o.stop_source.stop_requested()) {
-            set_stopped(std::move(o).rcvr);
-            return;
-        }
-
-        if (o.next_ops =
-                std::exchange(op_state_t::linked_ops, std::addressof(o));
-            not o.next_ops) {
-            start(std::move(*op_state_t::single_ops));
-        }
     }
 
     using stop_callback_t =

--- a/include/async/split.hpp
+++ b/include/async/split.hpp
@@ -45,10 +45,7 @@ template <typename S, typename Uniq> struct single_receiver {
         return {op_state_t::stop_source.get_token()};
     }
 
-  private:
-    template <typename... Args>
-    friend auto tag_invoke(set_value_t, single_receiver const &,
-                           Args &&...args) -> void {
+    template <typename... Args> static auto set_value(Args &&...args) -> void {
         if (op_state_t::linked_ops) {
             using tuple_t = value_holder<Args...>;
             store_values<tuple_t>(std::forward<Args>(args)...);
@@ -56,9 +53,7 @@ template <typename S, typename Uniq> struct single_receiver {
         }
     }
 
-    template <typename... Args>
-    friend auto tag_invoke(set_error_t, single_receiver const &,
-                           Args &&...args) -> void {
+    template <typename... Args> static auto set_error(Args &&...args) -> void {
         if (op_state_t::linked_ops) {
             using tuple_t = error_holder<Args...>;
             store_values<tuple_t>(std::forward<Args>(args)...);
@@ -66,8 +61,7 @@ template <typename S, typename Uniq> struct single_receiver {
         }
     }
 
-    template <typename... Args>
-    friend auto tag_invoke(set_stopped_t, single_receiver const &) -> void {
+    static auto set_stopped() -> void {
         if (op_state_t::linked_ops) {
             using tuple_t = stopped_holder<>;
             store_values<tuple_t>();

--- a/include/async/split.hpp
+++ b/include/async/split.hpp
@@ -126,7 +126,7 @@ struct op_state : op_state_base<S, Uniq> {
         std::visit(
             [&]<typename T>(T const &t) -> void {
                 if constexpr (not std::is_same_v<T, std::monostate>) {
-                    t(rcvr);
+                    t(std::move(rcvr));
                 }
             },
             op_state_t::values);
@@ -143,7 +143,7 @@ struct op_state : op_state_base<S, Uniq> {
             get_stop_token(get_env(o.rcvr)),
             stop_callback_fn{std::addressof(o.stop_source)});
         if (o.stop_source.stop_requested()) {
-            set_stopped(std::forward<O>(o).rcvr);
+            set_stopped(std::move(o).rcvr);
             return;
         }
 

--- a/include/async/start.hpp
+++ b/include/async/start.hpp
@@ -1,28 +1,13 @@
 #pragma once
 
-#include <stdx/type_traits.hpp>
-
 #include <utility>
 
 namespace async {
 constexpr inline struct start_t {
-    template <typename> struct failure_t {};
-
-    template <typename T>
-        requires true
-    constexpr auto operator()(T &&t) const
-        noexcept(noexcept(tag_invoke(std::declval<start_t>(),
-                                     std::forward<T>(t))))
-            -> decltype(tag_invoke(*this, std::forward<T>(t))) {
-        return tag_invoke(*this, std::forward<T>(t));
-    }
-
-    template <typename T>
-    constexpr auto operator()(T &&) const -> failure_t<T> {
-        static_assert(stdx::always_false_v<T>,
-                      "No function call for start: does the argument "
-                      "provide a tag_invoke(start_t)?");
-        return {};
+    template <typename O>
+    constexpr auto operator()(O &o) const
+        noexcept(noexcept(o.start())) -> decltype(o.start()) {
+        return o.start();
     }
 } start{};
 } // namespace async

--- a/include/async/start_detached.hpp
+++ b/include/async/start_detached.hpp
@@ -27,9 +27,9 @@ template <typename Ops> struct receiver {
         return singleton_env<get_stop_token_t>(ops->stop_src.get_token());
     }
 
-    constexpr auto set_value(auto &&...) const -> void { ops->die(); }
-    constexpr auto set_error(auto &&...) const -> void { ops->die(); }
-    constexpr auto set_stopped() const -> void { ops->die(); }
+    constexpr auto set_value(auto &&...) const && -> void { ops->die(); }
+    constexpr auto set_error(auto &&...) const && -> void { ops->die(); }
+    constexpr auto set_stopped() const && -> void { ops->die(); }
 };
 
 template <typename Uniq, typename Sndr, typename Alloc, typename StopSource>

--- a/include/async/start_detached.hpp
+++ b/include/async/start_detached.hpp
@@ -27,11 +27,9 @@ template <typename Ops> struct receiver {
         return singleton_env<get_stop_token_t>(ops->stop_src.get_token());
     }
 
-  private:
-    friend auto tag_invoke(channel_tag auto, receiver const &r,
-                           auto &&...) -> void {
-        r.ops->die();
-    }
+    constexpr auto set_value(auto &&...) const -> void { ops->die(); }
+    constexpr auto set_error(auto &&...) const -> void { ops->die(); }
+    constexpr auto set_stopped() const -> void { ops->die(); }
 };
 
 template <typename Uniq, typename Sndr, typename Alloc, typename StopSource>

--- a/include/async/static_allocator.hpp
+++ b/include/async/static_allocator.hpp
@@ -56,7 +56,11 @@ struct static_allocator {
         auto &a =
             detail::static_allocator_v<Name, T, static_allocation_limit<Name>>;
         if (auto t = a.construct(std::forward<Args>(args)...); t != nullptr) {
-            std::forward<F>(f)(std::move(*t));
+            if constexpr (requires { std::forward<F>(f)(std::move(*t)); }) {
+                std::forward<F>(f)(std::move(*t));
+            } else {
+                std::forward<F>(f)(*t);
+            }
             return true;
         }
         return false;

--- a/include/async/sync_wait.hpp
+++ b/include/async/sync_wait.hpp
@@ -40,19 +40,13 @@ template <typename V, typename RL> struct receiver {
         return {loop.get_scheduler()};
     }
 
-  private:
     template <typename... Args>
-    friend auto tag_invoke(set_value_t, receiver const &r,
-                           Args &&...args) -> void {
-        r.values.emplace(stdx::make_tuple(std::forward<Args>(args)...));
-        r.loop.finish();
+    constexpr auto set_value(Args &&...args) const -> void {
+        values.emplace(stdx::make_tuple(std::forward<Args>(args)...));
+        loop.finish();
     }
-    friend auto tag_invoke(set_error_t, receiver const &r, auto &&...) -> void {
-        r.loop.finish();
-    }
-    friend auto tag_invoke(set_stopped_t, receiver const &r) -> void {
-        r.loop.finish();
-    }
+    constexpr auto set_error(auto &&...) const -> void { loop.finish(); }
+    constexpr auto set_stopped() const -> void { loop.finish(); }
 };
 
 namespace detail {

--- a/include/async/sync_wait.hpp
+++ b/include/async/sync_wait.hpp
@@ -41,12 +41,12 @@ template <typename V, typename RL> struct receiver {
     }
 
     template <typename... Args>
-    constexpr auto set_value(Args &&...args) const -> void {
+    constexpr auto set_value(Args &&...args) const && -> void {
         values.emplace(stdx::make_tuple(std::forward<Args>(args)...));
         loop.finish();
     }
-    constexpr auto set_error(auto &&...) const -> void { loop.finish(); }
-    constexpr auto set_stopped() const -> void { loop.finish(); }
+    constexpr auto set_error(auto &&...) const && -> void { loop.finish(); }
+    constexpr auto set_stopped() const && -> void { loop.finish(); }
 };
 
 namespace detail {

--- a/include/async/then.hpp
+++ b/include/async/then.hpp
@@ -107,14 +107,14 @@ template <typename Tag, typename R, typename... Fs> struct receiver {
     }
 
     template <typename... Args>
-    constexpr auto set_value(Args &&...args) -> void {
+    constexpr auto set_value(Args &&...args) && -> void {
         handle<set_value_t>(std::forward<Args>(args)...);
     }
     template <typename... Args>
-    constexpr auto set_error(Args &&...args) -> void {
+    constexpr auto set_error(Args &&...args) && -> void {
         handle<set_error_t>(std::forward<Args>(args)...);
     }
-    constexpr auto set_stopped() -> void { handle<set_stopped_t>(); }
+    constexpr auto set_stopped() && -> void { handle<set_stopped_t>(); }
 
   private:
     template <typename T, typename... Args>

--- a/include/async/then.hpp
+++ b/include/async/then.hpp
@@ -106,36 +106,43 @@ template <typename Tag, typename R, typename... Fs> struct receiver {
         return forward_env_of(r);
     }
 
-  private:
-    template <stdx::same_as_unqualified<receiver> Self, typename... Args>
-    friend auto tag_invoke(Tag, Self &&self, Args &&...args) -> void {
-        using arities =
-            typename detail::args<Args &&...>::template arities_t<Fs...>;
-        using offsets = typename detail::offsets_t<arities, Fs...>;
-
-        auto arg_tuple = stdx::tuple<Args &&...>{std::forward<Args>(args)...};
-        auto const invoke = [&]<typename F, typename Offset, typename Arity>(
-                                F &&func, Offset, Arity) -> decltype(auto) {
-            return detail::invoke<Offset::value>(
-                std::forward<F>(func), std::move(arg_tuple),
-                std::make_index_sequence<Arity::value>{});
-        };
-        auto results = stdx::transform(invoke, std::forward<Self>(self).fs,
-                                       offsets{}, arities{});
-        auto filtered_results =
-            stdx::filter<detail::nonvoid_result_t>(std::move(results));
-
-        std::move(filtered_results).apply([&]<typename... Ts>(Ts &&...ts) {
-            Tag{}(std::forward<Self>(self).r, std::forward<Ts>(ts)...);
-        });
+    template <typename... Args>
+    constexpr auto set_value(Args &&...args) -> void {
+        handle<set_value_t>(std::forward<Args>(args)...);
     }
+    template <typename... Args>
+    constexpr auto set_error(Args &&...args) -> void {
+        handle<set_error_t>(std::forward<Args>(args)...);
+    }
+    constexpr auto set_stopped() -> void { handle<set_stopped_t>(); }
 
-    template <typename T, stdx::same_as_unqualified<receiver> Self,
-              typename... Args>
-    friend auto tag_invoke(T, Self &&self, Args &&...args)
-        -> decltype(T{}(std::forward<Self>(self).r,
-                        std::forward<Args>(args)...)) {
-        return T{}(std::forward<Self>(self).r, std::forward<Args>(args)...);
+  private:
+    template <typename T, typename... Args>
+    auto handle(Args &&...args) -> void {
+        if constexpr (std::same_as<Tag, T>) {
+            using arities =
+                typename detail::args<Args &&...>::template arities_t<Fs...>;
+            using offsets = typename detail::offsets_t<arities, Fs...>;
+
+            auto arg_tuple =
+                stdx::tuple<Args &&...>{std::forward<Args>(args)...};
+            auto const invoke =
+                [&]<typename F, typename Offset, typename Arity>(
+                    F &&func, Offset, Arity) -> decltype(auto) {
+                return detail::invoke<Offset::value>(
+                    std::forward<F>(func), std::move(arg_tuple),
+                    std::make_index_sequence<Arity::value>{});
+            };
+            auto results = stdx::transform(invoke, fs, offsets{}, arities{});
+            auto filtered_results =
+                stdx::filter<detail::nonvoid_result_t>(std::move(results));
+
+            std::move(filtered_results).apply([&]<typename... Ts>(Ts &&...ts) {
+                Tag{}(std::move(r), std::forward<Ts>(ts)...);
+            });
+        } else {
+            T{}(std::move(r), std::forward<Args>(args)...);
+        }
     }
 };
 

--- a/include/async/type_traits.hpp
+++ b/include/async/type_traits.hpp
@@ -192,17 +192,17 @@ template <typename Tag> struct channel_holder {
 
         template <typename R> auto operator()(R &&r) const & -> void {
             this->apply([&]<typename... Args>(Args &&...args) {
-                Tag{}(std::move(r), std::forward<Args>(args)...);
+                Tag{}(std::forward<R>(r), std::forward<Args>(args)...);
             });
         }
         template <typename R> auto operator()(R &&r) & -> void {
             this->apply([&]<typename... Args>(Args &&...args) {
-                Tag{}(std::move(r), std::forward<Args>(args)...);
+                Tag{}(std::forward<R>(r), std::forward<Args>(args)...);
             });
         }
         template <typename R> auto operator()(R &&r) && -> void {
             std::move(*this).apply([&]<typename... Args>(Args &&...args) {
-                Tag{}(std::move(r), std::forward<Args>(args)...);
+                Tag{}(std::forward<R>(r), std::forward<Args>(args)...);
             });
         }
     };

--- a/include/async/type_traits.hpp
+++ b/include/async/type_traits.hpp
@@ -192,17 +192,17 @@ template <typename Tag> struct channel_holder {
 
         template <typename R> auto operator()(R &&r) const & -> void {
             this->apply([&]<typename... Args>(Args &&...args) {
-                Tag{}(std::forward<R>(r), std::forward<Args>(args)...);
+                Tag{}(std::move(r), std::forward<Args>(args)...);
             });
         }
         template <typename R> auto operator()(R &&r) & -> void {
             this->apply([&]<typename... Args>(Args &&...args) {
-                Tag{}(std::forward<R>(r), std::forward<Args>(args)...);
+                Tag{}(std::move(r), std::forward<Args>(args)...);
             });
         }
         template <typename R> auto operator()(R &&r) && -> void {
             std::move(*this).apply([&]<typename... Args>(Args &&...args) {
-                Tag{}(std::forward<R>(r), std::forward<Args>(args)...);
+                Tag{}(std::move(r), std::forward<Args>(args)...);
             });
         }
     };

--- a/include/async/variant_sender.hpp
+++ b/include/async/variant_sender.hpp
@@ -150,10 +150,8 @@ template <typename... Ops> struct op_state {
     using variant_t = boost::mp11::mp_unique<std::variant<Ops...>>;
     variant_t v;
 
-  private:
-    template <stdx::same_as_unqualified<op_state> O>
-    friend constexpr auto tag_invoke(start_t, O &&o) -> void {
-        std::visit([](auto &&ops) { start(FWD(ops)); }, std::forward<O>(o).v);
+    constexpr auto start() & -> void {
+        std::visit([](auto &&ops) { async::start(FWD(ops)); }, v);
     }
 };
 

--- a/include/async/when_all.hpp
+++ b/include/async/when_all.hpp
@@ -39,20 +39,13 @@ template <typename SubOps> struct sub_receiver {
                                                    ops->get_receiver());
     }
 
-  private:
-    template <typename... Args>
-    friend auto tag_invoke(set_value_t, sub_receiver const &r,
-                           Args &&...args) -> void {
-        r.ops->emplace_value(std::forward<Args>(args)...);
+    template <typename... Args> auto set_value(Args &&...args) const -> void {
+        ops->emplace_value(std::forward<Args>(args)...);
     }
-    template <typename... Args>
-    friend auto tag_invoke(set_error_t, sub_receiver const &r,
-                           Args &&...args) -> void {
-        r.ops->emplace_error(std::forward<Args>(args)...);
+    template <typename... Args> auto set_error(Args &&...args) const -> void {
+        ops->emplace_error(std::forward<Args>(args)...);
     }
-    friend auto tag_invoke(set_stopped_t, sub_receiver const &r) -> void {
-        r.ops->emplace_stopped();
-    }
+    auto set_stopped() const -> void { ops->emplace_stopped(); }
 };
 
 template <typename S, typename Tag, typename E>

--- a/include/async/when_any.hpp
+++ b/include/async/when_any.hpp
@@ -250,6 +250,19 @@ struct op_state
                    std::move(completions));
     }
 
+    constexpr auto start() & -> void {
+        stop_cb.emplace(get_stop_token(get_env(rcvr)),
+                        stop_callback_fn{std::addressof(stop_source)});
+        if (stop_source.stop_requested()) {
+            set_stopped(std::move(rcvr));
+        } else {
+            count = sizeof...(Sndrs);
+            (async::start(
+                 static_cast<sub_op_state<op_state, Rcvr, Sndrs> &>(*this).ops),
+             ...);
+        }
+    }
+
     using stop_callback_t =
         stop_callback_for_t<stop_token_of_t<env_of_t<Rcvr>>, stop_callback_fn>;
 
@@ -258,22 +271,6 @@ struct op_state
     std::atomic<std::size_t> count{};
     inplace_stop_source stop_source{};
     std::optional<stop_callback_t> stop_cb{};
-
-  private:
-    template <stdx::same_as_unqualified<op_state> O>
-    friend constexpr auto tag_invoke(start_t, O &&o) -> void {
-        o.stop_cb.emplace(get_stop_token(get_env(o.rcvr)),
-                          stop_callback_fn{std::addressof(o.stop_source)});
-        if (o.stop_source.stop_requested()) {
-            set_stopped(std::move(o).rcvr);
-        } else {
-            o.count = sizeof...(Sndrs);
-            (start(static_cast<stdx::forward_like_t<
-                       O, sub_op_state<op_state, Rcvr, Sndrs>>>(o)
-                       .ops),
-             ...);
-        }
-    }
 }; // namespace async
 
 template <typename StopPolicy, typename... Sndrs> struct sender : Sndrs... {
@@ -317,18 +314,17 @@ struct op_state<StopPolicy, Rcvr> {
         }
         op_state *ops;
     };
+
+    constexpr auto start() & -> void {
+        stop_cb.emplace(async::get_stop_token(get_env(rcvr)),
+                        stop_callback_fn{this});
+    }
+
     using stop_callback_t =
         stop_callback_for_t<stop_token_of_t<env_of_t<Rcvr>>, stop_callback_fn>;
 
     [[no_unique_address]] Rcvr rcvr;
     std::optional<stop_callback_t> stop_cb{};
-
-  private:
-    template <stdx::same_as_unqualified<op_state> O>
-    friend constexpr auto tag_invoke(start_t, O &&o) -> void {
-        o.stop_cb.emplace(async::get_stop_token(get_env(o.rcvr)),
-                          stop_callback_fn{std::addressof(o)});
-    }
 };
 
 template <typename StopPolicy> struct sender<StopPolicy> {

--- a/include/async/when_any.hpp
+++ b/include/async/when_any.hpp
@@ -38,11 +38,13 @@ template <typename SubOps> struct sub_receiver {
                                                    ops->get_receiver());
     }
 
-  private:
-    template <channel_tag Tag, typename... Args>
-    friend auto tag_invoke(Tag, sub_receiver const &r, Args &&...args) -> void {
-        r.ops->template emplace<Tag>(std::forward<Args>(args)...);
+    template <typename... Args> auto set_value(Args &&...args) const -> void {
+        ops->template emplace<set_value_t>(std::forward<Args>(args)...);
     }
+    template <typename... Args> auto set_error(Args &&...args) const -> void {
+        ops->template emplace<set_error_t>(std::forward<Args>(args)...);
+    }
+    auto set_stopped() const -> void { ops->template emplace<set_stopped_t>(); }
 };
 
 template <typename Ops, typename R, typename S>

--- a/test/concepts.cpp
+++ b/test/concepts.cpp
@@ -44,13 +44,9 @@ struct error {};
 
 template <typename E = error, typename... Ts>
 struct receiver : async::receiver_base {
-  private:
-    friend auto tag_invoke(async::set_value_t, receiver const &,
-                           std::same_as<Ts> auto...) -> void {}
-    friend auto tag_invoke(async::set_error_t, receiver const &,
-                           std::same_as<E> auto) -> void {}
-    template <std::same_as<receiver> R>
-    friend auto tag_invoke(async::set_stopped_t, R const &) -> void {}
+    constexpr auto set_value(std::same_as<Ts> auto...) const -> void {}
+    constexpr auto set_error(std::same_as<E> auto) const -> void {}
+    constexpr auto set_stopped() const -> void {}
 };
 } // namespace
 
@@ -131,11 +127,8 @@ struct sender : async::sender_base {
 };
 
 template <typename... Ts> struct value_receiver : async::receiver_base {
-  private:
-    template <std::same_as<value_receiver> R>
-    friend auto tag_invoke(async::set_value_t, R const &, Ts...) -> void {}
-    friend auto tag_invoke(async::set_error_t, value_receiver const &,
-                           auto) -> void {}
+    constexpr auto set_value(Ts...) const -> void {}
+    constexpr auto set_error(auto) const -> void {}
 };
 } // namespace
 

--- a/test/concepts.cpp
+++ b/test/concepts.cpp
@@ -44,9 +44,9 @@ struct error {};
 
 template <typename E = error, typename... Ts>
 struct receiver : async::receiver_base {
-    constexpr auto set_value(std::same_as<Ts> auto...) const -> void {}
-    constexpr auto set_error(std::same_as<E> auto) const -> void {}
-    constexpr auto set_stopped() const -> void {}
+    constexpr auto set_value(std::same_as<Ts> auto...) const && -> void {}
+    constexpr auto set_error(std::same_as<E> auto) const && -> void {}
+    constexpr auto set_stopped() const && -> void {}
 };
 } // namespace
 
@@ -127,8 +127,8 @@ struct sender : async::sender_base {
 };
 
 template <typename... Ts> struct value_receiver : async::receiver_base {
-    constexpr auto set_value(Ts...) const -> void {}
-    constexpr auto set_error(auto) const -> void {}
+    constexpr auto set_value(Ts...) const && -> void {}
+    constexpr auto set_error(auto) const && -> void {}
 };
 } // namespace
 

--- a/test/concepts.cpp
+++ b/test/concepts.cpp
@@ -13,9 +13,7 @@ TEST_CASE("queryable", "[concepts]") {
 
 namespace {
 struct op_state {
-  private:
-    [[maybe_unused]] friend auto tag_invoke(async::start_t,
-                                            op_state const &) noexcept {}
+    auto start() & noexcept {}
 };
 struct not_op_state {};
 } // namespace

--- a/test/continue_on.cpp
+++ b/test/continue_on.cpp
@@ -21,7 +21,7 @@ template <auto> class test_scheduler {
       private:
         template <stdx::same_as_unqualified<op_state> O>
         friend constexpr auto tag_invoke(async::start_t, O &&o) -> void {
-            async::set_value(std::forward<O>(o).receiver);
+            async::set_value(std::move(o).receiver);
         }
     };
 

--- a/test/continue_on.cpp
+++ b/test/continue_on.cpp
@@ -18,10 +18,8 @@ template <auto> class test_scheduler {
     template <typename R> struct op_state {
         [[no_unique_address]] R receiver;
 
-      private:
-        template <stdx::same_as_unqualified<op_state> O>
-        friend constexpr auto tag_invoke(async::start_t, O &&o) -> void {
-            async::set_value(std::move(o).receiver);
+        constexpr auto start() & -> void {
+            async::set_value(std::move(receiver));
         }
     };
 

--- a/test/just.cpp
+++ b/test/just.cpp
@@ -39,7 +39,7 @@ TEST_CASE("move-only value", "[just]") {
     static_assert(async::singleshot_sender<decltype(s), universal_receiver>);
     auto op = async::connect(
         std::move(s), receiver{[&](move_only<int> mo) { value = mo.value; }});
-    async::start(std::move(op));
+    async::start(op);
     CHECK(value == 42);
 }
 

--- a/test/just_error.cpp
+++ b/test/just_error.cpp
@@ -30,7 +30,7 @@ TEST_CASE("move-only value", "[just_error]") {
     auto op = async::connect(
         std::move(s),
         error_receiver{[&](move_only<int> mo) { value = mo.value; }});
-    async::start(std::move(op));
+    async::start(op);
     CHECK(value == 42);
 }
 

--- a/test/let_error.cpp
+++ b/test/let_error.cpp
@@ -114,21 +114,45 @@ TEST_CASE("let_error with variant", "[let_error]") {
 
     auto r = receiver{[&](auto i) { value = i; }};
     value = 6;
-    async::start(async::connect(s, r));
+    {
+        auto o = async::connect(s, r);
+        async::start(o);
+    }
     CHECK(value == 3);
-    async::start(async::connect(s, r));
+    {
+        auto o = async::connect(s, r);
+        async::start(o);
+    }
     CHECK(value == 10);
-    async::start(async::connect(s, r));
+    {
+        auto o = async::connect(s, r);
+        async::start(o);
+    }
     CHECK(value == 5);
-    async::start(async::connect(s, r));
+    {
+        auto o = async::connect(s, r);
+        async::start(o);
+    }
     CHECK(value == 16);
-    async::start(async::connect(s, r));
+    {
+        auto o = async::connect(s, r);
+        async::start(o);
+    }
     CHECK(value == 8);
-    async::start(async::connect(s, r));
+    {
+        auto o = async::connect(s, r);
+        async::start(o);
+    }
     CHECK(value == 4);
-    async::start(async::connect(s, r));
+    {
+        auto o = async::connect(s, r);
+        async::start(o);
+    }
     CHECK(value == 2);
-    async::start(async::connect(s, r));
+    {
+        auto o = async::connect(s, r);
+        async::start(o);
+    }
     CHECK(value == 1);
 }
 

--- a/test/let_value.cpp
+++ b/test/let_value.cpp
@@ -121,21 +121,45 @@ TEST_CASE("let_value with variant", "[let_value]") {
 
     auto r = receiver{[&](auto i) { value = i; }};
     value = 6;
-    async::start(async::connect(s, r));
+    {
+        auto o = async::connect(s, r);
+        async::start(o);
+    }
     CHECK(value == 3);
-    async::start(async::connect(s, r));
+    {
+        auto o = async::connect(s, r);
+        async::start(o);
+    }
     CHECK(value == 10);
-    async::start(async::connect(s, r));
+    {
+        auto o = async::connect(s, r);
+        async::start(o);
+    }
     CHECK(value == 5);
-    async::start(async::connect(s, r));
+    {
+        auto o = async::connect(s, r);
+        async::start(o);
+    }
     CHECK(value == 16);
-    async::start(async::connect(s, r));
+    {
+        auto o = async::connect(s, r);
+        async::start(o);
+    }
     CHECK(value == 8);
-    async::start(async::connect(s, r));
+    {
+        auto o = async::connect(s, r);
+        async::start(o);
+    }
     CHECK(value == 4);
-    async::start(async::connect(s, r));
+    {
+        auto o = async::connect(s, r);
+        async::start(o);
+    }
     CHECK(value == 2);
-    async::start(async::connect(s, r));
+    {
+        auto o = async::connect(s, r);
+        async::start(o);
+    }
     CHECK(value == 1);
 }
 

--- a/test/repeat.cpp
+++ b/test/repeat.cpp
@@ -112,7 +112,7 @@ TEST_CASE("repeat_until is pipeable", "[repeat]") {
 
 TEST_CASE("repeat can be cancelled", "[repeat]") {
     int var{};
-    only_stoppable_receiver r{[&] { var += 42; }};
+    stoppable_receiver r{[&] { var += 42; }};
 
     auto sub = async::just() | async::sequence([&] {
                    if (++var == 2) {

--- a/test/retry.cpp
+++ b/test/retry.cpp
@@ -85,7 +85,7 @@ TEST_CASE("retry_until retries on error", "[retry]") {
 
 TEST_CASE("retry can be cancelled", "[retry]") {
     int var{};
-    only_stoppable_receiver r{[&] { var += 42; }};
+    stoppable_receiver r{[&] { var += 42; }};
 
     auto sub = async::just() | async::sequence([&] {
                    if (++var == 2) {

--- a/test/sequence.cpp
+++ b/test/sequence.cpp
@@ -92,7 +92,7 @@ TEST_CASE("move-only first sender", "[sequence]") {
     static_assert(async::singleshot_sender<decltype(s)>);
     auto op =
         async::connect(std::move(s), receiver{[&](auto i) { value = i; }});
-    async::start(std::move(op));
+    async::start(op);
     CHECK(value == 42);
 }
 

--- a/test/split.cpp
+++ b/test/split.cpp
@@ -114,7 +114,7 @@ TEST_CASE("split cancellation (stopped by source)", "[split]") {
     static_assert(async::singleshot_sender<decltype(s), universal_receiver>);
     auto spl = async::split(std::move(s));
 
-    auto r1 = only_stoppable_receiver{[&] { ++stopped; }};
+    auto r1 = stoppable_receiver{[&] { ++stopped; }};
     auto r2 = stopped_receiver{[&] { ++stopped; }};
     auto op1 = async::connect(spl, r1);
     auto op2 = async::connect(spl, r2);

--- a/test/split.cpp
+++ b/test/split.cpp
@@ -155,13 +155,10 @@ struct test_sender {
     template <typename R> struct op_state {
         R r;
 
-      private:
-        template <stdx::same_as_unqualified<op_state> O>
-        friend constexpr auto tag_invoke(async::start_t, O &&o) -> void {
-            async::set_value(std::forward<O>(o).r);
-        }
+        constexpr auto start() & -> void { async::set_value(std::move(r)); }
     };
 
+  private:
     template <typename R>
     [[nodiscard]] friend constexpr auto
     tag_invoke(async::connect_t, test_sender &&,

--- a/test/start_on.cpp
+++ b/test/start_on.cpp
@@ -49,7 +49,7 @@ TEST_CASE("move-only value", "[start_on]") {
     static_assert(async::singleshot_sender<decltype(s), universal_receiver>);
     auto op = async::connect(std::move(s),
                              receiver{[&](auto mo) { value = mo.value; }});
-    async::start(std::move(op));
+    async::start(op);
     CHECK(value == 42);
 }
 

--- a/test/start_on.cpp
+++ b/test/start_on.cpp
@@ -70,7 +70,7 @@ TEST_CASE("start_on advertises what it sends according to the receiver",
         async::start_on(async::inline_scheduler{}, async::when_all());
     static_assert(not async::sender_of<decltype(s), async::set_stopped_t()>);
 
-    [[maybe_unused]] auto r = only_stoppable_receiver{[] {}};
+    [[maybe_unused]] auto r = stoppable_receiver{[] {}};
     static_assert(async::sender_of<decltype(s), async::set_stopped_t(),
                                    async::env_of_t<decltype(r)>>);
 }

--- a/test/then.cpp
+++ b/test/then.cpp
@@ -223,7 +223,7 @@ TEST_CASE("move-only value (to then) (variadic)", "[then]") {
              async::then([](auto i) { return i.value; }, [](auto) {});
     static_assert(async::sender_of<decltype(s), async::set_value_t(int)>);
     auto op = async::connect(std::move(s), receiver{[&](auto i) { x = i; }});
-    async::start(std::move(op));
+    async::start(op);
     CHECK(x == 2);
 }
 

--- a/test/type_traits.cpp
+++ b/test/type_traits.cpp
@@ -279,7 +279,7 @@ TEST_CASE("channel holder (values)", "[type_traits]") {
     int value{};
     auto r = receiver{[&](auto i) { value = i; }};
     auto h = async::value_holder<int>{42};
-    h(r);
+    h(std::move(r));
     CHECK(value == 42);
 }
 
@@ -287,7 +287,7 @@ TEST_CASE("channel holder (error)", "[type_traits]") {
     int value{};
     auto r = error_receiver{[&](auto i) { value = i; }};
     auto h = async::error_holder<int>{42};
-    h(r);
+    h(std::move(r));
     CHECK(value == 42);
 }
 
@@ -295,7 +295,7 @@ TEST_CASE("channel holder (stopped)", "[type_traits]") {
     int value{};
     auto r = stopped_receiver{[&] { value = 42; }};
     auto h = async::stopped_holder<>{};
-    h(r);
+    h(std::move(r));
     CHECK(value == 42);
 }
 

--- a/test/when_all.cpp
+++ b/test/when_all.cpp
@@ -95,7 +95,7 @@ TEST_CASE("move-only value", "[when_all]") {
     static_assert(async::singleshot_sender<decltype(w), universal_receiver>);
     auto op = async::connect(
         std::move(w), receiver{[&](move_only<int> mo) { value = mo.value; }});
-    async::start(std::move(op));
+    async::start(op);
     CHECK(value == 42);
 }
 

--- a/test/when_all.cpp
+++ b/test/when_all.cpp
@@ -223,7 +223,7 @@ TEST_CASE("when_all with zero args completes immediately when stopped",
           "[when_all]") {
     int value{};
     [[maybe_unused]] auto w = async::when_all();
-    auto r = only_stoppable_receiver{[&] { value = 42; }};
+    auto r = stoppable_receiver{[&] { value = 42; }};
     static_assert(
         async::stoppable_sender<decltype(w), async::env_of_t<decltype(r)>>);
     static_assert(

--- a/test/when_any.cpp
+++ b/test/when_any.cpp
@@ -263,7 +263,7 @@ TEST_CASE("when_any with zero args can be stopped (before start)",
           "[when_any]") {
     int value{};
     [[maybe_unused]] auto w = async::when_any();
-    auto r = only_stoppable_receiver{[&] { value = 42; }};
+    auto r = stoppable_receiver{[&] { value = 42; }};
     static_assert(
         std::same_as<async::completion_signatures_of_t<
                          decltype(w), async::env_of_t<decltype(r)>>,
@@ -279,7 +279,7 @@ TEST_CASE("when_any with zero args can be stopped (after start)",
           "[when_any]") {
     int value{};
     [[maybe_unused]] auto w = async::when_any();
-    auto r = only_stoppable_receiver{[&] { value = 42; }};
+    auto r = stoppable_receiver{[&] { value = 42; }};
     static_assert(
         std::same_as<async::completion_signatures_of_t<
                          decltype(w), async::env_of_t<decltype(r)>>,

--- a/test/when_any.cpp
+++ b/test/when_any.cpp
@@ -113,7 +113,7 @@ TEST_CASE("move-only value", "[when_any]") {
     static_assert(async::singleshot_sender<decltype(w), universal_receiver>);
     auto op = async::connect(
         std::move(w), receiver{[&](move_only<int> mo) { value = mo.value; }});
-    async::start(std::move(op));
+    async::start(op);
     CHECK(value == 42);
 }
 


### PR DESCRIPTION
NB according to P2300:
- `set_value(rcvr, vs...)` is ill-formed if `rcvr` is an lvalue or a const rvalue. Likewise `set_error`, `set_stopped`.
- `start(op)` is ill-formed if `op` is an rvalue.