### PR TITLE
:arrow_up: Update stdx, fix tuple usage

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,7 +15,7 @@ else()
     cpmaddpackage("gh:intel/cicd-repo-infrastructure#3e2bef0")
 endif()
 
-add_versioned_package("gh:intel/cpp-std-extensions#5196d26")
+add_versioned_package("gh:intel/cpp-std-extensions#67120f7")
 add_versioned_package("gh:intel/cpp-baremetal-concurrency#659771e")
 add_versioned_package("gh:boostorg/mp11#boost-1.83.0")
 

--- a/include/async/compose.hpp
+++ b/include/async/compose.hpp
@@ -12,6 +12,9 @@
 namespace async {
 namespace _compose {
 template <typename... As> struct adaptor {
+    template <typename... Ts>
+    constexpr adaptor(Ts &&...ts) : as{std::forward<Ts>(ts)...} {}
+
     using is_adaptor_composition = void;
     stdx::tuple<As...> as;
 
@@ -25,6 +28,7 @@ template <typename... As> struct adaptor {
     }
 };
 
+template <typename... Ts> adaptor(Ts...) -> adaptor<Ts...>;
 template <typename... Ts> adaptor(stdx::tuple<Ts...>) -> adaptor<Ts...>;
 
 template <typename S>

--- a/include/async/continue_on.hpp
+++ b/include/async/continue_on.hpp
@@ -31,9 +31,8 @@ template <typename Sched> struct pipeable {
 
 template <typename Sched>
 [[nodiscard]] constexpr auto continue_on(Sched &&sched) {
-    return _compose::adaptor{
-        stdx::tuple{_continue_on::pipeable<std::remove_cvref_t<Sched>>{
-            std::forward<Sched>(sched)}}};
+    return _compose::adaptor{_continue_on::pipeable<std::remove_cvref_t<Sched>>{
+        std::forward<Sched>(sched)}};
 }
 
 template <sender S, typename Sched>

--- a/include/async/env.hpp
+++ b/include/async/env.hpp
@@ -51,12 +51,17 @@ template <typename Query> struct has_query {
 };
 } // namespace detail
 
-template <typename... Envs> struct env : stdx::tuple<Envs...> {
+template <typename... Envs> struct env {
+    template <typename... Es>
+    constexpr env(Es &&...es) : children{std::forward<Es>(es)...} {}
+
+    stdx::tuple<Envs...> children{};
+
     template <detail::valid_query_over<Envs...> Query>
     constexpr auto query(Query q) const -> decltype(auto) {
-        using I = boost::mp11::mp_find_if_q<stdx::tuple<Envs...>,
+        using I = boost::mp11::mp_find_if_q<boost::mp11::mp_list<Envs...>,
                                             detail::has_query<Query>>;
-        return q(this->operator[](I{}));
+        return q(children[I{}]);
     }
 };
 template <typename... Envs>

--- a/include/async/let_error.hpp
+++ b/include/async/let_error.hpp
@@ -20,9 +20,9 @@ using sender = _let::sender<Name, S, F, set_error_t>;
 
 template <stdx::ct_string Name = "let_error", stdx::callable F>
 [[nodiscard]] constexpr auto let_error(F &&f) {
-    return _compose::adaptor{stdx::tuple{
+    return _compose::adaptor{
         _let::pipeable<Name, std::remove_cvref_t<F>, _let_error::sender>{
-            std::forward<F>(f)}}};
+            std::forward<F>(f)}};
 }
 
 template <stdx::ct_string Name = "let_error", sender S, stdx::callable F>

--- a/include/async/let_stopped.hpp
+++ b/include/async/let_stopped.hpp
@@ -20,9 +20,9 @@ using sender = _let::sender<Name, S, F, set_stopped_t>;
 
 template <stdx::ct_string Name = "let_stopped", stdx::callable F>
 [[nodiscard]] constexpr auto let_stopped(F &&f) {
-    return _compose::adaptor{stdx::tuple{
+    return _compose::adaptor{
         _let::pipeable<Name, std::remove_cvref_t<F>, _let_stopped::sender>{
-            std::forward<F>(f)}}};
+            std::forward<F>(f)}};
 }
 
 template <stdx::ct_string Name = "let_stopped", sender S, stdx::callable F>

--- a/include/async/let_value.hpp
+++ b/include/async/let_value.hpp
@@ -20,9 +20,9 @@ using sender = _let::sender<Name, S, F, set_value_t>;
 
 template <stdx::ct_string Name = "let_value", stdx::callable F>
 [[nodiscard]] constexpr auto let_value(F &&f) {
-    return _compose::adaptor{stdx::tuple{
+    return _compose::adaptor{
         _let::pipeable<Name, std::remove_cvref_t<F>, _let_value::sender>{
-            std::forward<F>(f)}}};
+            std::forward<F>(f)}};
 }
 
 template <stdx::ct_string Name = "let_value", sender S, stdx::callable F>

--- a/include/async/sequence.hpp
+++ b/include/async/sequence.hpp
@@ -161,8 +161,8 @@ template <stdx::ct_string Name, std::invocable F> struct pipeable {
 
 template <stdx::ct_string Name = "sequence", std::invocable F>
 [[nodiscard]] constexpr auto sequence(F &&f) {
-    return _compose::adaptor{stdx::tuple{
-        _sequence::pipeable<Name, std::remove_cvref_t<F>>{std::forward<F>(f)}}};
+    return _compose::adaptor{
+        _sequence::pipeable<Name, std::remove_cvref_t<F>>{std::forward<F>(f)}};
 }
 
 template <stdx::ct_string Name = "sequence", sender S, std::invocable F>

--- a/include/async/timeout_after.hpp
+++ b/include/async/timeout_after.hpp
@@ -40,10 +40,10 @@ template <typename Domain = timer_mgr::default_domain,
                   "set_stopped cannot send values");
     static_assert(not std::is_same_v<Tag, set_error_t> or sizeof...(Vs) == 1,
                   "set_error should send one value only");
-    return _compose::adaptor{stdx::tuple{
+    return _compose::adaptor{
         _timeout_after::pipeable<Domain, Tag, std::remove_cvref_t<Duration>,
                                  std::remove_cvref_t<Vs>...>{
-            std::forward<Duration>(d), {std::forward<Vs>(vs)...}}}};
+            std::forward<Duration>(d), {std::forward<Vs>(vs)...}}};
 }
 
 template <typename Domain = timer_mgr::default_domain,

--- a/include/async/when_any.hpp
+++ b/include/async/when_any.hpp
@@ -526,8 +526,8 @@ template <stdx::ct_string Name = "first_successful", sender... Sndrs>
 template <stdx::ct_string Name = "stop_when", typename Trigger>
 [[nodiscard]] constexpr auto stop_when(Trigger &&t) {
     return _compose::adaptor{
-        stdx::tuple{_when_any::pipeable<Name, std::remove_cvref_t<Trigger>>{
-            std::forward<Trigger>(t)}}};
+        _when_any::pipeable<Name, std::remove_cvref_t<Trigger>>{
+            std::forward<Trigger>(t)}};
 }
 
 template <stdx::ct_string Name = "stop_when", sender Sndr, sender Trigger>


### PR DESCRIPTION
Problem:
- A couple of constructs (env, adaptor) use tuples in a way that causes clang-18 to crash.

Solution:
- Fix them up. No behaviour change here, just pacifying the compiler.