### PR TITLE
:bug: Fix `upon_error` and `upon_stopped` completion channels

### DIFF
--- a/test/upon_error.cpp
+++ b/test/upon_error.cpp
@@ -13,7 +13,7 @@ TEST_CASE("upon_error", "[upon_error]") {
 
     auto s = async::just_error(42);
     auto n = async::upon_error(s, [](auto i) { return i + 17; });
-    auto op = async::connect(n, error_receiver{[&](auto i) { value = i; }});
+    auto op = async::connect(n, receiver{[&](auto i) { value = i; }});
     async::start(op);
     CHECK(value == 59);
 }
@@ -22,7 +22,7 @@ TEST_CASE("upon_error advertises what it sends", "[upon_error]") {
     auto s = async::just_error(42);
     [[maybe_unused]] auto n =
         async::upon_error(s, [](auto i) { return i + 17; });
-    static_assert(async::sender_of<decltype(n), async::set_error_t(int)>);
+    static_assert(async::sender_of<decltype(n), async::set_value_t(int)>);
 }
 
 TEST_CASE("upon_error is pipeable", "[upon_error]") {
@@ -30,7 +30,7 @@ TEST_CASE("upon_error is pipeable", "[upon_error]") {
 
     auto s = async::just_error(42);
     auto n = s | async::upon_error([](auto i) { return i + 17; });
-    auto op = async::connect(n, error_receiver{[&](auto i) { value = i; }});
+    auto op = async::connect(n, receiver{[&](auto i) { value = i; }});
     async::start(op);
     CHECK(value == 59);
 }
@@ -39,11 +39,9 @@ TEST_CASE("upon_error can send nothing", "[upon_error]") {
     int value{};
 
     auto s = async::just_error(42);
-    [[maybe_unused]] auto n1 = async::upon_error(s, [](auto) {});
-    static_assert(async::sender_of<decltype(n1), async::set_error_t()>);
-    [[maybe_unused]] auto n2 = async::upon_error(n1, [] {});
-    static_assert(async::sender_of<decltype(n2), async::set_error_t()>);
-    auto op = async::connect(n2, error_receiver{[&] { value = 42; }});
+    auto n = async::upon_error(s, [](auto) {});
+    static_assert(async::sender_of<decltype(n), async::set_value_t()>);
+    auto op = async::connect(n, receiver{[&] { value = 42; }});
     async::start(op);
     CHECK(value == 42);
 }
@@ -53,8 +51,8 @@ TEST_CASE("move-only value", "[upon_error]") {
 
     auto s = async::just_error(42);
     auto n = s | async::upon_error([](auto i) { return move_only{i}; });
-    auto op = async::connect(
-        std::move(n), error_receiver{[&](auto mo) { value = mo.value; }});
+    auto op = async::connect(std::move(n),
+                             receiver{[&](auto mo) { value = mo.value; }});
     async::start(op);
     CHECK(value == 42);
 }
@@ -66,54 +64,32 @@ TEST_CASE("single-shot sender", "[upon_error]") {
     static_assert(async::singleshot_sender<decltype(n), universal_receiver>);
 }
 
-TEST_CASE("upon_error propagates success (order 1)", "[upon_error]") {
+TEST_CASE("upon_error propagates success", "[upon_error]") {
+    bool upon_error_called{};
     int value{};
 
-    auto s = async::just() | async::then([] { return 42; }) |
-             async::upon_error([] { return 17; });
+    auto s =
+        async::just(42) | async::upon_error([&] { upon_error_called = true; });
     static_assert(
         std::same_as<async::completion_signatures_of_t<decltype(s)>,
                      async::completion_signatures<async::set_value_t(int)>>);
     auto op = async::connect(s, receiver{[&](auto i) { value = i; }});
     async::start(op);
     CHECK(value == 42);
+    CHECK(not upon_error_called);
 }
 
-TEST_CASE("upon_error propagates success (order 2)", "[upon_error]") {
+TEST_CASE("upon_error propagates stopped", "[upon_error]") {
+    bool upon_error_called{};
     int value{};
 
-    auto s = async::just() | async::upon_error([] { return 17; }) |
-             async::then([] { return 42; });
-    static_assert(
-        std::same_as<async::completion_signatures_of_t<decltype(s)>,
-                     async::completion_signatures<async::set_value_t(int)>>);
-    auto op = async::connect(s, receiver{[&](auto i) { value = i; }});
-    async::start(op);
-    CHECK(value == 42);
-}
-
-TEST_CASE("upon_error propagates stopped (order 1)", "[upon_error]") {
-    int value{};
-
-    auto s = async::just_stopped() | async::upon_stopped([&] { value = 41; }) |
-             async::upon_error([] { return 17; });
+    auto s = async::just_stopped() |
+             async::upon_error([&] { upon_error_called = true; });
     static_assert(
         std::same_as<async::completion_signatures_of_t<decltype(s)>,
                      async::completion_signatures<async::set_stopped_t()>>);
-    auto op = async::connect(s, stopped_receiver{[&] { ++value; }});
+    auto op = async::connect(s, stopped_receiver{[&] { value = 42; }});
     async::start(op);
     CHECK(value == 42);
-}
-
-TEST_CASE("upon_error propagates stopped (order 2)", "[upon_error]") {
-    int value{};
-
-    auto s = async::just_stopped() | async::upon_error([] { return 17; }) |
-             async::upon_stopped([&] { value = 41; });
-    static_assert(
-        std::same_as<async::completion_signatures_of_t<decltype(s)>,
-                     async::completion_signatures<async::set_stopped_t()>>);
-    auto op = async::connect(s, stopped_receiver{[&] { ++value; }});
-    async::start(op);
-    CHECK(value == 42);
+    CHECK(not upon_error_called);
 }

--- a/test/upon_stopped.cpp
+++ b/test/upon_stopped.cpp
@@ -13,23 +13,23 @@ TEST_CASE("upon_stopped", "[upon_stopped]") {
 
     auto s = async::just_stopped();
     auto n = async::upon_stopped(s, [&] { value = 42; });
-    auto op = async::connect(n, stopped_receiver{[] {}});
+    auto op = async::connect(n, receiver{[] {}});
     async::start(op);
     CHECK(value == 42);
 }
 
 TEST_CASE("upon_stopped advertises what it sends", "[upon_stopped]") {
     auto s = async::just_stopped();
-    [[maybe_unused]] auto n = async::upon_stopped(s, [] {});
-    static_assert(async::sender_of<decltype(n), async::set_stopped_t()>);
+    [[maybe_unused]] auto n = async::upon_stopped(s, [] { return 42; });
+    static_assert(async::sender_of<decltype(n), async::set_value_t(int)>);
 }
 
 TEST_CASE("upon_stopped is pipeable", "[upon_stopped]") {
     int value{};
 
     auto s = async::just_stopped();
-    auto n = s | async::upon_stopped([&] { value = 42; });
-    auto op = async::connect(n, stopped_receiver{[] {}});
+    auto n = s | async::upon_stopped([] { return 42; });
+    auto op = async::connect(n, receiver{[&](auto i) { value = i; }});
     async::start(op);
     CHECK(value == 42);
 }
@@ -41,54 +41,32 @@ TEST_CASE("single-shot sender", "[upon_stopped]") {
     static_assert(async::singleshot_sender<decltype(n), universal_receiver>);
 }
 
-TEST_CASE("upon_stopped propagates success (order 1)", "[upon_stopped]") {
+TEST_CASE("upon_stopped propagates success", "[upon_stopped]") {
+    bool upon_stopped_called{};
     int value{};
 
-    auto s = async::just() | async::then([] { return 42; }) |
-             async::upon_stopped([] {});
+    auto s = async::just(42) |
+             async::upon_stopped([&] { upon_stopped_called = true; });
     static_assert(
         std::same_as<async::completion_signatures_of_t<decltype(s)>,
                      async::completion_signatures<async::set_value_t(int)>>);
     auto op = async::connect(s, receiver{[&](auto i) { value = i; }});
     async::start(op);
     CHECK(value == 42);
+    CHECK(not upon_stopped_called);
 }
 
-TEST_CASE("upon_stopped propagates success (order 2)", "[upon_stopped]") {
+TEST_CASE("upon_stopped propagates errors", "[upon_stopped]") {
+    bool upon_stopped_called{};
     int value{};
 
-    auto s = async::just() | async::upon_stopped([] {}) |
-             async::then([] { return 42; });
-    static_assert(
-        std::same_as<async::completion_signatures_of_t<decltype(s)>,
-                     async::completion_signatures<async::set_value_t(int)>>);
-    auto op = async::connect(s, receiver{[&](auto i) { value = i; }});
-    async::start(op);
-    CHECK(value == 42);
-}
-
-TEST_CASE("upon_stopped propagates errors (order 1)", "[upon_stopped]") {
-    int value{};
-
-    auto s = async::just_error(0) | async::upon_error([](auto) { return 42; }) |
-             async::upon_stopped([] {});
+    auto s = async::just_error(42) |
+             async::upon_stopped([&] { upon_stopped_called = true; });
     static_assert(
         std::same_as<async::completion_signatures_of_t<decltype(s)>,
                      async::completion_signatures<async::set_error_t(int)>>);
     auto op = async::connect(s, error_receiver{[&](auto i) { value = i; }});
     async::start(op);
     CHECK(value == 42);
-}
-
-TEST_CASE("upon_stopped propagates errors (order 2)", "[upon_stopped]") {
-    int value{};
-
-    auto s = async::just_error(0) | async::upon_stopped([] {}) |
-             async::upon_error([](auto) { return 42; });
-    static_assert(
-        std::same_as<async::completion_signatures_of_t<decltype(s)>,
-                     async::completion_signatures<async::set_error_t(int)>>);
-    auto op = async::connect(s, error_receiver{[&](auto i) { value = i; }});
-    async::start(op);
-    CHECK(value == 42);
+    CHECK(not upon_stopped_called);
 }


### PR DESCRIPTION
The spec states that `upon_error` and `upon_stopped` complete on the _value_ channel. But previously here they were acting like `then` on their respective channels, completing on those channels.