### PR TITLE
Synchronous senders implicitly use the stack allocator

### DIFF
--- a/include/async/completes_synchronously.hpp
+++ b/include/async/completes_synchronously.hpp
@@ -1,7 +1,9 @@
 #pragma once
 
+#include <async/env.hpp>
 #include <async/forwarding_query.hpp>
 
+#include <type_traits>
 #include <utility>
 
 namespace async {
@@ -14,6 +16,9 @@ constexpr inline struct completes_synchronously_t : forwarding_query_t {
         return std::forward<T>(t).query(*this);
     }
 
-    constexpr auto operator()(auto &&) const -> bool { return false; }
+    constexpr auto operator()(auto &&) const -> std::false_type { return {}; }
 } completes_synchronously{};
+
+template <typename S>
+concept sync_sender = static_cast<bool>(completes_synchronously(env_of_t<S>{}));
 } // namespace async

--- a/include/async/just.hpp
+++ b/include/async/just.hpp
@@ -1,12 +1,10 @@
 #pragma once
 
-#include <async/allocator.hpp>
 #include <async/completes_synchronously.hpp>
 #include <async/completion_tags.hpp>
 #include <async/concepts.hpp>
 #include <async/connect.hpp>
 #include <async/env.hpp>
-#include <async/stack_allocator.hpp>
 #include <async/type_traits.hpp>
 
 #include <stdx/concepts.hpp>
@@ -50,8 +48,7 @@ template <typename Tag, typename... Vs> struct sender {
     }
 
     [[nodiscard]] constexpr auto query(get_env_t) const noexcept {
-        return env{prop{get_allocator_t{}, stack_allocator{}},
-                   prop{completes_synchronously_t{}, std::true_type{}}};
+        return prop{completes_synchronously_t{}, std::true_type{}};
     }
 };
 } // namespace _just

--- a/include/async/just_result_of.hpp
+++ b/include/async/just_result_of.hpp
@@ -1,11 +1,9 @@
 #pragma once
 
-#include <async/allocator.hpp>
 #include <async/completes_synchronously.hpp>
 #include <async/concepts.hpp>
 #include <async/connect.hpp>
 #include <async/env.hpp>
-#include <async/stack_allocator.hpp>
 #include <async/type_traits.hpp>
 
 #include <stdx/concepts.hpp>
@@ -69,8 +67,7 @@ template <typename Tag, std::invocable... Fs> struct sender : Fs... {
             boost::mp11::mp_not_fn<std::is_void>>>;
 
     [[nodiscard]] constexpr auto query(get_env_t) const noexcept {
-        return env{prop{get_allocator_t{}, stack_allocator{}},
-                   prop{completes_synchronously_t{}, std::true_type{}}};
+        return prop{completes_synchronously_t{}, std::true_type{}};
     }
 };
 } // namespace _just_result_of

--- a/include/async/schedulers/inline_scheduler.hpp
+++ b/include/async/schedulers/inline_scheduler.hpp
@@ -1,12 +1,10 @@
 #pragma once
 
-#include <async/allocator.hpp>
 #include <async/completes_synchronously.hpp>
 #include <async/concepts.hpp>
 #include <async/connect.hpp>
 #include <async/env.hpp>
 #include <async/get_completion_scheduler.hpp>
-#include <async/stack_allocator.hpp>
 #include <async/type_traits.hpp>
 
 #include <stdx/concepts.hpp>
@@ -29,8 +27,7 @@ class inline_scheduler {
             async::completion_signatures<set_value_t()>;
 
         [[nodiscard]] static constexpr auto query(get_env_t) noexcept {
-            return env{prop{get_allocator_t{}, stack_allocator{}},
-                       prop{completes_synchronously_t{}, std::true_type{}},
+            return env{prop{completes_synchronously_t{}, std::true_type{}},
                        prop{get_completion_scheduler<set_value_t>,
                             inline_scheduler{}}};
         }

--- a/include/async/when_all.hpp
+++ b/include/async/when_all.hpp
@@ -1,12 +1,10 @@
 #pragma once
 
-#include <async/allocator.hpp>
 #include <async/completes_synchronously.hpp>
 #include <async/completion_tags.hpp>
 #include <async/concepts.hpp>
 #include <async/connect.hpp>
 #include <async/env.hpp>
-#include <async/stack_allocator.hpp>
 #include <async/stop_token.hpp>
 
 #include <stdx/concepts.hpp>
@@ -339,9 +337,6 @@ struct sync_op_state
     [[no_unique_address]] Rcvr rcvr;
 };
 
-template <typename S>
-concept sync_sender = static_cast<bool>(completes_synchronously(env_of_t<S>{}));
-
 template <typename S, typename R>
 concept not_stoppable = not stoppable_sender<S, env_of_t<R>>;
 
@@ -397,8 +392,7 @@ template <typename... Sndrs> struct sender : Sndrs... {
 
     [[nodiscard]] constexpr static auto query(get_env_t) {
         if constexpr ((... and sync_sender<Sndrs>)) {
-            return env{prop{get_allocator_t{}, stack_allocator{}},
-                       prop{completes_synchronously_t{}, std::true_type{}}};
+            return prop{completes_synchronously_t{}, std::true_type{}};
         } else {
             return empty_env{};
         }
@@ -443,8 +437,7 @@ template <> struct sender<> {
     }
 
     [[nodiscard]] constexpr static auto query(get_env_t) noexcept {
-        return env{prop{get_allocator_t{}, stack_allocator{}},
-                   prop{completes_synchronously_t{}, std::true_type{}}};
+        return prop{completes_synchronously_t{}, std::true_type{}};
     }
 };
 } // namespace _when_all

--- a/test/allocator.cpp
+++ b/test/allocator.cpp
@@ -133,3 +133,19 @@ TEST_CASE("static allocator is an allocator", "[allocator]") {
 TEST_CASE("stack allocator is an allocator", "[allocator]") {
     static_assert(async::allocator<async::stack_allocator>);
 }
+
+TEST_CASE("sender that completes synchronously defaults to a stack allocator",
+          "[allocator]") {
+    [[maybe_unused]] auto s = async::inline_scheduler{}.schedule();
+    static_assert(
+        std::is_same_v<async::allocator_of_t<async::env_of_t<decltype(s)>>,
+                       async::stack_allocator>);
+}
+
+TEST_CASE("sender that completes asynchronously defaults to a static allocator",
+          "[allocator]") {
+    [[maybe_unused]] auto s = async::thread_scheduler{}.schedule();
+    static_assert(
+        std::is_same_v<async::allocator_of_t<async::env_of_t<decltype(s)>>,
+                       async::static_allocator>);
+}


### PR DESCRIPTION
- if a sender is marked to complete synchronously, it doesn't need to also specify that it uses a stack allocator: that is implicit.
- `start_detached` allows passing an environment which will be used to determine the allocator, and also used in the receiver.