### PR TITLE
:loud_sound: Add debug hooks for sender factories

### DIFF
--- a/docs/schedulers.adoc
+++ b/docs/schedulers.adoc
@@ -15,6 +15,14 @@ using S = async::fixed_priority_scheduler<0>; // highest priority
 NOTE: The intended use case for `fixed_priority_scheduler` is to schedule tasks
 to be executed on prioritized interrupts.
 
+A `fixed_priority_scheduler` can be given a name which is used to output debug events.
+The default name is `"fixed_priority_scheduler"`.
+
+[source,cpp]
+----
+auto s = async::fixed_priority_scheduler<0, "my scheduler">{};
+----
+
 The `fixed_priority_scheduler` works hand in glove with a `task_manager` that
 manages tasks in priority order. A `priority_task_manager` is provided and may
 be used by providing a HAL, and by specializing the `injected_task_manager`
@@ -75,6 +83,14 @@ async::start_detached(s);
 // i is now 42
 ----
 
+An `inline_scheduler` can be given a name which is used to output debug events.
+The default name is `"inline_scheduler"`.
+
+[source,cpp]
+----
+auto s = async::inline_scheduler<"my scheduler">{};
+----
+
 CAUTION: The `inline_scheduler` may cause stack overflows when used with certain
 adaptors like xref:sender_adaptors.adoc#_repeat[`repeat`] or
 xref:sender_adaptors.adoc#_retry[`retry`].
