### PR TITLE
:art: Remove usage of `universal_receiver` from `when_*` algorithms

### DIFF
--- a/include/async/when_all.hpp
+++ b/include/async/when_all.hpp
@@ -413,11 +413,8 @@ template <stdx::ct_string Name, typename... Sndrs> struct sender : Sndrs... {
     }
 
     template <typename R>
-        requires(... and
-                 multishot_sender<typename Sndrs::sender_t,
-                                  detail::universal_receiver<overriding_env<
-                                      get_stop_token_t, inplace_stop_token,
-                                      std::remove_cvref_t<R>>>>)
+        requires(... and multishot_sender<typename Sndrs::sender_t,
+                                          std::remove_cvref_t<R>>)
     [[nodiscard]] constexpr auto connect(
         R &&r) const & -> op_state_t<Name, std::remove_cvref_t<R>, Sndrs...> {
         check_connect<sender const &, R>();

--- a/include/async/when_any.hpp
+++ b/include/async/when_any.hpp
@@ -399,11 +399,8 @@ struct sender : Sndrs... {
     }
 
     template <typename R>
-        requires(... and
-                 multishot_sender<typename Sndrs::sender_t,
-                                  detail::universal_receiver<overriding_env<
-                                      get_stop_token_t, inplace_stop_token,
-                                      std::remove_cvref_t<R>>>>)
+        requires(... and multishot_sender<typename Sndrs::sender_t,
+                                          std::remove_cvref_t<R>>)
     [[nodiscard]] constexpr auto connect(R &&r) const
         & -> op_state_t<Name, StopPolicy, std::remove_cvref_t<R>, Sndrs...> {
         check_connect<sender const &, R>();


### PR DESCRIPTION
Problem:
- `universal_receiver` should be used only for concept checking, and it is used as a "real" receiver when checking connection of `when_all` and `when_any`.

Solution:
- Don't use it: it isn't needed for the check.