### PR TITLE
:art: Remove bespoke environment implementations

### DIFF
--- a/docs/environments.adoc
+++ b/docs/environments.adoc
@@ -19,16 +19,8 @@ struct custom_receiver {
   auto set_error(auto&&) { ... }
   auto set_stopped() { ... }
 
-  struct env {
-    [[nodiscard]] constexpr auto query(async::get_stop_token_t) const
-        -> async::inplace_stop_token {
-      return token;
-    }
-    async::inplace_stop_token token;
-  };
-
-  [[nodiscard]] constexpr auto query(async::get_env_t) const -> env {
-    return {stop_source->get_token()};
+  [[nodiscard]] constexpr auto query(async::get_env_t) const {
+    return async::prop{async::get_stop_token_t{}, stop_source->get_token()};
   }
 
   inplace_stop_source* stop_source;
@@ -44,3 +36,45 @@ propagate through the sender-receiver chain.
 
 NOTE: Remember that a receiver should not own a stop_source: receivers must
 be movable, and in general a stop_source is not.
+
+=== Constructing and composing environments
+
+An environment is conceptually a key-value store through which a receiver (or a
+sender) provides properties to algorithms (sender adaptors) to customize the way
+they work.
+
+Some of the facilities for environment handling are covered in https://wg21.link/p3325[P3325].
+
+A `prop` is a single key-value pair. Construct one with a query and the value
+that will be returned for that query.
+
+[source,cpp]
+----
+auto e = async::prop{async::get_stop_token_t{}, stop_source->get_token()};
+----
+
+NOTE: A `prop` _is_ an environment. A small one, but it models the
+concepts required.
+
+`env` is how we compose multiple properties, or multiple environments:
+
+[source,cpp]
+----
+auto e = async::env{
+           async::prop{async::get_stop_token_t{}, stop_source->get_token()},
+           async::prop{async::get_allocator_t{}, async::stack_allocator{}}};
+----
+
+This allows us to use an existing environment and extend it with new properties,
+or override existing ones.
+
+[source,cpp]
+----
+auto old_e = /* existing environment */;
+auto e = async::env{
+           async::prop{async::get_stop_token_t{}, stop_source->get_token()},
+           old_e};
+----
+
+In this case, whether or not `get_stop_token` is a valid query on `old_e`,
+calling it on `e` will return the newly-provided stop token.

--- a/include/async/allocator.hpp
+++ b/include/async/allocator.hpp
@@ -38,5 +38,6 @@ constexpr inline struct get_allocator_t : forwarding_query_t {
 } get_allocator;
 
 template <typename T>
-using allocator_of_t = decltype(get_allocator(std::declval<T>()));
+using allocator_of_t =
+    std::remove_cvref_t<decltype(get_allocator(std::declval<T>()))>;
 } // namespace async

--- a/include/async/env.hpp
+++ b/include/async/env.hpp
@@ -20,6 +20,24 @@ template <typename Query, typename Value> struct prop {
 template <typename Query, typename Value>
 prop(Query, Value) -> prop<Query, Value>;
 
+template <template <typename> typename Query, typename Value, typename... Ts>
+struct template_prop {
+    template <typename T>
+        requires(... or std::same_as<T, Ts>)
+    [[nodiscard]] constexpr auto
+    query(Query<T>) const noexcept -> Value const & {
+        return value;
+    }
+
+    [[no_unique_address]] Value value{};
+};
+
+template <template <typename> typename Query, typename... Ts>
+constexpr auto make_template_prop = []<typename Value>(Value &&v) {
+    return template_prop<Query, std::remove_cvref_t<Value>, Ts...>{
+        std::forward<Value>(v)};
+};
+
 namespace detail {
 template <typename Query, typename Env>
 concept valid_query_for = requires(Env const &e) { e.query(Query{}); };

--- a/include/async/just.hpp
+++ b/include/async/just.hpp
@@ -5,6 +5,7 @@
 #include <async/completion_tags.hpp>
 #include <async/concepts.hpp>
 #include <async/connect.hpp>
+#include <async/env.hpp>
 #include <async/stack_allocator.hpp>
 #include <async/type_traits.hpp>
 
@@ -28,18 +29,6 @@ template <typename Tag, typename R, typename... Vs> struct op_state {
     }
 };
 
-struct env {
-    [[nodiscard]] constexpr static auto
-    query(get_allocator_t) noexcept -> stack_allocator {
-        return {};
-    }
-
-    [[nodiscard]] constexpr static auto
-    query(completes_synchronously_t) noexcept -> bool {
-        return true;
-    }
-};
-
 template <typename Tag, typename... Vs> struct sender {
     using is_sender = void;
     using completion_signatures = async::completion_signatures<Tag(Vs...)>;
@@ -60,8 +49,9 @@ template <typename Tag, typename... Vs> struct sender {
         return {std::forward<R>(r), values};
     }
 
-    [[nodiscard]] constexpr auto query(get_env_t) const noexcept -> env {
-        return {};
+    [[nodiscard]] constexpr auto query(get_env_t) const noexcept {
+        return env{prop{get_allocator_t{}, stack_allocator{}},
+                   prop{completes_synchronously_t{}, true}};
     }
 };
 } // namespace _just

--- a/include/async/read_env.hpp
+++ b/include/async/read_env.hpp
@@ -24,13 +24,6 @@ template <typename R, typename Tag> struct op_state {
     }
 };
 
-struct env {
-    [[nodiscard]] constexpr static auto
-    query(completes_synchronously_t) noexcept -> bool {
-        return true;
-    }
-};
-
 template <typename Tag> struct sender {
     using is_sender = void;
 
@@ -41,8 +34,8 @@ template <typename Tag> struct sender {
         return {};
     }
 
-    [[nodiscard]] constexpr static auto query(get_env_t) noexcept -> env {
-        return {};
+    [[nodiscard]] constexpr static auto query(get_env_t) noexcept {
+        return prop{completes_synchronously, true};
     }
 
     template <receiver R>

--- a/include/async/schedulers/inline_scheduler.hpp
+++ b/include/async/schedulers/inline_scheduler.hpp
@@ -23,31 +23,16 @@ class inline_scheduler {
         constexpr auto start() & -> void { set_value(std::move(receiver)); }
     };
 
-    struct env {
-        [[nodiscard]] constexpr static auto
-        query(get_allocator_t) noexcept -> stack_allocator {
-            return {};
-        }
-
-        [[nodiscard]] constexpr static auto
-        query(get_completion_scheduler_t<set_value_t>) noexcept
-            -> inline_scheduler {
-            return {};
-        }
-
-        [[nodiscard]] constexpr static auto
-        query(completes_synchronously_t) noexcept -> bool {
-            return true;
-        }
-    };
-
     struct sender_base {
         using is_sender = void;
         using completion_signatures =
             async::completion_signatures<set_value_t()>;
 
-        [[nodiscard]] static constexpr auto query(get_env_t) noexcept -> env {
-            return {};
+        [[nodiscard]] static constexpr auto query(get_env_t) noexcept {
+            return env{prop{get_allocator_t{}, stack_allocator{}},
+                       prop{completes_synchronously_t{}, true},
+                       prop{get_completion_scheduler<set_value_t>,
+                            inline_scheduler{}}};
         }
     };
 

--- a/include/async/schedulers/priority_scheduler.hpp
+++ b/include/async/schedulers/priority_scheduler.hpp
@@ -50,19 +50,12 @@ struct op_state final : Task {
 
 template <priority_t P, typename Task = priority_task>
 class fixed_priority_scheduler {
-    struct env {
-        [[nodiscard]] constexpr static auto
-        query(get_completion_scheduler_t<set_value_t>) noexcept
-            -> fixed_priority_scheduler {
-            return {};
-        }
-    };
-
     struct sender {
         using is_sender = void;
 
-        [[nodiscard]] constexpr auto query(get_env_t) const noexcept -> env {
-            return {};
+        [[nodiscard]] constexpr auto query(get_env_t) const noexcept {
+            return prop{get_completion_scheduler_t<set_value_t>{},
+                        fixed_priority_scheduler{}};
         }
 
         template <typename Env>

--- a/include/async/schedulers/runloop_scheduler.hpp
+++ b/include/async/schedulers/runloop_scheduler.hpp
@@ -54,23 +54,15 @@ template <typename Uniq = decltype([] {})> class run_loop {
     };
 
     struct scheduler {
-        struct env {
-            [[nodiscard]] constexpr auto
-            query(get_completion_scheduler_t<set_value_t>) const noexcept
-                -> scheduler {
-                return loop->get_scheduler();
-            }
-            run_loop *loop;
-        };
-
         struct sender {
             using is_sender = void;
             using completion_signatures =
                 async::completion_signatures<set_value_t(), set_stopped_t()>;
 
-            [[nodiscard]] constexpr auto
-            query(get_env_t) const noexcept -> env {
-                return {loop};
+            [[nodiscard]] constexpr auto query(get_env_t) const noexcept {
+                return make_template_prop<get_completion_scheduler_t,
+                                          set_value_t, set_stopped_t>(
+                    loop->get_scheduler());
             }
 
             template <receiver R>

--- a/include/async/schedulers/thread_scheduler.hpp
+++ b/include/async/schedulers/thread_scheduler.hpp
@@ -27,21 +27,14 @@ class thread_scheduler {
         }
     };
 
-    struct env {
-        [[nodiscard]] constexpr static auto
-        query(get_completion_scheduler_t<set_value_t>) noexcept
-            -> thread_scheduler {
-            return {};
-        }
-    };
-
     struct sender {
         using is_sender = void;
         using completion_signatures =
             async::completion_signatures<set_value_t()>;
 
-        [[nodiscard]] constexpr static auto query(get_env_t) noexcept -> env {
-            return {};
+        [[nodiscard]] static constexpr auto query(get_env_t) noexcept {
+            return prop{get_completion_scheduler<set_value_t>,
+                        thread_scheduler{}};
         }
 
         template <receiver R>

--- a/include/async/schedulers/time_scheduler.hpp
+++ b/include/async/schedulers/time_scheduler.hpp
@@ -81,22 +81,13 @@ struct op_state<Domain, Duration, Rcvr, Task> final
 template <typename Domain, typename Duration,
           typename Task = timer_task<timer_mgr::time_point_for_t<Duration>>>
 class time_scheduler {
-    struct env {
-        [[nodiscard]] constexpr auto
-        query(get_completion_scheduler_t<set_value_t>) const noexcept
-            -> time_scheduler {
-            return {d};
-        }
-
-        [[no_unique_address]] Duration d{};
-    };
-
     struct sender {
         using is_sender = void;
         [[no_unique_address]] Duration d{};
 
-        [[nodiscard]] constexpr auto query(get_env_t) const noexcept -> env {
-            return {d};
+        [[nodiscard]] constexpr auto query(get_env_t) const noexcept {
+            return prop{get_completion_scheduler_t<set_value_t>{},
+                        time_scheduler{d}};
         }
 
         template <typename Env>

--- a/include/async/stop_token.hpp
+++ b/include/async/stop_token.hpp
@@ -201,10 +201,12 @@ struct get_stop_token_t : forwarding_query_t {
     constexpr auto operator()(auto &&) const -> never_stop_token { return {}; }
 };
 
-template <typename E> auto get_stop_token(E &&e) {
+template <typename E>
+auto get_stop_token(E &&e) -> decltype(get_stop_token_t{}(std::forward<E>(e))) {
     return get_stop_token_t{}(std::forward<E>(e));
 }
 
 template <typename T>
-using stop_token_of_t = decltype(get_stop_token(std::declval<T>()));
+using stop_token_of_t =
+    std::remove_cvref_t<decltype(get_stop_token(std::declval<T>()))>;
 } // namespace async

--- a/include/async/when_any.hpp
+++ b/include/async/when_any.hpp
@@ -220,7 +220,6 @@ struct op_state
 
     template <typename Tag, typename... Args>
     auto emplace(Args &&...args) -> void {
-        [[maybe_unused]] auto x = env_t{}.query(get_stop_token_t{});
         StopPolicy::template emplace<mutex, Tag>(completions, stop_source,
                                                  std::forward<Args>(args)...);
         if (--count == 0) {

--- a/test/continue_on.cpp
+++ b/test/continue_on.cpp
@@ -3,6 +3,7 @@
 #include <async/concepts.hpp>
 #include <async/connect.hpp>
 #include <async/continue_on.hpp>
+#include <async/env.hpp>
 #include <async/just.hpp>
 #include <async/let_stopped.hpp>
 #include <async/schedulers/inline_scheduler.hpp>
@@ -23,22 +24,15 @@ template <auto> class test_scheduler {
         }
     };
 
-    struct env {
-        template <typename Tag>
-        [[nodiscard]] constexpr static auto query(
-            async::get_completion_scheduler_t<Tag>) noexcept -> test_scheduler {
-            return {};
-        }
-    };
-
     struct sender {
         using is_sender = void;
         using completion_signatures =
             async::completion_signatures<async::set_value_t()>;
 
-        [[nodiscard]] constexpr auto
-        query(async::get_env_t) const noexcept -> env {
-            return {};
+        [[nodiscard]] constexpr static auto query(async::get_env_t) noexcept {
+            return async::make_template_prop<
+                async::get_completion_scheduler_t, async::set_value_t,
+                async::set_error_t, async::set_stopped_t>(test_scheduler{});
         }
 
         template <async::receiver_from<sender> R>

--- a/test/env.cpp
+++ b/test/env.cpp
@@ -1,6 +1,7 @@
 #include "detail/common.hpp"
 
 #include <async/env.hpp>
+#include <async/get_completion_scheduler.hpp>
 
 #include <catch2/catch_test_macros.hpp>
 
@@ -8,54 +9,68 @@
 #include <functional>
 
 TEST_CASE("empty env", "[env]") {
-    auto r = receiver{[] {}};
+    auto const r = receiver{[] {}};
     static_assert(std::same_as<async::env_of_t<decltype(r)>, async::empty_env>);
 }
 
+TEST_CASE("nonexistent query", "[env]") {
+    auto const e = async::empty_env{};
+    CHECK(get_fwd(e) == none{});
+}
+
 TEST_CASE("non-empty env", "[env]") {
-    auto r = stoppable_receiver{[] {}};
+    auto const r = stoppable_receiver{[] {}};
     static_assert(
-        std::same_as<async::env_of_t<decltype(r)>, typename decltype(r)::env>);
+        not std::same_as<async::env_of_t<decltype(r)>, async::empty_env>);
 }
 
 TEST_CASE("single prop", "[env]") {
-    auto e = async::prop{get_fwd, 42};
+    auto const e = async::prop{get_fwd, 42};
     CHECK(get_fwd(e) == 42);
 }
 
+TEST_CASE("prop with move-only type", "[env]") {
+    auto const e = async::prop{get_fwd, move_only{42}};
+    CHECK(get_fwd(e).value == 42);
+}
+
 TEST_CASE("singleton env", "[env]") {
-    auto e = async::env{async::prop{get_fwd, 42}};
+    auto const e = async::env{async::prop{get_fwd, 42}};
     CHECK(get_fwd(e) == 42);
 }
 
 TEST_CASE("doubleton env", "[env]") {
-    auto e = async::env{async::prop{get_fwd, 42}, async::prop{get_nofwd, 17}};
+    auto const e =
+        async::env{async::prop{get_fwd, 42}, async::prop{get_nofwd, 17}};
     CHECK(get_fwd(e) == 42);
     CHECK(get_nofwd(e) == 17);
 }
 
 TEST_CASE("env with duplicate property looks up the first one", "[env]") {
-    auto e = async::env{async::prop{get_fwd, 42}, async::prop{get_fwd, 17}};
+    auto const e =
+        async::env{async::prop{get_fwd, 42}, async::prop{get_fwd, 17}};
     CHECK(get_fwd(e) == 42);
 }
 
 TEST_CASE("forwarding_env screens non-forwarding queries", "[env]") {
-    auto e = async::env{async::prop{get_fwd, 42},
-                        async::forwarding_env{async::prop{get_nofwd, 17}}};
+    auto const e =
+        async::env{async::prop{get_fwd, 42},
+                   async::forwarding_env{async::prop{get_nofwd, 17}}};
+    CHECK(get_fwd(e) == 42);
     CHECK(get_nofwd(e) == none{});
 }
 
 TEST_CASE("env composition", "[env]") {
-    auto e1 = async::env{async::prop{get_fwd, 42}};
-    auto e2 = async::env{async::prop{get_fwd, 17}};
-    auto e = async::env{e1, e2};
+    auto const e1 = async::env{async::prop{get_fwd, 42}};
+    auto const e2 = async::env{async::prop{get_fwd, 17}};
+    auto const e = async::env{e1, e2};
     CHECK(get_fwd(e) == 42);
 }
 
 TEST_CASE("env composition (by ref)", "[env]") {
-    auto e1 = async::env{async::prop{get_fwd, 42}};
-    auto e2 = async::env{async::prop{get_nofwd, 17}};
-    auto e = async::env{std::cref(e1), std::cref(e2)};
+    auto const e1 = async::env{async::prop{get_fwd, 42}};
+    auto const e2 = async::env{async::prop{get_nofwd, 17}};
+    auto const e = async::env{std::cref(e1), std::cref(e2)};
     CHECK(get_fwd(e) == 42);
     CHECK(get_nofwd(e) == 17);
 }
@@ -70,7 +85,32 @@ struct test_queryable {
 } // namespace
 
 TEST_CASE("forwarding_env_of", "[env]") {
-    auto e = async::forward_env_of(test_queryable{});
+    auto const e = async::forward_env_of(test_queryable{});
     CHECK(get_fwd(e) == 42);
     CHECK(get_nofwd(e) == none{});
+}
+
+TEST_CASE("template query prop", "[env]") {
+    auto const e =
+        async::make_template_prop<async::get_completion_scheduler_t,
+                                  async::set_value_t, async::set_error_t,
+                                  async::set_stopped_t>(42);
+    CHECK(async::get_completion_scheduler<async::set_value_t>(e) == 42);
+    CHECK(async::get_completion_scheduler<async::set_error_t>(e) == 42);
+    CHECK(async::get_completion_scheduler<async::set_stopped_t>(e) == 42);
+}
+
+TEST_CASE("valid_query_for", "[env]") {
+    static_assert(
+        async::detail::valid_query_for<async::get_env_t, test_queryable>);
+    static_assert(
+        not async::detail::valid_query_for<async::get_env_t, async::empty_env>);
+}
+
+TEST_CASE("valid_query_over", "[env]") {
+    static_assert(
+        async::detail::valid_query_over<async::get_env_t, async::empty_env,
+                                        test_queryable>);
+    static_assert(not async::detail::valid_query_over<async::get_env_t,
+                                                      async::empty_env>);
 }

--- a/test/read_env.cpp
+++ b/test/read_env.cpp
@@ -21,7 +21,7 @@ TEST_CASE("read_env advertises what it sends", "[read_env]") {
     using ST = async::stop_token_of_t<E>;
     static_assert(
         async::sender_of<decltype(async::read_env(async::get_stop_token_t{})),
-                         async::set_value_t(ST), E>);
+                         async::set_value_t(ST const &), E>);
     static_assert(std::is_same_v<
                   async::completion_signatures_of_t<decltype(async::read_env(
                       async::get_stop_token_t{}))>,


### PR DESCRIPTION
Most environments only need to specify one or two properties.