### PR TITLE
:sparkles: Add debug context concept

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@
 .cmake-format.yaml
 CMakePresets.json
 /toolchains
+mull.yml

--- a/include/async/debug_context.hpp
+++ b/include/async/debug_context.hpp
@@ -1,0 +1,46 @@
+#pragma once
+
+#include <stdx/ct_string.hpp>
+
+namespace async {
+namespace debug {
+template <typename T> struct context_for;
+
+namespace detail {
+template <std::size_t N>
+constexpr auto is_ct_string(stdx::ct_string<N>) -> std::true_type;
+constexpr auto is_ct_string(...) -> std::false_type;
+template <auto V>
+concept ct_stringlike = decltype(is_ct_string(V))::value;
+
+template <typename T>
+constexpr auto erased_context = []<typename C>(C) {
+    struct Ctx : C {
+        using context [[maybe_unused]] = C;
+    };
+    return Ctx{};
+}(context_for<T>{});
+} // namespace detail
+
+template <typename T>
+using erased_context_for = decltype(detail::erased_context<T>);
+
+template <typename T> constexpr auto name_of = T::name;
+template <typename T> using tag_of = typename T::tag;
+template <typename T> using children_of = typename T::children;
+template <typename T> using type_of = typename T::type;
+
+template <typename T> constexpr auto contextlike_v = false;
+
+template <typename T>
+concept contextlike = detail::ct_stringlike<T::name> and requires {
+    typename T::tag;
+    typename T::type;
+} and[]<template <typename...> typename L, typename... Ts>(L<Ts...> *) {
+    return (... and contextlike_v<Ts>);
+}
+(std::add_pointer_t<typename T::children>{});
+
+template <contextlike T> constexpr auto contextlike_v<T> = contextlike<T>;
+} // namespace debug
+} // namespace async

--- a/include/async/read_env.hpp
+++ b/include/async/read_env.hpp
@@ -36,8 +36,10 @@ template <stdx::ct_string Name, typename R, typename Tag> struct op_state {
     [[no_unique_address]] R receiver;
 
     constexpr auto start() & -> void {
-        debug_signal<"start", Name, op_state>(get_env(receiver));
-        debug_signal<"set_value", Name, op_state>(get_env(receiver));
+        debug_signal<"start", debug::erased_context_for<op_state>>(
+            get_env(receiver));
+        debug_signal<"set_value", debug::erased_context_for<op_state>>(
+            get_env(receiver));
         set_value(std::move(receiver), Tag{}(get_env(receiver)));
     }
 
@@ -83,4 +85,14 @@ template <stdx::ct_string Name = "">
 [[nodiscard]] constexpr auto get_scheduler() -> sender auto {
     return read_env<Name>(get_scheduler_t{});
 }
+
+template <typename> struct read_env_t;
+
+template <stdx::ct_string Name, typename R, typename Tag>
+struct debug::context_for<_read_env::op_state<Name, R, Tag>> {
+    using tag = read_env_t<Tag>;
+    constexpr static auto name = Name;
+    using children = stdx::type_list<>;
+    using type = _read_env::op_state<Name, R, Tag>;
+};
 } // namespace async

