### PR TITLE
:zap: Improve `when_all` for senders that complete synchronously

### DIFF
--- a/include/async/just.hpp
+++ b/include/async/just.hpp
@@ -51,7 +51,7 @@ template <typename Tag, typename... Vs> struct sender {
 
     [[nodiscard]] constexpr auto query(get_env_t) const noexcept {
         return env{prop{get_allocator_t{}, stack_allocator{}},
-                   prop{completes_synchronously_t{}, true}};
+                   prop{completes_synchronously_t{}, std::true_type{}}};
     }
 };
 } // namespace _just

--- a/include/async/just_result_of.hpp
+++ b/include/async/just_result_of.hpp
@@ -70,7 +70,7 @@ template <typename Tag, std::invocable... Fs> struct sender : Fs... {
 
     [[nodiscard]] constexpr auto query(get_env_t) const noexcept {
         return env{prop{get_allocator_t{}, stack_allocator{}},
-                   prop{completes_synchronously_t{}, true}};
+                   prop{completes_synchronously_t{}, std::true_type{}}};
     }
 };
 } // namespace _just_result_of

--- a/include/async/schedulers/inline_scheduler.hpp
+++ b/include/async/schedulers/inline_scheduler.hpp
@@ -30,7 +30,7 @@ class inline_scheduler {
 
         [[nodiscard]] static constexpr auto query(get_env_t) noexcept {
             return env{prop{get_allocator_t{}, stack_allocator{}},
-                       prop{completes_synchronously_t{}, true},
+                       prop{completes_synchronously_t{}, std::true_type{}},
                        prop{get_completion_scheduler<set_value_t>,
                             inline_scheduler{}}};
         }

--- a/test/when_all.cpp
+++ b/test/when_all.cpp
@@ -1,5 +1,6 @@
 #include "detail/common.hpp"
 
+#include <async/allocator.hpp>
 #include <async/concepts.hpp>
 #include <async/connect.hpp>
 #include <async/just.hpp>
@@ -247,4 +248,20 @@ TEST_CASE("when_all with one arg is a no-op", "[when_all]") {
     auto s = async::just(42);
     [[maybe_unused]] auto w = async::when_all(s);
     static_assert(std::same_as<decltype(s), decltype(w)>);
+}
+
+TEST_CASE("nullary when_all has a stack allocator", "[when_all]") {
+    static_assert(
+        std::is_same_v<
+            async::allocator_of_t<async::env_of_t<decltype(async::when_all())>>,
+            async::stack_allocator>);
+}
+
+TEST_CASE("when_all has a stack allocator when all its subsenders do",
+          "[when_all]") {
+    static_assert(
+        std::is_same_v<
+            async::allocator_of_t<async::env_of_t<decltype(async::when_all(
+                async::just(42), async::just(17)))>>,
+            async::stack_allocator>);
 }


### PR DESCRIPTION
This PR (2 commits) improves codegen for senders (like MMIO bus senders) that don't actually exercise asynchrony.

For example:
``` cpp
int value{};
auto j1 = just(42);
auto j2 = just(17);
auto s = when_all(j1, j2) | then([&] (auto i, auto j) { return i + j; });
auto result = start_detached(s);
return value;
```

Using clang-18 with `-O3` and `-fno-exceptions` on a local CE, this change goes from 91 instructions down to 2 (`mov eax, 87; ret`).