### PR TITLE
:sparkles: Add `seq(s1, s2)`

### DIFF
--- a/include/async/sequence.hpp
+++ b/include/async/sequence.hpp
@@ -175,6 +175,11 @@ template <stdx::ct_string Name = "seq", sender S>
     return sequence<Name>(_sequence::detail::wrapper{std::forward<S>(s)});
 }
 
+template <stdx::ct_string Name = "seq", sender S1, sender S2>
+[[nodiscard]] constexpr auto seq(S1 &&s1, S2 &&s2) -> sender auto {
+    return std::forward<S1>(s1) | seq<Name>(std::forward<S2>(s2));
+}
+
 struct sequence_t;
 
 template <typename...> struct undef;

--- a/test/sequence.cpp
+++ b/test/sequence.cpp
@@ -158,6 +158,14 @@ TEST_CASE("seq(sender) is shorthand for sequence([] { return sender; })",
     CHECK(value == 42);
 }
 
+TEST_CASE("seq(s1, s2) is the same as s1 | seq(s2)", "[sequence]") {
+    int value{};
+    auto s = async::seq(async::just(), async::just(42));
+    auto op = async::connect(s, receiver{[&](auto i) { value = i; }});
+    async::start(op);
+    CHECK(value == 42);
+}
+
 TEST_CASE("seq(sender) with move-only sender", "[sequence]") {
     int value{};
     auto s = async::just() | async::seq(async::just(move_only{42}));


### PR DESCRIPTION
Problem:
- `seq` works in piped form (`s1 | seq(s2)`) but not in function form (`seq(s1, s2)`).

Solution:
- Add `seq(s1, s2)`