### PR TITLE
:art: Allow a sender to cause its own timeout with `timeout_after`

### DIFF
--- a/include/async/when_any.hpp
+++ b/include/async/when_any.hpp
@@ -492,10 +492,9 @@ template <stdx::ct_string Name, typename Sndr> struct pipeable {
   private:
     template <async::sender S, stdx::same_as_unqualified<pipeable> Self>
     friend constexpr auto operator|(S &&s, Self &&self) -> async::sender auto {
-        return sender<Name, first_complete,
-                      sub_sender<std::remove_cvref_t<S>, 0>,
-                      sub_sender<Sndr, 1>>{std::forward<S>(s),
-                                           std::forward<Self>(self).sndr};
+        return sender<Name, first_complete, sub_sender<Sndr, 0>,
+                      sub_sender<std::remove_cvref_t<S>, 1>>{
+            std::forward<Self>(self).sndr, std::forward<S>(s)};
     }
 };
 } // namespace _when_any

--- a/test/when_any.cpp
+++ b/test/when_any.cpp
@@ -186,8 +186,8 @@ TEST_CASE("first_successful policy", "[when_any]") {
 
 TEST_CASE("first_complete policy", "[when_any]") {
     int value{};
-    auto s1 = async::just_stopped();
-    auto s2 = async::just(17);
+    auto s1 = async::just(17);
+    auto s2 = async::just_stopped();
     auto w = async::stop_when(s1, s2);
 
     auto op = async::connect(w, stopped_receiver{[&] {
@@ -247,7 +247,7 @@ TEST_CASE("stop_when is pipeable", "[when_any]") {
                                  value = i;
                              }});
     async::start(op);
-    CHECK(value == 42);
+    CHECK(value == 17);
 }
 
 TEST_CASE("stop_when is adaptor-pipeable", "[when_any]") {
@@ -258,7 +258,7 @@ TEST_CASE("stop_when is adaptor-pipeable", "[when_any]") {
                                  value = i;
                              }});
     async::start(op);
-    CHECK(value == 42);
+    CHECK(value == 17);
 }
 
 TEST_CASE("when_any with zero args never completes", "[when_any]") {


### PR DESCRIPTION
Problem:
- `timeout_after(s, to)` cannot cause its own timeout.
- The ability to write a sender that causes its own timeout is useful for tests.

Solution:
- Start the timer sender before the sender to be timed out.
- This means the time allowed includes the time for the sender logic itself, rather than excluding it. That's an arbitrary decision that's easy to account for in production code, and starting the timer first means that tests can easily rig the sender to cause its own timeout, for easy timeout test scenarios.

Notes:
- Compare: `incite_on`. `timeout_after` is similar in this respect.