--- a/include/async/repeat.hpp
+++ b/include/async/repeat.hpp
@@ -77,7 +77,8 @@ struct op_state {
     constexpr op_state(op_state &&) = delete;
 
     constexpr auto start() & -> void {
-        debug_signal<"start", Name, op_state>(get_env(rcvr));
+        debug_signal<"start", debug::erased_context_for<op_state>>(
+            get_env(rcvr));
         auto &op = state.emplace(stdx::with_result_of{
             [&] { return connect(sndr, receiver_t{this}); }});
         async::start(op);
@@ -86,9 +87,12 @@ struct op_state {
     template <typename... Args> auto repeat(Args &&...args) -> void {
         if constexpr (not std::same_as<
                           Pred, std::remove_cvref_t<decltype(never_stop)>>) {
-            debug_signal<"eval_predicate", Name, op_state>(get_env(rcvr));
+            debug_signal<"eval_predicate", debug::erased_context_for<op_state>>(
+                get_env(rcvr));
             if (pred(args...)) {
-                debug_signal<set_value_t::name, Name, op_state>(get_env(rcvr));
+                debug_signal<set_value_t::name,
+                             debug::erased_context_for<op_state>>(
+                    get_env(rcvr));
                 set_value(std::move(rcvr), std::forward<Args>(args)...);
                 return;
             }
@@ -98,7 +102,8 @@ struct op_state {
 
     template <channel_tag Tag, typename... Args>
     auto passthrough(Args &&...args) -> void {
-        debug_signal<Tag::name, Name, op_state>(get_env(rcvr));
+        debug_signal<Tag::name, debug::erased_context_for<op_state>>(
+            get_env(rcvr));
         Tag{}(std::move(rcvr), std::forward<Args>(args)...);
     }
 
@@ -186,4 +191,15 @@ template <stdx::ct_string Name = "repeat_n", sender S>
 [[nodiscard]] auto repeat_n(S &&s, unsigned int n) {
     return std::forward<S>(s) | repeat_n<Name>(n);
 }
+
+struct repeat_t;
+
+template <stdx::ct_string Name, typename... Ts>
+struct debug::context_for<_repeat::op_state<Name, Ts...>> {
+    using tag = repeat_t;
+    constexpr static auto name = Name;
+    using type = _repeat::op_state<Name, Ts...>;
+    using children =
+        stdx::type_list<debug::erased_context_for<typename type::state_t>>;
+};
 } // namespace async

--- a/include/async/schedulers/inline_scheduler.hpp
+++ b/include/async/schedulers/inline_scheduler.hpp
@@ -16,21 +16,25 @@
 #include <utility>
 
 namespace async {
+namespace _inline_scheduler {
+template <stdx::ct_string Name, typename R> struct op_state {
+    [[no_unique_address]] R receiver;
+
+    constexpr auto start() & -> void {
+        debug_signal<"start", debug::erased_context_for<op_state>>(
+            get_env(receiver));
+        debug_signal<"set_value", debug::erased_context_for<op_state>>(
+            get_env(receiver));
+        set_value(std::move(receiver));
+    }
+
+    [[nodiscard]] constexpr auto query(get_env_t) const noexcept {
+        return prop{completes_synchronously_t{}, std::true_type{}};
+    }
+};
+} // namespace _inline_scheduler
+
 template <stdx::ct_string Name = "inline_scheduler"> class inline_scheduler {
-    template <typename R> struct op_state {
-        [[no_unique_address]] R receiver;
-
-        constexpr auto start() & -> void {
-            debug_signal<"start", Name, op_state>(get_env(receiver));
-            debug_signal<"set_value", Name, op_state>(get_env(receiver));
-            set_value(std::move(receiver));
-        }
-
-        [[nodiscard]] constexpr auto query(get_env_t) const noexcept {
-            return prop{completes_synchronously_t{}, std::true_type{}};
-        }
-    };
-
     struct sender_base {
         using is_sender = void;
         using completion_signatures =
@@ -45,7 +49,8 @@ template <stdx::ct_string Name = "inline_scheduler"> class inline_scheduler {
 
     struct multishot_sender : sender_base {
         template <receiver R>
-        [[nodiscard]] constexpr auto connect(R &&r) const -> op_state<R> {
+        [[nodiscard]] constexpr auto
+        connect(R &&r) const -> _inline_scheduler::op_state<Name, R> {
             check_connect<multishot_sender, R>();
             return {std::forward<R>(r)};
         }
@@ -53,7 +58,8 @@ template <stdx::ct_string Name = "inline_scheduler"> class inline_scheduler {
 
     struct singleshot_sender : sender_base {
         template <receiver R>
-        [[nodiscard]] constexpr auto connect(R &&r) && -> op_state<R> {
+        [[nodiscard]] constexpr auto
+        connect(R &&r) && -> _inline_scheduler::op_state<Name, R> {
             check_connect<singleshot_sender &&, R>();
             return {std::forward<R>(r)};
         }
@@ -74,5 +80,15 @@ template <stdx::ct_string Name = "inline_scheduler"> class inline_scheduler {
             return singleshot_sender{};
         }
     }
+};
+
+struct inline_scheduler_sender_t;
+
+template <stdx::ct_string Name, typename R>
+struct debug::context_for<_inline_scheduler::op_state<Name, R>> {
+    using tag = inline_scheduler_sender_t;
+    constexpr static auto name = Name;
+    using type = _inline_scheduler::op_state<Name, R>;
+    using children = stdx::type_list<>;
 };
 } // namespace async

--- a/include/async/schedulers/trigger_scheduler.hpp
+++ b/include/async/schedulers/trigger_scheduler.hpp
@@ -62,12 +62,14 @@ struct op_state final : op_state_base<Rcvr, op_state<Name, Rcvr, Args...>>,
 
     auto run(Args const &...args) -> void final {
         this->clear_stop_cb();
-        debug_signal<"set_value", Name, op_state>(get_env(rcvr));
+        debug_signal<"set_value", debug::erased_context_for<op_state>>(
+            get_env(rcvr));
         set_value(std::move(rcvr), args...);
     }
 
     constexpr auto start() & -> void {
-        debug_signal<"start", Name, op_state>(get_env(rcvr));
+        debug_signal<"start", debug::erased_context_for<op_state>>(
+            get_env(rcvr));
         if (this->check_stopped()) {
             complete_stopped();
             return;
@@ -82,7 +84,8 @@ struct op_state final : op_state_base<Rcvr, op_state<Name, Rcvr, Args...>>,
     }
 
     auto complete_stopped() {
-        debug_signal<"set_stopped", Name, op_state>(get_env(rcvr));
+        debug_signal<"set_stopped", debug::erased_context_for<op_state>>(
+            get_env(rcvr));
         set_stopped(std::move(rcvr));
     }
 
@@ -128,5 +131,15 @@ template <stdx::ct_string Name, typename... Args> class trigger_scheduler {
 
   public:
     [[nodiscard]] constexpr static auto schedule() -> sender { return {}; }
+};
+
+struct trigger_scheduler_sender_t;
+
+template <stdx::ct_string Name, typename Rcvr, typename... Args>
+struct debug::context_for<trigger_mgr::op_state<Name, Rcvr, Args...>> {
+    using tag = trigger_scheduler_sender_t;
+    constexpr static auto name = Name;
+    using children = stdx::type_list<>;
+    using type = trigger_mgr::op_state<Name, Rcvr, Args...>;
 };
 } // namespace async

--- a/include/async/split.hpp
+++ b/include/async/split.hpp
@@ -4,12 +4,14 @@
 #include <async/completion_tags.hpp>
 #include <async/concepts.hpp>
 #include <async/connect.hpp>
+#include <async/debug.hpp>
 #include <async/env.hpp>
 #include <async/stop_token.hpp>
 #include <async/type_traits.hpp>
 
 #include <stdx/concepts.hpp>
 #include <stdx/functional.hpp>
+#include <stdx/type_traits.hpp>
 #include <stdx/utility.hpp>
 
 #include <boost/mp11/algorithm.hpp>
@@ -232,4 +234,14 @@ template <sender S, typename Uniq = decltype([] {})>
 [[nodiscard]] constexpr auto split(S &&s) -> sender auto {
     return std::forward<S>(s) | split<Uniq>();
 }
+
+struct split_t;
+
+template <typename... Ops> struct debug::context_for<_split::op_state<Ops...>> {
+    using tag = split_t;
+    constexpr static auto name = stdx::ct_string{"split"};
+    using type = _split::op_state<Ops...>;
+    using children = stdx::type_list<
+        debug::erased_context_for<typename type::single_op_state_t>>;
+};
 } // namespace async

--- a/include/async/start_detached.hpp
+++ b/include/async/start_detached.hpp
@@ -88,13 +88,13 @@ struct op_state : op_state_base<StopSource, Env> {
           ops{connect(std::forward<S>(s), receiver_t{this})} {}
 
     template <stdx::ct_string S> auto die() {
-        debug_signal<S, "start_detached", op_state>(this->e);
+        debug_signal<S, debug::erased_context_for<op_state>>(this->e);
         set_stop_source<Uniq, Alloc, StopSource>(nullptr);
         Alloc::template destruct<Uniq>(this);
     }
 
     constexpr auto start() & -> void {
-        debug_signal<"start", "start_detached", op_state>(this->e);
+        debug_signal<"start", debug::erased_context_for<op_state>>(this->e);
         async::start(ops);
     }
 
@@ -201,4 +201,15 @@ template <typename Uniq> auto stop_detached() {
 template <stdx::ct_string Name> auto stop_detached() {
     return stop_detached<stdx::cts_t<Name>>();
 }
+
+struct start_detached_t;
+
+template <typename... Ts>
+struct debug::context_for<_start_detached::op_state<Ts...>> {
+    using tag = start_detached_t;
+    constexpr static auto name = stdx::ct_string{"start_detached"};
+    using children = stdx::type_list<>;
+    // context_for<typename _start_detached::op_state<Ts...>::ops_t>>;
+    using type = _start_detached::op_state<Ts...>;
+};
 } // namespace async

--- a/include/async/variant_sender.hpp
+++ b/include/async/variant_sender.hpp
@@ -3,10 +3,12 @@
 #include <async/completes_synchronously.hpp>
 #include <async/concepts.hpp>
 #include <async/connect.hpp>
+#include <async/debug.hpp>
 #include <async/env.hpp>
 #include <async/type_traits.hpp>
 
 #include <stdx/concepts.hpp>
+#include <stdx/ct_string.hpp>
 #include <stdx/function_traits.hpp>
 #include <stdx/functional.hpp>
 #include <stdx/tuple.hpp>
@@ -251,4 +253,15 @@ constexpr auto make_variant_sender(bool b, F1 &&f1, F2 &&f2) {
     return boost::mp11::mp_apply<_variant::sender, senders>{
         select(b, std::forward<F1>(f1), std::forward<F2>(f2))};
 }
+
+struct variant_t;
+
+template <typename... Ops>
+struct debug::context_for<_variant::op_state<Ops...>> {
+    using tag = variant_t;
+    constexpr static auto name = stdx::ct_string{"variant"};
+    using type = _variant::op_state<Ops...>;
+    using children = boost::mp11::mp_transform<debug::erased_context_for,
+                                               typename type::variant_t>;
+};
 } // namespace async

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -24,6 +24,7 @@ add_tests(
     concepts
     continue_on
     debug
+    debug_context
     env
     forwarding_query
     freestanding_sync_wait

--- a/test/debug_context.cpp
+++ b/test/debug_context.cpp
@@ -1,0 +1,80 @@
+#include <async/debug_context.hpp>
+
+#include <catch2/catch_test_macros.hpp>
+
+namespace {
+template <typename...> struct list;
+
+struct leaf_context {
+    struct tag;
+    constexpr static auto name = stdx::ct_string{"name"};
+    using children = list<>;
+    using type = int;
+};
+
+struct branch_context {
+    struct tag;
+    constexpr static auto name = stdx::ct_string{"name"};
+    using children = list<leaf_context>;
+    using type = int;
+};
+
+struct bad_context_no_name {
+    struct tag;
+    using children = list<>;
+    using type = int;
+};
+
+struct bad_context_no_tag {
+    constexpr static auto name = stdx::ct_string{"name"};
+    using children = list<>;
+    using type = int;
+};
+
+struct bad_context_no_children {
+    struct tag;
+    constexpr static auto name = stdx::ct_string{"name"};
+    using type = int;
+};
+
+struct bad_context_bad_children {
+    struct tag;
+    constexpr static auto name = stdx::ct_string{"name"};
+    using children = list<int>;
+    using type = int;
+};
+
+struct bad_context_no_type {
+    struct tag;
+    constexpr static auto name = stdx::ct_string{"name"};
+    using children = list<>;
+};
+} // namespace
+
+TEST_CASE("leaf context", "[debug_context]") {
+    static_assert(async::debug::contextlike<leaf_context>);
+}
+
+TEST_CASE("branch context", "[debug_context]") {
+    static_assert(async::debug::contextlike<branch_context>);
+}
+
+TEST_CASE("not a context (no name)", "[debug_context]") {
+    static_assert(not async::debug::contextlike<bad_context_no_name>);
+}
+
+TEST_CASE("not a context (no tag)", "[debug_context]") {
+    static_assert(not async::debug::contextlike<bad_context_no_tag>);
+}
+
+TEST_CASE("not a context (no children)", "[debug_context]") {
+    static_assert(not async::debug::contextlike<bad_context_no_children>);
+}
+
+TEST_CASE("not a context (children are not contexts)", "[debug_context]") {
+    static_assert(not async::debug::contextlike<bad_context_bad_children>);
+}
+
+TEST_CASE("not a context (no type)", "[debug_context]") {
+    static_assert(not async::debug::contextlike<bad_context_no_type>);
+}

--- a/test/freestanding_sync_wait.cpp
+++ b/test/freestanding_sync_wait.cpp
@@ -91,12 +91,12 @@ namespace {
 std::vector<std::string> debug_events{};
 
 struct debug_handler {
-    template <stdx::ct_string C, stdx::ct_string L, stdx::ct_string S,
-              typename Ctx>
+    template <stdx::ct_string C, stdx::ct_string S, typename Ctx>
     constexpr auto signal(auto &&...) {
-        if constexpr (stdx::is_specialization_of_v<
-                          Ctx, async::_sync_wait::receiver>) {
-            debug_events.push_back(fmt::format("{} {} {}", C, L, S));
+        if constexpr (std::is_same_v<async::debug::tag_of<Ctx>,
+                                     async::sync_wait_t>) {
+            debug_events.push_back(
+                fmt::format("{} {} {}", C, async::debug::name_of<Ctx>, S));
         }
     }
 };

--- a/test/hosted_sync_wait.cpp
+++ b/test/hosted_sync_wait.cpp
@@ -87,12 +87,12 @@ namespace {
 std::vector<std::string> debug_events{};
 
 struct debug_handler {
-    template <stdx::ct_string C, stdx::ct_string L, stdx::ct_string S,
-              typename Ctx>
+    template <stdx::ct_string C, stdx::ct_string S, typename Ctx>
     constexpr auto signal(auto &&...) {
-        if constexpr (stdx::is_specialization_of_v<
-                          Ctx, async::_sync_wait::receiver>) {
-            debug_events.push_back(fmt::format("{} {} {}", C, L, S));
+        if constexpr (std::is_same_v<async::debug::tag_of<Ctx>,
+                                     async::sync_wait_t>) {
+            debug_events.push_back(
+                fmt::format("{} {} {}", C, async::debug::name_of<Ctx>, S));
         }
     }
 };

--- a/test/just.cpp
+++ b/test/just.cpp
@@ -11,6 +11,7 @@
 #include <stdx/ct_format.hpp>
 #include <stdx/type_traits.hpp>
 
+#include <boost/mp11/list.hpp>
 #include <catch2/catch_test_macros.hpp>
 #include <fmt/format.h>
 
@@ -95,10 +96,13 @@ namespace {
 std::vector<std::string> debug_events{};
 
 struct debug_handler {
-    template <stdx::ct_string C, stdx::ct_string L, stdx::ct_string S,
-              typename Ctx>
+    template <stdx::ct_string C, stdx::ct_string S, typename Ctx>
     constexpr auto signal(auto &&...) {
-        debug_events.push_back(fmt::format("{} {} {}", C, L, S));
+        static_assert(std::is_same_v<async::debug::tag_of<Ctx>, async::just_t>);
+        static_assert(
+            boost::mp11::mp_empty<async::debug::children_of<Ctx>>::value);
+        debug_events.push_back(
+            fmt::format("{} {} {}", C, async::debug::name_of<Ctx>, S));
     }
 };
 } // namespace

--- a/test/just_error.cpp
+++ b/test/just_error.cpp
@@ -11,6 +11,7 @@
 #include <stdx/ct_format.hpp>
 #include <stdx/type_traits.hpp>
 
+#include <boost/mp11/list.hpp>
 #include <catch2/catch_test_macros.hpp>
 #include <fmt/format.h>
 
@@ -79,10 +80,14 @@ namespace {
 std::vector<std::string> debug_events{};
 
 struct debug_handler {
-    template <stdx::ct_string C, stdx::ct_string L, stdx::ct_string S,
-              typename Ctx>
+    template <stdx::ct_string C, stdx::ct_string S, typename Ctx>
     constexpr auto signal(auto &&...) {
-        debug_events.push_back(fmt::format("{} {} {}", C, L, S));
+        static_assert(
+            std::is_same_v<async::debug::tag_of<Ctx>, async::just_error_t>);
+        static_assert(
+            boost::mp11::mp_empty<async::debug::children_of<Ctx>>::value);
+        debug_events.push_back(
+            fmt::format("{} {} {}", C, async::debug::name_of<Ctx>, S));
     }
 };
 } // namespace

--- a/test/just_error_result_of.cpp
+++ b/test/just_error_result_of.cpp
@@ -11,6 +11,7 @@
 #include <stdx/ct_format.hpp>
 #include <stdx/type_traits.hpp>
 
+#include <boost/mp11/list.hpp>
 #include <catch2/catch_test_macros.hpp>
 #include <fmt/format.h>
 
@@ -121,10 +122,14 @@ namespace {
 std::vector<std::string> debug_events{};
 
 struct debug_handler {
-    template <stdx::ct_string C, stdx::ct_string L, stdx::ct_string S,
-              typename Ctx>
+    template <stdx::ct_string C, stdx::ct_string S, typename Ctx>
     constexpr auto signal(auto &&...) {
-        debug_events.push_back(fmt::format("{} {} {}", C, L, S));
+        static_assert(std::is_same_v<async::debug::tag_of<Ctx>,
+                                     async::just_error_result_of_t>);
+        static_assert(
+            boost::mp11::mp_empty<async::debug::children_of<Ctx>>::value);
+        debug_events.push_back(
+            fmt::format("{} {} {}", C, async::debug::name_of<Ctx>, S));
     }
 };
 } // namespace

--- a/test/just_result_of.cpp
+++ b/test/just_result_of.cpp
@@ -12,6 +12,7 @@
 #include <stdx/ct_format.hpp>
 #include <stdx/type_traits.hpp>
 
+#include <boost/mp11/list.hpp>
 #include <catch2/catch_test_macros.hpp>
 #include <fmt/format.h>
 
@@ -119,10 +120,14 @@ namespace {
 std::vector<std::string> debug_events{};
 
 struct debug_handler {
-    template <stdx::ct_string C, stdx::ct_string L, stdx::ct_string S,
-              typename Ctx>
+    template <stdx::ct_string C, stdx::ct_string S, typename Ctx>
     constexpr auto signal(auto &&...) {
-        debug_events.push_back(fmt::format("{} {} {}", C, L, S));
+        static_assert(
+            std::is_same_v<async::debug::tag_of<Ctx>, async::just_result_of_t>);
+        static_assert(
+            boost::mp11::mp_empty<async::debug::children_of<Ctx>>::value);
+        debug_events.push_back(
+            fmt::format("{} {} {}", C, async::debug::name_of<Ctx>, S));
     }
 };
 } // namespace

--- a/test/just_stopped.cpp
+++ b/test/just_stopped.cpp
@@ -11,6 +11,7 @@
 #include <stdx/ct_format.hpp>
 #include <stdx/type_traits.hpp>
 
+#include <boost/mp11/list.hpp>
 #include <catch2/catch_test_macros.hpp>
 #include <fmt/format.h>
 
@@ -68,10 +69,14 @@ namespace {
 std::vector<std::string> debug_events{};
 
 struct debug_handler {
-    template <stdx::ct_string C, stdx::ct_string L, stdx::ct_string S,
-              typename Ctx>
+    template <stdx::ct_string C, stdx::ct_string S, typename Ctx>
     constexpr auto signal(auto &&...) {
-        debug_events.push_back(fmt::format("{} {} {}", C, L, S));
+        static_assert(
+            std::is_same_v<async::debug::tag_of<Ctx>, async::just_stopped_t>);
+        static_assert(
+            boost::mp11::mp_empty<async::debug::children_of<Ctx>>::value);
+        debug_events.push_back(
+            fmt::format("{} {} {}", C, async::debug::name_of<Ctx>, S));
     }
 };
 } // namespace

--- a/test/let_error.cpp
+++ b/test/let_error.cpp
@@ -14,6 +14,7 @@
 
 #include <stdx/ct_format.hpp>
 
+#include <boost/mp11/list.hpp>
 #include <catch2/catch_test_macros.hpp>
 #include <fmt/format.h>
 
@@ -252,12 +253,14 @@ namespace {
 std::vector<std::string> debug_events{};
 
 struct debug_handler {
-    template <stdx::ct_string C, stdx::ct_string L, stdx::ct_string S,
-              typename Ctx>
+    template <stdx::ct_string C, stdx::ct_string S, typename Ctx>
     constexpr auto signal(auto &&...) {
-        using namespace stdx::literals;
-        if constexpr (L != "just_error"_cts and L != "just_stopped"_cts) {
-            debug_events.push_back(fmt::format("{} {} {}", C, L, S));
+        if constexpr (std::is_same_v<async::debug::tag_of<Ctx>,
+                                     async::let_t<async::set_error_t>>) {
+            static_assert(not boost::mp11::mp_empty<
+                          async::debug::children_of<Ctx>>::value);
+            debug_events.push_back(
+                fmt::format("{} {} {}", C, async::debug::name_of<Ctx>, S));
         }
     }
 };

--- a/test/let_stopped.cpp
+++ b/test/let_stopped.cpp
@@ -13,6 +13,7 @@
 
 #include <stdx/ct_format.hpp>
 
+#include <boost/mp11/list.hpp>
 #include <catch2/catch_test_macros.hpp>
 #include <fmt/format.h>
 
@@ -164,12 +165,14 @@ namespace {
 std::vector<std::string> debug_events{};
 
 struct debug_handler {
-    template <stdx::ct_string C, stdx::ct_string L, stdx::ct_string S,
-              typename Ctx>
+    template <stdx::ct_string C, stdx::ct_string S, typename Ctx>
     constexpr auto signal(auto &&...) {
-        using namespace stdx::literals;
-        if constexpr (L != "just_error"_cts and L != "just_stopped"_cts) {
-            debug_events.push_back(fmt::format("{} {} {}", C, L, S));
+        if constexpr (std::is_same_v<async::debug::tag_of<Ctx>,
+                                     async::let_t<async::set_stopped_t>>) {
+            static_assert(not boost::mp11::mp_empty<
+                          async::debug::children_of<Ctx>>::value);
+            debug_events.push_back(
+                fmt::format("{} {} {}", C, async::debug::name_of<Ctx>, S));
         }
     }
 };

--- a/test/let_value.cpp
+++ b/test/let_value.cpp
@@ -13,6 +13,7 @@
 
 #include <stdx/ct_format.hpp>
 
+#include <boost/mp11/list.hpp>
 #include <catch2/catch_test_macros.hpp>
 #include <fmt/format.h>
 
@@ -259,12 +260,14 @@ namespace {
 std::vector<std::string> debug_events{};
 
 struct debug_handler {
-    template <stdx::ct_string C, stdx::ct_string L, stdx::ct_string S,
-              typename Ctx>
+    template <stdx::ct_string C, stdx::ct_string S, typename Ctx>
     constexpr auto signal(auto &&...) {
-        using namespace stdx::literals;
-        if constexpr (L != "just"_cts and L != "just_error"_cts) {
-            debug_events.push_back(fmt::format("{} {} {}", C, L, S));
+        if constexpr (std::is_same_v<async::debug::tag_of<Ctx>,
+                                     async::let_t<async::set_value_t>>) {
+            static_assert(not boost::mp11::mp_empty<
+                          async::debug::children_of<Ctx>>::value);
+            debug_events.push_back(
+                fmt::format("{} {} {}", C, async::debug::name_of<Ctx>, S));
         }
     }
 };

--- a/test/repeat.cpp
+++ b/test/repeat.cpp
@@ -15,6 +15,7 @@
 
 #include <stdx/ct_format.hpp>
 
+#include <boost/mp11/list.hpp>
 #include <catch2/catch_test_macros.hpp>
 #include <fmt/format.h>
 
@@ -177,12 +178,14 @@ namespace {
 std::vector<std::string> debug_events{};
 
 struct debug_handler {
-    template <stdx::ct_string C, stdx::ct_string L, stdx::ct_string S,
-              typename Ctx>
+    template <stdx::ct_string C, stdx::ct_string S, typename Ctx>
     constexpr auto signal(auto &&...) {
-        using namespace stdx::literals;
-        if constexpr (L != "just"_cts and L != "just_error"_cts) {
-            debug_events.push_back(fmt::format("{} {} {}", C, L, S));
+        if constexpr (std::same_as<async::debug::tag_of<Ctx>,
+                                   async::repeat_t>) {
+            static_assert(not boost::mp11::mp_empty<
+                          async::debug::children_of<Ctx>>::value);
+            debug_events.push_back(
+                fmt::format("{} {} {}", C, async::debug::name_of<Ctx>, S));
         }
     }
 };

--- a/test/retry.cpp
+++ b/test/retry.cpp
@@ -15,6 +15,7 @@
 
 #include <stdx/ct_format.hpp>
 
+#include <boost/mp11/list.hpp>
 #include <catch2/catch_test_macros.hpp>
 #include <fmt/format.h>
 
@@ -150,12 +151,13 @@ namespace {
 std::vector<std::string> debug_events{};
 
 struct debug_handler {
-    template <stdx::ct_string C, stdx::ct_string L, stdx::ct_string S,
-              typename Ctx>
+    template <stdx::ct_string C, stdx::ct_string S, typename Ctx>
     constexpr auto signal(auto &&...) {
-        using namespace stdx::literals;
-        if constexpr (L != "just"_cts and L != "just_error"_cts) {
-            debug_events.push_back(fmt::format("{} {} {}", C, L, S));
+        if constexpr (std::same_as<async::debug::tag_of<Ctx>, async::retry_t>) {
+            static_assert(not boost::mp11::mp_empty<
+                          async::debug::children_of<Ctx>>::value);
+            debug_events.push_back(
+                fmt::format("{} {} {}", C, async::debug::name_of<Ctx>, S));
         }
     }
 };

--- a/test/schedulers/inline_scheduler.cpp
+++ b/test/schedulers/inline_scheduler.cpp
@@ -12,6 +12,7 @@
 #include <stdx/ct_format.hpp>
 #include <stdx/type_traits.hpp>
 
+#include <boost/mp11/list.hpp>
 #include <catch2/catch_test_macros.hpp>
 #include <fmt/format.h>
 
@@ -86,10 +87,14 @@ namespace {
 std::vector<std::string> debug_events{};
 
 struct debug_handler {
-    template <stdx::ct_string C, stdx::ct_string L, stdx::ct_string S,
-              typename Ctx>
+    template <stdx::ct_string C, stdx::ct_string S, typename Ctx>
     constexpr auto signal(auto &&...) {
-        debug_events.push_back(fmt::format("{} {} {}", C, L, S));
+        static_assert(std::is_same_v<async::debug::tag_of<Ctx>,
+                                     async::inline_scheduler_sender_t>);
+        static_assert(
+            boost::mp11::mp_empty<async::debug::children_of<Ctx>>::value);
+        debug_events.push_back(
+            fmt::format("{} {} {}", C, async::debug::name_of<Ctx>, S));
     }
 };
 } // namespace

--- a/test/schedulers/priority_scheduler.cpp
+++ b/test/schedulers/priority_scheduler.cpp
@@ -14,6 +14,7 @@
 #include <stdx/concepts.hpp>
 #include <stdx/ct_format.hpp>
 
+#include <boost/mp11/list.hpp>
 #include <catch2/catch_test_macros.hpp>
 #include <fmt/format.h>
 
@@ -133,10 +134,15 @@ namespace {
 std::vector<std::string> debug_events{};
 
 struct debug_handler {
-    template <stdx::ct_string C, stdx::ct_string L, stdx::ct_string S,
-              typename Ctx>
+    template <stdx::ct_string C, stdx::ct_string S, typename Ctx>
     constexpr auto signal(auto &&...) {
-        debug_events.push_back(fmt::format("{} {} {}", C, L, S));
+        if constexpr (std::is_same_v<async::debug::tag_of<Ctx>,
+                                     async::priority_scheduler_sender_t>) {
+            static_assert(
+                boost::mp11::mp_empty<async::debug::children_of<Ctx>>::value);
+            debug_events.push_back(
+                fmt::format("{} {} {}", C, async::debug::name_of<Ctx>, S));
+        }
     }
 };
 } // namespace

--- a/test/schedulers/runloop_scheduler.cpp
+++ b/test/schedulers/runloop_scheduler.cpp
@@ -7,6 +7,7 @@
 #include <stdx/ct_format.hpp>
 #include <stdx/type_traits.hpp>
 
+#include <boost/mp11/list.hpp>
 #include <catch2/catch_test_macros.hpp>
 #include <fmt/format.h>
 
@@ -53,10 +54,14 @@ namespace {
 std::vector<std::string> debug_events{};
 
 struct debug_handler {
-    template <stdx::ct_string C, stdx::ct_string L, stdx::ct_string S,
-              typename Ctx>
+    template <stdx::ct_string C, stdx::ct_string S, typename Ctx>
     constexpr auto signal(auto &&...) {
-        debug_events.push_back(fmt::format("{} {} {}", C, L, S));
+        static_assert(std::is_same_v<async::debug::tag_of<Ctx>,
+                                     async::runloop_scheduler_sender_t>);
+        static_assert(
+            boost::mp11::mp_empty<async::debug::children_of<Ctx>>::value);
+        debug_events.push_back(
+            fmt::format("{} {} {}", C, async::debug::name_of<Ctx>, S));
     }
 };
 } // namespace

--- a/test/schedulers/thread_scheduler.cpp
+++ b/test/schedulers/thread_scheduler.cpp
@@ -11,6 +11,7 @@
 #include <stdx/ct_format.hpp>
 #include <stdx/type_traits.hpp>
 
+#include <boost/mp11/list.hpp>
 #include <catch2/catch_test_macros.hpp>
 #include <fmt/format.h>
 
@@ -80,10 +81,14 @@ namespace {
 std::vector<std::string> debug_events{};
 
 struct debug_handler {
-    template <stdx::ct_string C, stdx::ct_string L, stdx::ct_string S,
-              typename Ctx>
+    template <stdx::ct_string C, stdx::ct_string S, typename Ctx>
     constexpr auto signal(auto &&...) {
-        debug_events.push_back(fmt::format("{} {} {}", C, L, S));
+        static_assert(std::is_same_v<async::debug::tag_of<Ctx>,
+                                     async::thread_scheduler_sender_t>);
+        static_assert(
+            boost::mp11::mp_empty<async::debug::children_of<Ctx>>::value);
+        debug_events.push_back(
+            fmt::format("{} {} {}", C, async::debug::name_of<Ctx>, S));
     }
 };
 } // namespace

--- a/test/schedulers/trigger_scheduler.cpp
+++ b/test/schedulers/trigger_scheduler.cpp
@@ -14,6 +14,7 @@
 #include <stdx/ct_format.hpp>
 #include <stdx/ct_string.hpp>
 
+#include <boost/mp11/list.hpp>
 #include <catch2/catch_template_test_macros.hpp>
 #include <catch2/catch_test_macros.hpp>
 #include <fmt/format.h>
@@ -163,10 +164,15 @@ namespace {
 std::vector<std::string> debug_events{};
 
 struct debug_handler {
-    template <stdx::ct_string C, stdx::ct_string L, stdx::ct_string S,
-              typename Ctx>
+    template <stdx::ct_string C, stdx::ct_string S, typename Ctx>
     constexpr auto signal(auto &&...) {
-        debug_events.push_back(fmt::format("{} {} {}", C, L, S));
+        if constexpr (std::is_same_v<async::debug::tag_of<Ctx>,
+                                     async::trigger_scheduler_sender_t>) {
+            static_assert(
+                boost::mp11::mp_empty<async::debug::children_of<Ctx>>::value);
+            debug_events.push_back(
+                fmt::format("{} {} {}", C, async::debug::name_of<Ctx>, S));
+        }
     }
 };
 } // namespace

--- a/test/sequence.cpp
+++ b/test/sequence.cpp
@@ -219,12 +219,13 @@ namespace {
 std::vector<std::string> debug_events{};
 
 struct debug_handler {
-    template <stdx::ct_string C, stdx::ct_string L, stdx::ct_string S,
-              typename Ctx>
+    template <stdx::ct_string C, stdx::ct_string S, typename Ctx>
     constexpr auto signal(auto &&...) {
         using namespace stdx::literals;
-        if constexpr (L != "just"_cts) {
-            debug_events.push_back(fmt::format("{} {} {}", C, L, S));
+        if constexpr (std::is_same_v<async::debug::tag_of<Ctx>,
+                                     async::sequence_t>) {
+            debug_events.push_back(
+                fmt::format("{} {} {}", C, async::debug::name_of<Ctx>, S));
         }
     }
 };

--- a/test/start_detached.cpp
+++ b/test/start_detached.cpp
@@ -279,12 +279,12 @@ namespace {
 std::vector<std::string> debug_events{};
 
 struct debug_handler {
-    template <stdx::ct_string C, stdx::ct_string L, stdx::ct_string S,
-              typename Ctx>
+    template <stdx::ct_string C, stdx::ct_string S, typename Ctx>
     constexpr auto signal(auto &&...) {
-        if constexpr (stdx::is_specialization_of_v<
-                          Ctx, async::_start_detached::op_state>) {
-            debug_events.push_back(fmt::format("{} {} {}", C, L, S));
+        if constexpr (std::is_same_v<async::debug::tag_of<Ctx>,
+                                     async::start_detached_t>) {
+            debug_events.push_back(
+                fmt::format("{} {} {}", C, async::debug::name_of<Ctx>, S));
         }
     }
 };

--- a/test/upon_error.cpp
+++ b/test/upon_error.cpp
@@ -107,12 +107,13 @@ namespace {
 std::vector<std::string> debug_events{};
 
 struct debug_handler {
-    template <stdx::ct_string C, stdx::ct_string L, stdx::ct_string S,
-              typename Ctx>
+    template <stdx::ct_string C, stdx::ct_string S, typename Ctx>
     constexpr auto signal(auto &&...) {
         using namespace stdx::literals;
-        if constexpr (L != "just_error"_cts) {
-            debug_events.push_back(fmt::format("{} {} {}", C, L, S));
+        if constexpr (std::is_same_v<async::debug::tag_of<Ctx>,
+                                     async::upon_error_t>) {
+            debug_events.push_back(
+                fmt::format("{} {} {}", C, async::debug::name_of<Ctx>, S));
         }
     }
 };

--- a/test/upon_stopped.cpp
+++ b/test/upon_stopped.cpp
@@ -83,12 +83,13 @@ namespace {
 std::vector<std::string> debug_events{};
 
 struct debug_handler {
-    template <stdx::ct_string C, stdx::ct_string L, stdx::ct_string S,
-              typename Ctx>
+    template <stdx::ct_string C, stdx::ct_string S, typename Ctx>
     constexpr auto signal(auto &&...) {
         using namespace stdx::literals;
-        if constexpr (L != "just_stopped"_cts) {
-            debug_events.push_back(fmt::format("{} {} {}", C, L, S));
+        if constexpr (std::is_same_v<async::debug::tag_of<Ctx>,
+                                     async::upon_stopped_t>) {
+            debug_events.push_back(
+                fmt::format("{} {} {}", C, async::debug::name_of<Ctx>, S));
         }
     }
 };

--- a/test/when_all.cpp
+++ b/test/when_all.cpp
@@ -16,6 +16,7 @@
 #include <stdx/ct_format.hpp>
 #include <stdx/tuple_destructure.hpp>
 
+#include <boost/mp11/list.hpp>
 #include <catch2/catch_test_macros.hpp>
 #include <fmt/format.h>
 
@@ -306,13 +307,13 @@ std::vector<std::string> debug_events{};
 struct debug_handler {
     std::mutex m{};
 
-    template <stdx::ct_string C, stdx::ct_string L, stdx::ct_string S,
-              typename Ctx>
+    template <stdx::ct_string C, stdx::ct_string S, typename Ctx>
     auto signal(auto &&...) {
-        using namespace stdx::literals;
-        if constexpr (L != "just"_cts) {
+        if constexpr (std::same_as<async::debug::tag_of<Ctx>,
+                                   async::when_all_t>) {
             std::lock_guard l{m};
-            debug_events.push_back(fmt::format("{} {} {}", C, L, S));
+            debug_events.push_back(
+                fmt::format("{} {} {}", C, async::debug::name_of<Ctx>, S));
         }
     }
 };

--- a/test/when_any.cpp
+++ b/test/when_any.cpp
@@ -17,6 +17,7 @@
 #include <stdx/ct_format.hpp>
 #include <stdx/type_traits.hpp>
 
+#include <boost/mp11/list.hpp>
 #include <catch2/catch_test_macros.hpp>
 #include <fmt/format.h>
 
@@ -377,13 +378,13 @@ std::vector<std::string> debug_events{};
 struct debug_handler {
     std::mutex m{};
 
-    template <stdx::ct_string C, stdx::ct_string L, stdx::ct_string S,
-              typename Ctx>
+    template <stdx::ct_string C, stdx::ct_string S, typename Ctx>
     auto signal(auto &&...) {
-        using namespace stdx::literals;
-        if constexpr (L != "just"_cts) {
+        if constexpr (std::same_as<async::debug::tag_of<Ctx>,
+                                   async::when_any_t>) {
             std::lock_guard l{m};
-            debug_events.push_back(fmt::format("{} {} {}", C, L, S));
+            debug_events.push_back(
+                fmt::format("{} {} {}", C, async::debug::name_of<Ctx>, S));
         }
     }
 };


### PR DESCRIPTION
Problem:
- A debug context is an opaque type with no useful API. Doing something useful with debugging requires a lot of work.

Solution:
- Add a concept that debug contexts model, that provides a more useful API.
- A debug context has:
  - A `name` (a `stdx::ct_string`) -- which was previously called the link name
  - A `tag` which represents a simple categorization of the link type
  - A `type` which is the previous opaque type of the operation state
  - `children` which is the list of debug contexts of its contained senders