### PR TITLE
:bug: Fix `sync_wait` to be `[[nodiscard]]` when piped

### DIFF
--- a/include/async/sync_wait.hpp
+++ b/include/async/sync_wait.hpp
@@ -79,7 +79,7 @@ template <typename Uniq, typename Env> struct pipeable {
 
   private:
     template <async::sender S, stdx::same_as_unqualified<pipeable> Self>
-    friend auto operator|(S &&s, Self &&self) {
+    [[nodiscard]] friend auto operator|(S &&s, Self &&self) {
         return wait<Uniq>(std::forward<S>(s), std::forward<Self>(self).e);
     }
 };


### PR DESCRIPTION
Problem:
- `sync_wait(s)` is `[[nodiscard]]` but `s | sync_wait()` is not.

Solution:
- Mark `operator|` on `sync_wait` as `[[nodiscard]]`.