@@ -115,6 +131,14 @@ auto s = async::start_on(async::thread_scheduler{},
 async::start_detached(s);
 // without some other sync mechanism, this is risky:
 // there is now a detached thread running that will update x at some point
+----
+
+A `thread_scheduler` can be given a name which is used to output debug events.
+The default name is `"thread_scheduler"`.
+
+[source,cpp]
+----
+auto s = async::thread_scheduler<"my scheduler">{};
 ----
 
 === `time_scheduler`
@@ -232,6 +256,15 @@ auto alt_timer_interrupt_service_routine() {
 }
 
 // and now x is 42
+----
+
+A `time_scheduler_factory` can be given a name that it passes on to the
+schedulers it creates, and which is used to output debug events. The default
+name is `"time_scheduler"`.
+
+[source,cpp]
+----
+auto sched_factory = async::time_scheduler_factory<alt_domain, "my scheduler">;
 ----
 
 === `trigger_scheduler`

--- a/docs/sender_factories.adoc
+++ b/docs/sender_factories.adoc
@@ -13,6 +13,14 @@ auto sndr = async::just(42, 17);
 // sndr produces (sends) the values 42 and 17
 ----
 
+`just` can be given a name that is used for debug events. By default, its name
+is `"just"`.
+
+[source,cpp]
+----
+auto sndr = async::just<"the answer">(42);
+----
+
 [NOTE]
 .For functional programmers
 ====
@@ -33,6 +41,14 @@ auto sndr = async::just_error(42);
 // sndr produces (sends) the value 42 on the error channel
 ----
 
+`just_error` can be given a name that is used for debug events. By default, its name
+is `"just_error"`.
+
+[source,cpp]
+----
+auto sndr = async::just_error<"oops">(42);
+----
+
 === `just_error_result_of`
 
 Found in the header: `async/just_result_of.hpp`
@@ -49,6 +65,14 @@ auto sndr2 = async::just_error_result_of([] { return 42; },
                                          [] { do_something(); });
 // sndr2 also sends 42 on the error channel,
 // as well as executing do_something() - which returns void
+----
+
+`just_error_result_of` can be given a name that is used for debug events. By default, its name
+is `"just_error_result_of"`.
+
+[source,cpp]
+----
+auto sndr = async::just_error_result_of<"oops">([] { return 42; });
 ----
 
 NOTE: Do not rely on the order of evaluation of the functions given to
@@ -78,6 +102,14 @@ auto sndr2 = async::just_result_of([] { return 42; },
 // as well as executing do_something() - which returns void
 ----
 
+`just_result_of` can be given a name that is used for debug events. By default, its name
+is `"just_result_of"`.
+
+[source,cpp]
+----
+auto sndr = async::just_result_of<"the answer">([] { return 42; });
+----
+
 NOTE: Do not rely on the order of evaluation of the functions given to
 `just_result_of`!
 
@@ -104,6 +136,14 @@ auto sndr = async::just_stopped();
 // sndr completes on the stopped channel
 ----
 
+`just_stopped` can be given a name that is used for debug events. By default, its name
+is `"just_stopped"`.
+
+[source,cpp]
+----
+auto sndr = async::just_stopped<"cancel">();
+----
+
 === `read_env`
 
 Found in the header: `async/read_env.hpp`
@@ -123,6 +163,17 @@ auto s = async::read_env(async::get_stop_token_t{});
 ----
 auto s1 = async::get_stop_token(); // same as async::read_env(async::get_stop_token_t{});
 auto s2 = async::get_scheduler();  // same as async::read_env(async::get_scheduler_t{});
+----
+
+`read_env` (and its tag aliases) can be given a name that is used for debug
+events. By default, the name is the name exposed by the tag, or if there is no
+such name, `"read_env"`.
+
+[source,cpp]
+----
+auto s1 = async::get_stop_token<"gst">(); // name = "gst"
+auto s2 = async::get_stop_token();        // name = "get_stop_token"
+auto s3 = async::read_env(unnamed_tag{}); // name = "read_env"
 ----
 
 === `schedule`

--- a/include/async/allocator.hpp
+++ b/include/async/allocator.hpp
@@ -5,6 +5,8 @@
 #include <async/stack_allocator.hpp>
 #include <async/static_allocator.hpp>
 
+#include <stdx/ct_string.hpp>
+
 #include <type_traits>
 #include <utility>
 
@@ -31,6 +33,8 @@ concept allocator = std::is_empty_v<T> and requires(
 };
 
 constexpr inline struct get_allocator_t : forwarding_query_t {
+    constexpr static auto name = stdx::ct_string{"get_allocator"};
+
     template <typename T>
         requires true // more constrained
     constexpr auto operator()(T &&t) const noexcept(

--- a/include/async/completes_synchronously.hpp
+++ b/include/async/completes_synchronously.hpp
@@ -3,11 +3,15 @@
 #include <async/env.hpp>
 #include <async/forwarding_query.hpp>
 
+#include <stdx/ct_string.hpp>
+
 #include <type_traits>
 #include <utility>
 
 namespace async {
 constexpr inline struct completes_synchronously_t : forwarding_query_t {
+    constexpr static auto name = stdx::ct_string{"completes_synchronously"};
+
     template <typename T>
         requires true // more constrained
     constexpr auto operator()(T &&t) const noexcept(noexcept(

--- a/include/async/completion_tags.hpp
+++ b/include/async/completion_tags.hpp
@@ -8,6 +8,7 @@
 namespace async {
 constexpr inline struct set_value_t {
     constexpr static auto name = stdx::ct_string{"set_value"};
+
     template <typename R, typename... Ts>
     constexpr auto operator()(R &&r, Ts &&...ts) const noexcept(
         noexcept(std::forward<R>(r).set_value(std::forward<Ts>(ts)...)))
@@ -20,6 +21,7 @@ constexpr inline struct set_value_t {
 
 constexpr inline struct set_error_t {
     constexpr static auto name = stdx::ct_string{"set_error"};
+
     template <typename R, typename... Ts>
     constexpr auto operator()(R &&r, Ts &&...ts) const noexcept(
         noexcept(std::forward<R>(r).set_error(std::forward<Ts>(ts)...)))
@@ -32,6 +34,7 @@ constexpr inline struct set_error_t {
 
 constexpr inline struct set_stopped_t {
     constexpr static auto name = stdx::ct_string{"set_stopped"};
+
     template <typename R>
     constexpr auto operator()(R &&r) const
         noexcept(noexcept(std::forward<R>(r).set_stopped()))

--- a/include/async/debug.hpp
+++ b/include/async/debug.hpp
@@ -72,6 +72,8 @@ using default_interface = named_interface<"unknown">;
 } // namespace debug
 
 constexpr inline struct get_debug_interface_t : forwarding_query_t {
+    constexpr static auto name = stdx::ct_string{"get_debug_interface"};
+
     template <typename T>
         requires true // more constrained
     [[nodiscard]] constexpr auto operator()(T &&t) const noexcept(noexcept(

--- a/include/async/get_completion_scheduler.hpp
+++ b/include/async/get_completion_scheduler.hpp
@@ -2,10 +2,14 @@
 
 #include <async/forwarding_query.hpp>
 
+#include <stdx/ct_string.hpp>
+
 #include <utility>
 
 namespace async {
 template <typename Tag> struct get_completion_scheduler_t : forwarding_query_t {
+    constexpr static auto name = stdx::ct_string{"get_completion_scheduler"};
+
     template <typename T>
     constexpr auto operator()(T &&t) const noexcept(noexcept(
         std::forward<T>(t).query(std::declval<get_completion_scheduler_t>())))

--- a/include/async/get_completion_signatures.hpp
+++ b/include/async/get_completion_signatures.hpp
@@ -2,11 +2,15 @@
 
 #include <async/env.hpp>
 
+#include <stdx/ct_string.hpp>
+
 #include <type_traits>
 #include <utility>
 
 namespace async {
 constexpr inline struct get_completion_signatures_t {
+    constexpr static auto name = stdx::ct_string{"get_completion_signatures"};
+
     template <typename S, typename E>
     constexpr auto operator()(S &&s, E &&e) const noexcept(noexcept(
         std::forward<S>(s).get_completion_signatures(std::forward<E>(e))))

--- a/include/async/get_scheduler.hpp
+++ b/include/async/get_scheduler.hpp
@@ -2,12 +2,15 @@
 
 #include <async/forwarding_query.hpp>
 
+#include <stdx/ct_string.hpp>
 #include <stdx/type_traits.hpp>
 
 #include <utility>
 
 namespace async {
 struct get_scheduler_t : forwarding_query_t {
+    constexpr static auto name = stdx::ct_string{"get_scheduler"};
+
     template <typename T>
     constexpr auto operator()(T &&t) const noexcept(
         noexcept(std::forward<T>(t).query(std::declval<get_scheduler_t>())))

--- a/include/async/schedulers/inline_scheduler.hpp
+++ b/include/async/schedulers/inline_scheduler.hpp
@@ -3,22 +3,28 @@
 #include <async/completes_synchronously.hpp>
 #include <async/concepts.hpp>
 #include <async/connect.hpp>
+#include <async/debug.hpp>
 #include <async/env.hpp>
 #include <async/get_completion_scheduler.hpp>
 #include <async/type_traits.hpp>
 
 #include <stdx/concepts.hpp>
+#include <stdx/ct_string.hpp>
 
 #include <concepts>
 #include <type_traits>
 #include <utility>
 
 namespace async {
-class inline_scheduler {
+template <stdx::ct_string Name = "inline_scheduler"> class inline_scheduler {
     template <typename R> struct op_state {
         [[no_unique_address]] R receiver;
 
-        constexpr auto start() & -> void { set_value(std::move(receiver)); }
+        constexpr auto start() & -> void {
+            debug_signal<"start", Name, op_state>(get_env(receiver));
+            debug_signal<"set_value", Name, op_state>(get_env(receiver));
+            set_value(std::move(receiver));
+        }
 
         [[nodiscard]] constexpr auto query(get_env_t) const noexcept {
             return prop{completes_synchronously_t{}, std::true_type{}};

--- a/include/async/schedulers/thread_scheduler.hpp
+++ b/include/async/schedulers/thread_scheduler.hpp
@@ -6,11 +6,13 @@
 
 #include <async/concepts.hpp>
 #include <async/connect.hpp>
+#include <async/debug.hpp>
 #include <async/env.hpp>
 #include <async/get_completion_scheduler.hpp>
 #include <async/type_traits.hpp>
 
 #include <stdx/concepts.hpp>
+#include <stdx/ct_string.hpp>
 
 #include <concepts>
 #include <thread>
@@ -18,12 +20,16 @@
 #include <utility>
 
 namespace async {
-class thread_scheduler {
+template <stdx::ct_string Name = "thread_scheduler"> class thread_scheduler {
     template <typename R> struct op_state {
         [[no_unique_address]] R receiver;
 
         auto start() & -> void {
-            std::thread{[&] { set_value(std::move(receiver)); }}.detach();
+            debug_signal<"start", Name, op_state>(get_env(receiver));
+            std::thread{[&] {
+                debug_signal<"set_value", Name, op_state>(get_env(receiver));
+                set_value(std::move(receiver));
+            }}.detach();
         }
     };
 

--- a/include/async/stop_token.hpp
+++ b/include/async/stop_token.hpp
@@ -3,6 +3,7 @@
 #include <async/forwarding_query.hpp>
 #include <conc/concurrency.hpp>
 
+#include <stdx/ct_string.hpp>
 #include <stdx/intrusive_list.hpp>
 
 #include <atomic>
@@ -193,6 +194,8 @@ template <typename F> struct inplace_stop_callback final : stop_callback_base {
 };
 
 struct get_stop_token_t : forwarding_query_t {
+    constexpr static auto name = stdx::ct_string{"get_stop_token"};
+
     template <typename T>
         requires true // more constrained
     constexpr auto operator()(T &&t) const noexcept(

--- a/test/continue_on.cpp
+++ b/test/continue_on.cpp
@@ -151,8 +151,8 @@ TEST_CASE("move-only value", "[continue_on]") {
 
 TEST_CASE("singleshot continue_on", "[continue_on]") {
     auto sched1 = test_scheduler<1>{};
-    [[maybe_unused]] auto n = async::inline_scheduler::schedule<
-                                  async::inline_scheduler::singleshot>() |
+    [[maybe_unused]] auto n = async::inline_scheduler<>::schedule<
+                                  async::inline_scheduler<>::singleshot>() |
                               async::continue_on(sched1);
     static_assert(async::singleshot_sender<decltype(n), universal_receiver>);
 }

--- a/test/freestanding_sync_wait.cpp
+++ b/test/freestanding_sync_wait.cpp
@@ -22,14 +22,14 @@
 #include <fmt/format.h>
 
 TEST_CASE("sync_wait for inline scheduler", "[freestanding_sync_wait]") {
-    auto value = async::inline_scheduler::schedule() |
+    auto value = async::inline_scheduler<>::schedule() |
                  async::then([] { return 42; }) | async::sync_wait();
     REQUIRE(value.has_value());
     CHECK(get<0>(*value) == 42);
 }
 
 TEST_CASE("sync_wait for thread scheduler", "[freestanding_sync_wait]") {
-    auto value = async::thread_scheduler::schedule() |
+    auto value = async::thread_scheduler<>::schedule() |
                  async::then([] { return 42; }) | async::sync_wait();
     REQUIRE(value.has_value());
     CHECK(get<0>(*value) == 42);
@@ -61,7 +61,7 @@ TEST_CASE("sync_wait with read (inline scheduler)",
                  return async::start_on(sched, async::just(42));
              });
 
-    auto value = async::inline_scheduler::schedule() |
+    auto value = async::inline_scheduler<>::schedule() |
                  async::sequence([&] { return s; }) | async::sync_wait();
     REQUIRE(value.has_value());
     CHECK(get<0>(*value) == 42);
@@ -72,7 +72,7 @@ TEST_CASE("sync_wait with read (thread scheduler", "[freestanding_sync_wait]") {
                  return async::start_on(sched, async::just(42));
              });
 
-    auto value = async::thread_scheduler::schedule() |
+    auto value = async::thread_scheduler<>::schedule() |
                  async::sequence([&] { return s; }) | async::sync_wait();
     REQUIRE(value.has_value());
     CHECK(get<0>(*value) == 42);
@@ -109,7 +109,7 @@ TEST_CASE("sync_wait can be named and debugged with a string",
     using namespace std::string_literals;
     debug_events.clear();
     int var{};
-    using S = async::inline_scheduler;
+    using S = async::inline_scheduler<>;
     auto s = S::schedule() | async::then([&] { var = 42; });
     CHECK(async::sync_wait<"op">(s));
     CHECK(var == 42);

--- a/test/hosted_sync_wait.cpp
+++ b/test/hosted_sync_wait.cpp
@@ -20,14 +20,14 @@
 #include <fmt/format.h>
 
 TEST_CASE("sync_wait for inline scheduler", "[hosted_sync_wait]") {
-    auto value = async::inline_scheduler::schedule() |
+    auto value = async::inline_scheduler<>::schedule() |
                  async::then([] { return 42; }) | async::sync_wait();
     REQUIRE(value.has_value());
     CHECK(get<0>(*value) == 42);
 }
 
 TEST_CASE("sync_wait for thread scheduler", "[hosted_sync_wait]") {
-    auto value = async::thread_scheduler::schedule() |
+    auto value = async::thread_scheduler<>::schedule() |
                  async::then([] { return 42; }) | async::sync_wait();
     REQUIRE(value.has_value());
     CHECK(get<0>(*value) == 42);
@@ -58,7 +58,7 @@ TEST_CASE("sync_wait with read (inline scheduler)", "[hosted_sync_wait]") {
                  return async::start_on(sched, async::just(42));
              });
 
-    auto value = async::inline_scheduler::schedule() |
+    auto value = async::inline_scheduler<>::schedule() |
                  async::sequence([&] { return s; }) | async::sync_wait();
     REQUIRE(value.has_value());
     CHECK(get<0>(*value) == 42);
@@ -69,7 +69,7 @@ TEST_CASE("sync_wait with read (thread scheduler)", "[hosted_sync_wait]") {
                  return async::start_on(sched, async::just(42));
              });
 
-    auto value = async::thread_scheduler::schedule() |
+    auto value = async::thread_scheduler<>::schedule() |
                  async::sequence([&] { return s; }) | async::sync_wait();
     REQUIRE(value.has_value());
     CHECK(get<0>(*value) == 42);
@@ -105,7 +105,7 @@ TEST_CASE("sync_wait can be named and debugged with a string",
     using namespace std::string_literals;
     debug_events.clear();
     int var{};
-    using S = async::inline_scheduler;
+    using S = async::inline_scheduler<>;
     auto s = S::schedule() | async::then([&] { var = 42; });
     CHECK(async::sync_wait<"op">(s));
     CHECK(var == 42);

--- a/test/repeat.cpp
+++ b/test/repeat.cpp
@@ -138,7 +138,7 @@ TEST_CASE("repeat may complete synchronously", "[repeat]") {
 TEST_CASE("repeat may not complete synchronously", "[repeat]") {
     int var{};
     auto sub =
-        async::thread_scheduler::schedule() | async::then([&] { ++var; });
+        async::thread_scheduler<>::schedule() | async::then([&] { ++var; });
     auto s = async::repeat_until(sub, [&](auto i) { return i == 42; });
     static_assert(not async::synchronous<decltype(s)>);
 }
@@ -156,7 +156,7 @@ TEST_CASE("repeat op state may be synchronous", "[repeat]") {
 
 TEST_CASE("repeat op state may not be synchronous", "[repeat]") {
     int var{};
-    auto sub = async::thread_scheduler::schedule() | async::then([&] {
+    auto sub = async::thread_scheduler<>::schedule() | async::then([&] {
                    ++var;
                    return var;
                });

--- a/test/retry.cpp
+++ b/test/retry.cpp
@@ -111,7 +111,7 @@ TEST_CASE("retry may complete synchronously", "[retry]") {
 TEST_CASE("retry may not complete synchronously", "[retry]") {
     int var{};
     auto sub =
-        async::thread_scheduler::schedule() | async::then([&] { ++var; });
+        async::thread_scheduler<>::schedule() | async::then([&] { ++var; });
     auto s = async::retry_until(sub, [&](auto i) { return i == 42; });
     static_assert(not async::synchronous<decltype(s)>);
 }
@@ -129,7 +129,7 @@ TEST_CASE("retry op state may be synchronous", "[retry]") {
 
 TEST_CASE("retry op state may not be synchronous", "[retry]") {
     int var{};
-    auto sub = async::thread_scheduler::schedule() | async::then([&] {
+    auto sub = async::thread_scheduler<>::schedule() | async::then([&] {
                    ++var;
                    return var;
                });

--- a/test/schedulers/fail/inline_scheduler_connect.cpp
+++ b/test/schedulers/fail/inline_scheduler_connect.cpp
@@ -11,5 +11,5 @@ static_assert(async::receiver<fail_receiver>);
 
 auto main() -> int {
     [[maybe_unused]] auto op =
-        async::connect(async::inline_scheduler::schedule(), fail_receiver{});
+        async::connect(async::inline_scheduler<>::schedule(), fail_receiver{});
 }

--- a/test/schedulers/fail/thread_scheduler_connect.cpp
+++ b/test/schedulers/fail/thread_scheduler_connect.cpp
@@ -11,5 +11,5 @@ static_assert(async::receiver<fail_receiver>);
 
 auto main() -> int {
     [[maybe_unused]] auto op =
-        async::connect(async::thread_scheduler::schedule(), fail_receiver{});
+        async::connect(async::thread_scheduler<>::schedule(), fail_receiver{});
 }

--- a/test/schedulers/inline_scheduler.cpp
+++ b/test/schedulers/inline_scheduler.cpp
@@ -3,21 +3,31 @@
 #include <async/allocator.hpp>
 #include <async/completes_synchronously.hpp>
 #include <async/concepts.hpp>
+#include <async/debug.hpp>
 #include <async/env.hpp>
 #include <async/get_completion_scheduler.hpp>
 #include <async/schedulers/inline_scheduler.hpp>
 #include <async/stack_allocator.hpp>
 
+#include <stdx/ct_format.hpp>
+#include <stdx/type_traits.hpp>
+
 #include <catch2/catch_test_macros.hpp>
+#include <fmt/format.h>
+
+#include <concepts>
+#include <string>
+#include <type_traits>
+#include <vector>
 
 TEST_CASE("inline_scheduler fulfils concept", "[inline_scheduler]") {
-    static_assert(async::scheduler<async::inline_scheduler>);
+    static_assert(async::scheduler<async::inline_scheduler<>>);
 }
 
 TEST_CASE("inline_scheduler start immediately completes",
           "[inline_scheduler]") {
     bool recvd{};
-    auto s = async::inline_scheduler::schedule();
+    auto s = async::inline_scheduler<>::schedule();
     auto op = async::connect(s, receiver{[&] { recvd = true; }});
     async::start(op);
     CHECK(recvd);
@@ -25,49 +35,91 @@ TEST_CASE("inline_scheduler start immediately completes",
 
 TEST_CASE("inline_scheduler sender advertises nothing", "[inline_scheduler]") {
     static_assert(
-        async::sender_of<decltype(async::inline_scheduler::schedule()),
+        async::sender_of<decltype(async::inline_scheduler<>::schedule()),
                          async::set_value_t()>);
 }
 
 TEST_CASE("singleshot inline_scheduler", "[inline_scheduler]") {
-    [[maybe_unused]] auto s = async::inline_scheduler::schedule<
-        async::inline_scheduler::singleshot>();
+    [[maybe_unused]] auto s = async::inline_scheduler<>::schedule<
+        async::inline_scheduler<>::singleshot>();
     static_assert(async::singleshot_sender<decltype(s), universal_receiver>);
 }
 
 TEST_CASE("multishot inline_scheduler", "[inline_scheduler]") {
-    [[maybe_unused]] auto s =
-        async::inline_scheduler::schedule<async::inline_scheduler::multishot>();
+    [[maybe_unused]] auto s = async::inline_scheduler<>::schedule<
+        async::inline_scheduler<>::multishot>();
     static_assert(async::multishot_sender<decltype(s), universal_receiver>);
 
-    [[maybe_unused]] auto s_default = async::inline_scheduler::schedule();
+    [[maybe_unused]] auto s_default = async::inline_scheduler<>::schedule();
     static_assert(
         async::multishot_sender<decltype(s_default), universal_receiver>);
 }
 
 TEST_CASE("sender has the inline_scheduler as its completion scheduler",
           "[inline_scheduler]") {
-    auto s1 = async::inline_scheduler::schedule();
+    auto s1 = async::inline_scheduler<>::schedule();
     auto cs1 =
         async::get_completion_scheduler<async::set_value_t>(async::get_env(s1));
-    static_assert(std::same_as<decltype(cs1), async::inline_scheduler>);
+    static_assert(std::same_as<decltype(cs1), async::inline_scheduler<>>);
 
-    auto s2 = async::inline_scheduler::schedule<
-        async::inline_scheduler::singleshot>();
+    auto s2 = async::inline_scheduler<>::schedule<
+        async::inline_scheduler<>::singleshot>();
     auto cs2 =
         async::get_completion_scheduler<async::set_value_t>(async::get_env(s2));
-    static_assert(std::same_as<decltype(cs2), async::inline_scheduler>);
+    static_assert(std::same_as<decltype(cs2), async::inline_scheduler<>>);
 }
 
 TEST_CASE("sender has a stack allocator", "[inline_scheduler]") {
     static_assert(
         std::is_same_v<async::allocator_of_t<async::env_of_t<
-                           decltype(async::inline_scheduler::schedule())>>,
+                           decltype(async::inline_scheduler<>::schedule())>>,
                        async::stack_allocator>);
 }
 
 TEST_CASE("op state is synchronous", "[inline_scheduler]") {
     [[maybe_unused]] auto op =
-        async::connect(async::inline_scheduler::schedule(), receiver{[] {}});
+        async::connect(async::inline_scheduler<>::schedule(), receiver{[] {}});
     static_assert(async::synchronous<decltype(op)>);
+}
+
+namespace {
+std::vector<std::string> debug_events{};
+
+struct debug_handler {
+    template <stdx::ct_string C, stdx::ct_string L, stdx::ct_string S,
+              typename Ctx>
+    constexpr auto signal(auto &&...) {
+        debug_events.push_back(fmt::format("{} {} {}", C, L, S));
+    }
+};
+} // namespace
+
+template <> inline auto async::injected_debug_handler<> = debug_handler{};
+
+TEST_CASE("inline_scheduler can be debugged with a string",
+          "[inline_scheduler]") {
+    using namespace std::string_literals;
+    debug_events.clear();
+    auto s = async::inline_scheduler<>::schedule();
+    auto op = async::connect(
+        s, with_env{universal_receiver{},
+                    async::prop{async::get_debug_interface_t{},
+                                async::debug::named_interface<"op">{}}});
+    async::start(op);
+    CHECK(debug_events == std::vector{"op inline_scheduler start"s,
+                                      "op inline_scheduler set_value"s});
+}
+
+TEST_CASE("inline_scheduler can be named and debugged with a string",
+          "[inline_scheduler]") {
+    using namespace std::string_literals;
+    debug_events.clear();
+    auto s = async::inline_scheduler<"sched">::schedule();
+    auto op = async::connect(
+        s, with_env{universal_receiver{},
+                    async::prop{async::get_debug_interface_t{},
+                                async::debug::named_interface<"op">{}}});
+    async::start(op);
+    CHECK(debug_events ==
+          std::vector{"op sched start"s, "op sched set_value"s});
 }

--- a/test/schedulers/thread_scheduler.cpp
+++ b/test/schedulers/thread_scheduler.cpp
@@ -3,24 +3,32 @@
 #include <async/allocator.hpp>
 #include <async/completes_synchronously.hpp>
 #include <async/concepts.hpp>
+#include <async/debug.hpp>
 #include <async/env.hpp>
 #include <async/get_completion_scheduler.hpp>
 #include <async/schedulers/thread_scheduler.hpp>
 
+#include <stdx/ct_format.hpp>
+#include <stdx/type_traits.hpp>
+
 #include <catch2/catch_test_macros.hpp>
+#include <fmt/format.h>
 
 #include <concepts>
 #include <condition_variable>
 #include <mutex>
+#include <string>
 #include <thread>
+#include <type_traits>
+#include <vector>
 
 TEST_CASE("thread_scheduler fulfils concept", "[thread_scheduler]") {
-    static_assert(async::scheduler<async::thread_scheduler>);
+    static_assert(async::scheduler<async::thread_scheduler<>>);
 }
 
 TEST_CASE("thread_scheduler sender advertises nothing", "[thread_scheduler]") {
     static_assert(
-        async::sender_of<decltype(async::thread_scheduler::schedule()),
+        async::sender_of<decltype(async::thread_scheduler<>::schedule()),
                          async::set_value_t()>);
 }
 
@@ -33,7 +41,7 @@ TEST_CASE("thread_scheduler sender completes on a separate thread",
     std::mutex m{};
     std::condition_variable cv{};
 
-    auto s = async::thread_scheduler::schedule();
+    auto s = async::thread_scheduler<>::schedule();
     auto op = async::connect(s, receiver{[&] {
                                  other_thread_id = std::this_thread::get_id();
                                  std::lock_guard l{m};
@@ -49,21 +57,87 @@ TEST_CASE("thread_scheduler sender completes on a separate thread",
 
 TEST_CASE("sender has the thread_scheduler as its completion scheduler",
           "[inline_scheduler]") {
-    auto s = async::thread_scheduler::schedule();
+    auto s = async::thread_scheduler<>::schedule();
     auto cs =
         async::get_completion_scheduler<async::set_value_t>(async::get_env(s));
-    static_assert(std::same_as<decltype(cs), async::thread_scheduler>);
+    static_assert(std::same_as<decltype(cs), async::thread_scheduler<>>);
 }
 
 TEST_CASE("sender has a static allocator", "[inline_scheduler]") {
     static_assert(
         std::is_same_v<async::allocator_of_t<async::env_of_t<
-                           decltype(async::thread_scheduler::schedule())>>,
+                           decltype(async::thread_scheduler<>::schedule())>>,
                        async::static_allocator>);
 }
 
 TEST_CASE("op state is not synchronous", "[inline_scheduler]") {
     [[maybe_unused]] auto op =
-        async::connect(async::thread_scheduler::schedule(), receiver{[] {}});
+        async::connect(async::thread_scheduler<>::schedule(), receiver{[] {}});
     static_assert(not async::synchronous<decltype(op)>);
+}
+
+namespace {
+std::vector<std::string> debug_events{};
+
+struct debug_handler {
+    template <stdx::ct_string C, stdx::ct_string L, stdx::ct_string S,
+              typename Ctx>
+    constexpr auto signal(auto &&...) {
+        debug_events.push_back(fmt::format("{} {} {}", C, L, S));
+    }
+};
+} // namespace
+
+template <> inline auto async::injected_debug_handler<> = debug_handler{};
+
+TEST_CASE("thread_scheduler can be debugged with a string",
+          "[thread_scheduler]") {
+    using namespace std::string_literals;
+    debug_events.clear();
+
+    bool recvd{};
+    std::mutex m{};
+    std::condition_variable cv{};
+
+    auto s = async::thread_scheduler<>::schedule();
+    auto op = async::connect(
+        s, with_env{receiver{[&] {
+                        std::lock_guard l{m};
+                        recvd = true;
+                        cv.notify_one();
+                    }},
+                    async::prop{async::get_debug_interface_t{},
+                                async::debug::named_interface<"op">{}}});
+
+    async::start(op);
+    std::unique_lock l{m};
+    cv.wait(l, [&] { return recvd; });
+    CHECK(debug_events == std::vector{"op thread_scheduler start"s,
+                                      "op thread_scheduler set_value"s});
+}
+
+TEST_CASE("thread_scheduler can be named and debugged with a string",
+          "[thread_scheduler]") {
+    using namespace std::string_literals;
+    debug_events.clear();
+
+    bool recvd{};
+    std::mutex m{};
+    std::condition_variable cv{};
+
+    auto s = async::thread_scheduler<"sched">::schedule();
+    auto op = async::connect(
+        s, with_env{receiver{[&] {
+                        std::lock_guard l{m};
+                        recvd = true;
+                        cv.notify_one();
+                    }},
+                    async::prop{async::get_debug_interface_t{},
+                                async::debug::named_interface<"op">{}}});
+
+    async::start(op);
+    std::unique_lock l{m};
+    cv.wait(l, [&] { return recvd; });
+    CHECK(debug_events ==
+          std::vector{"op sched start"s, "op sched set_value"s});
 }

--- a/test/split.cpp
+++ b/test/split.cpp
@@ -19,8 +19,8 @@
 TEST_CASE("split", "[split]") {
     bool recvd1{};
     bool recvd2{};
-    auto s = async::inline_scheduler::schedule<
-        async::inline_scheduler::singleshot>();
+    auto s = async::inline_scheduler<>::schedule<
+        async::inline_scheduler<>::singleshot>();
     static_assert(async::singleshot_sender<decltype(s), universal_receiver>);
     auto spl = async::split(std::move(s));
     static_assert(async::multishot_sender<decltype(spl), universal_receiver>);
@@ -71,8 +71,8 @@ TEST_CASE("split advertises errors", "[split]") {
 
 namespace {
 auto test_split(int &value, int expected) {
-    auto spl = async::inline_scheduler::schedule<
-                   async::inline_scheduler::singleshot>() |
+    auto spl = async::inline_scheduler<>::schedule<
+                   async::inline_scheduler<>::singleshot>() |
                async::then([&] { return expected; }) | async::split();
     static_assert(async::multishot_sender<decltype(spl), universal_receiver>);
 
@@ -97,21 +97,21 @@ TEST_CASE("split called multiple times from same location", "[split]") {
 }
 
 TEST_CASE("split does nothing for multishot sender", "[split]") {
-    auto s1 =
-        async::inline_scheduler::schedule<async::inline_scheduler::multishot>();
+    auto s1 = async::inline_scheduler<>::schedule<
+        async::inline_scheduler<>::multishot>();
     [[maybe_unused]] auto spl1 = std::move(s1) | async::split();
     static_assert(std::same_as<decltype(s1), decltype(spl1)>);
 
-    auto s2 =
-        async::inline_scheduler::schedule<async::inline_scheduler::multishot>();
+    auto s2 = async::inline_scheduler<>::schedule<
+        async::inline_scheduler<>::multishot>();
     [[maybe_unused]] auto spl2 = async::split(std::move(s2));
     static_assert(std::same_as<decltype(s2), decltype(spl2)>);
 }
 
 TEST_CASE("split cancellation (stopped by source)", "[split]") {
     int stopped{};
-    auto s = async::inline_scheduler::schedule<
-        async::inline_scheduler::singleshot>();
+    auto s = async::inline_scheduler<>::schedule<
+        async::inline_scheduler<>::singleshot>();
     static_assert(async::singleshot_sender<decltype(s), universal_receiver>);
     auto spl = async::split(std::move(s));
 
@@ -177,28 +177,28 @@ TEST_CASE("split sender environment", "[split]") {
 }
 
 TEST_CASE("split may complete synchronously", "[split]") {
-    auto s = async::inline_scheduler::schedule<
-        async::inline_scheduler::singleshot>();
+    auto s = async::inline_scheduler<>::schedule<
+        async::inline_scheduler<>::singleshot>();
     [[maybe_unused]] auto spl = async::split(std::move(s));
     static_assert(async::synchronous<decltype(s)>);
 }
 
 TEST_CASE("split may not complete synchronously", "[split]") {
-    auto s = async::thread_scheduler::schedule();
+    auto s = async::thread_scheduler<>::schedule();
     [[maybe_unused]] auto spl = async::split(std::move(s));
     static_assert(not async::synchronous<decltype(s)>);
 }
 
 TEST_CASE("split op state may be synchronous", "[split]") {
-    auto s = async::inline_scheduler::schedule<
-        async::inline_scheduler::singleshot>();
+    auto s = async::inline_scheduler<>::schedule<
+        async::inline_scheduler<>::singleshot>();
     auto spl = async::split(std::move(s));
     [[maybe_unused]] auto op = async::connect(spl, receiver{[] {}});
     static_assert(async::synchronous<decltype(op)>);
 }
 
 TEST_CASE("split op state may not be synchronous", "[split]") {
-    auto s = async::thread_scheduler::schedule();
+    auto s = async::thread_scheduler<>::schedule();
     auto spl = async::split(std::move(s));
     [[maybe_unused]] auto op = async::connect(spl, receiver{[] {}});
     static_assert(not async::synchronous<decltype(op)>);

--- a/test/then.cpp
+++ b/test/then.cpp
@@ -107,8 +107,8 @@ TEST_CASE("move-only lambda", "[then]") {
 }
 
 TEST_CASE("single-shot sender", "[then]") {
-    [[maybe_unused]] auto n = async::inline_scheduler::schedule<
-                                  async::inline_scheduler::singleshot>() |
+    [[maybe_unused]] auto n = async::inline_scheduler<>::schedule<
+                                  async::inline_scheduler<>::singleshot>() |
                               async::then([] {});
     static_assert(async::singleshot_sender<decltype(n), universal_receiver>);
 }

--- a/test/upon_error.cpp
+++ b/test/upon_error.cpp
@@ -60,8 +60,8 @@ TEST_CASE("move-only value", "[upon_error]") {
 }
 
 TEST_CASE("single-shot sender", "[upon_error]") {
-    [[maybe_unused]] auto n = async::inline_scheduler::schedule<
-                                  async::inline_scheduler::singleshot>() |
+    [[maybe_unused]] auto n = async::inline_scheduler<>::schedule<
+                                  async::inline_scheduler<>::singleshot>() |
                               async::upon_error([] {});
     static_assert(async::singleshot_sender<decltype(n), universal_receiver>);
 }

--- a/test/upon_stopped.cpp
+++ b/test/upon_stopped.cpp
@@ -35,8 +35,8 @@ TEST_CASE("upon_stopped is pipeable", "[upon_stopped]") {
 }
 
 TEST_CASE("single-shot sender", "[upon_stopped]") {
-    [[maybe_unused]] auto n = async::inline_scheduler::schedule<
-                                  async::inline_scheduler::singleshot>() |
+    [[maybe_unused]] auto n = async::inline_scheduler<>::schedule<
+                                  async::inline_scheduler<>::singleshot>() |
                               async::upon_stopped([] {});
     static_assert(async::singleshot_sender<decltype(n), universal_receiver>);
 }

--- a/test/when_all.cpp
+++ b/test/when_all.cpp
@@ -75,11 +75,11 @@ TEST_CASE("when_all with thread scheduler", "[when_all]") {
     auto const d1 = std::chrono::milliseconds{dis(get_rng())};
     auto const d2 = std::chrono::milliseconds{dis(get_rng())};
 
-    auto s1 = async::thread_scheduler::schedule() | async::then([&] {
+    auto s1 = async::thread_scheduler<>::schedule() | async::then([&] {
                   std::this_thread::sleep_for(d1);
                   return 42;
               });
-    auto s2 = async::thread_scheduler::schedule() | async::then([&] {
+    auto s2 = async::thread_scheduler<>::schedule() | async::then([&] {
                   std::this_thread::sleep_for(d2);
                   return 17;
               });
@@ -171,8 +171,8 @@ TEST_CASE("when_all cancellation (before start)", "[when_all]") {
     bool fail{};
     phase_control ctrl{};
 
-    auto s =
-        async::thread_scheduler::schedule() | async::then([&] { fail = true; });
+    auto s = async::thread_scheduler<>::schedule() |
+             async::then([&] { fail = true; });
     auto const w = async::when_all(s, stoppable_just()) |
                    async::upon_stopped([&] { success = true; });
 
@@ -191,7 +191,7 @@ TEST_CASE("when_all cancellation (during operation)", "[when_all]") {
     bool success{};
     phase_control ctrl{};
 
-    auto s = async::thread_scheduler::schedule() |
+    auto s = async::thread_scheduler<>::schedule() |
              async::then([&] { ctrl.advance_and_wait(); });
     auto const w = async::when_all(s, stoppable_just()) |
                    async::upon_stopped([&] { success = true; });

--- a/test/when_any.cpp
+++ b/test/when_any.cpp
@@ -149,11 +149,11 @@ TEST_CASE("when_any with thread scheduler", "[when_any]") {
     auto const d1 = std::chrono::milliseconds{dis(get_rng())};
     auto const d2 = std::chrono::milliseconds{dis(get_rng())};
 
-    auto s1 = async::thread_scheduler::schedule() | async::then([&] {
+    auto s1 = async::thread_scheduler<>::schedule() | async::then([&] {
                   std::this_thread::sleep_for(d1);
                   return 42;
               });
-    auto s2 = async::thread_scheduler::schedule() | async::then([&] {
+    auto s2 = async::thread_scheduler<>::schedule() | async::then([&] {
                   std::this_thread::sleep_for(d2);
                   return 17;
               });
@@ -196,8 +196,8 @@ TEST_CASE("when_any cancellation (before start)", "[when_any]") {
     bool fail{};
     phase_control ctrl{};
 
-    auto s =
-        async::thread_scheduler::schedule() | async::then([&] { fail = true; });
+    auto s = async::thread_scheduler<>::schedule() |
+             async::then([&] { fail = true; });
     auto const w = async::when_any(s, async::when_any()) |
                    async::upon_stopped([&] { success = true; });
 
@@ -216,7 +216,7 @@ TEST_CASE("when_any cancellation (during operation)", "[when_any]") {
     bool success{};
     phase_control ctrl{};
 
-    auto s = async::thread_scheduler::schedule() |
+    auto s = async::thread_scheduler<>::schedule() |
              async::then([&] { ctrl.advance_and_wait(); });
     auto const w = async::when_any(s, async::when_any()) |
                    async::upon_stopped([&] { success = true; });


### PR DESCRIPTION
Add debug output for senders from factories:
 - `inline_scheduler`
 - `fixed_priority_scheduler`
 - `runloop_scheduler`
 - `thread_scheduler`
 - `time_scheduler`
 - `trigger_scheduler`

And from `read_env` and related factories. The `runloop_scheduler` used in `sync_wait` inherits its name from the name passed to `sync_wait`.