### PR TITLE
:sparkles: Add `stop_detached`

### DIFF
--- a/docs/sender_consumers.adoc
+++ b/docs/sender_consumers.adoc
@@ -21,11 +21,13 @@ auto started = async::start_detached(sndr);
 
 If a sender starts detached, its operation state has to be allocated somewhere.
 That is achieved through an xref:attributes.adoc#_allocator[allocator]
-determined from the sender's attributes.
+determined from the sender's attributes. Without further customization, if a
+sender completes synchronously, it will use the `stack_allocator` by default.
+Otherwise it will use the `static_allocator`.
 
 To hook into the static xref:attributes.adoc#_allocator[allocation strategy], a
 template argument (representing the name of the allocation domain) can be given
-to `start_detached`.
+to `start_detached`. This is used to select a static allocator.
 
 [source,cpp]
 ----
@@ -33,9 +35,24 @@ auto result = async::start_detached<struct Name>(s);
 ----
 
 The default template argument results in a different `static_allocator` for each
-call site, with a default allocation limit of 1. If the allocator's `construct` method
-returns `false` (presumably because the allocation limit has been reached),
-the result of `start_detached` is an empty optional.
+call site, with a default allocation limit of 1. If a name is given, that name
+is used to specialize the `static_allocator`, and can be used with
+xref:sender_consumers.adoc#_stop_detached[`stop_detached`] to request
+cancellation.
+
+If the allocator's `construct` method returns `false` (presumably because the
+allocation limit has been reached), the result of `start_detached` is an empty
+optional.
+
+An extra xref:environments.adoc#_environments[environment] may be given to
+`start_detached` in order to control sender behaviour, or to specify a custom
+allocator:
+
+[source,cpp]
+----
+auto result = async::start_detached(
+    s, async::prop{async::get_allocator_t{}, custom_allocator{}}));
+----
 
 === `start_detached_unstoppable`
 
@@ -53,6 +70,33 @@ required.
 ----
 auto result = async::start_detached_unstoppable<struct Name>(s);
 ----
+
+=== `stop_detached`
+
+Found in the header: `async/start_detached.hpp`
+
+A sender started with `start_detached` may be cancelled with `stop_detached`,
+using the same template argument:
+
+[source,cpp]
+----
+struct Name;
+auto result = async::start_detached<Name>(s);
+
+// later, in another context...
+auto stop_requested = async::stop_detached<Name>(); // true if a stop was requested
+----
+
+`stop_detached` will return `false` if it cannot request a stop:
+
+* because no sender with that name was given to `start_detached`
+* because the sender has already completed
+* because a stop was already requested
+* because the sender was started using `start_detached_unstoppable`
+* because the associated allocator supports multiple operation states, so a
+  single template argument is not sufficient to determine which one to stop (in
+  this case, the return value of `start_detached` may be used to request
+  cancellation)
 
 === `sync_wait`
 

--- a/docs/synopsis.adoc
+++ b/docs/synopsis.adoc
@@ -148,6 +148,7 @@ xref:schedulers.adoc#_time_scheduler[time_scheduler].
 ==== https://github.com/intel/cpp-baremetal-senders-and-receivers/blob/main/include/async/start_detached.hpp[start_detached.hpp]
 * `start_detached` - a xref:sender_consumers.adoc#_start_detached[sender consumer] that starts a sender without waiting for it to complete
 * `start_detached_unstoppable` - a xref:sender_consumers.adoc#_start_detached_unstoppable[sender consumer] that starts a sender without waiting for it to complete, without a provision for cancellation
+* `stop_detached` - a function that may request cancellation of a sender started with `start_detached`
 
 ==== https://github.com/intel/cpp-baremetal-senders-and-receivers/blob/main/include/async/start_on.hpp[start_on.hpp]
 * `start_on` - a xref:sender_adaptors.adoc#_start_on[sender adaptor] that starts execution on a given scheduler
@@ -249,6 +250,7 @@ contains traits and metaprogramming constructs used by many senders.
 * xref:sender_adaptors.adoc#_start_on[`start_on`] - https://github.com/intel/cpp-baremetal-senders-and-receivers/blob/main/include/async/schedulers/start_on.hpp[`#include <async/start_on.hpp>`]
 * `static_allocation_limit<Domain>` - https://github.com/intel/cpp-baremetal-senders-and-receivers/blob/main/include/async/schedulers/static_allocator.hpp[`#include <async/static_allocator.hpp>`]
 * xref:attributes.adoc#_allocator[`static_allocator`] - https://github.com/intel/cpp-baremetal-senders-and-receivers/blob/main/include/async/schedulers/static_allocator.hpp[`#include <async/static_allocator.hpp>`]
+* xref:sender_consumers.adoc#_stop_detached[`stop_detached`] - https://github.com/intel/cpp-baremetal-senders-and-receivers/blob/main/include/async/schedulers/start_detached.hpp[`#include <async/start_detached.hpp>`]
 * `stop_token_of_t` - https://github.com/intel/cpp-baremetal-senders-and-receivers/blob/main/include/async/schedulers/stop_token.hpp[`#include <async/stop_token.hpp>`]
 * xref:sender_adaptors.adoc#_when_any[`stop_when`] - https://github.com/intel/cpp-baremetal-senders-and-receivers/blob/main/include/async/schedulers/when_any.hpp[`#include <async/when_any.hpp>`]
 * xref:sender_consumers.adoc#_sync_wait[`sync_wait`] - https://github.com/intel/cpp-baremetal-senders-and-receivers/blob/main/include/async/schedulers/sync_wait.hpp[`#include <async/sync_wait.hpp>`]

--- a/include/async/allocator.hpp
+++ b/include/async/allocator.hpp
@@ -25,6 +25,9 @@ concept allocator = std::is_empty_v<T> and requires(
             [](archetypes::constructible) {}, 0)
     } -> std::same_as<bool>;
     { T::template destruct<archetypes::domain>(p) } -> std::same_as<void>;
+    {
+        T::template allocation_limit<archetypes::domain>
+    } -> std::same_as<std::size_t const &>;
 };
 
 constexpr inline struct get_allocator_t : forwarding_query_t {

--- a/include/async/stack_allocator.hpp
+++ b/include/async/stack_allocator.hpp
@@ -19,5 +19,7 @@ struct stack_allocator {
     }
 
     template <typename, typename T> static auto destruct(T const *) -> void {}
+
+    template <typename> constexpr static auto allocation_limit = std::size_t{};
 };
 } // namespace async

--- a/include/async/static_allocator.hpp
+++ b/include/async/static_allocator.hpp
@@ -72,5 +72,8 @@ struct static_allocator {
             detail::static_allocator_v<Name, T, static_allocation_limit<Name>>;
         a.destruct(t);
     }
+
+    template <typename Name>
+    constexpr static auto allocation_limit = static_allocation_limit<Name>;
 };
 } // namespace async

--- a/include/async/stop_token.hpp
+++ b/include/async/stop_token.hpp
@@ -68,6 +68,9 @@ struct stop_callback_base {
 struct inplace_stop_source {
     struct mutex;
 
+    constexpr inplace_stop_source() = default;
+    constexpr explicit(true) inplace_stop_source(bool b) : requested{b} {}
+
     [[nodiscard]] auto stop_requested() const noexcept -> bool {
         return requested.load();
     }


### PR DESCRIPTION
`stop_detached<Tag>()` may request cancellation of a sender started with `start_detached<Tag>(s)`.