### PR TITLE
:sparkles: Add `periodic` adapter

### DIFF
--- a/docs/schedulers.adoc
+++ b/docs/schedulers.adoc
@@ -218,6 +218,11 @@ async::timer_mgr::service_task();
 // x is now 42
 ----
 
+It is also possible to create a `time_scheduler` without specifying a duration:
+in this case it will use the connect receiver's environment to obtain an
+`expiration_provider` in order to compute the expiration time. The xref:sender_adaptors.adoc#_periodic[`periodic`]
+adapter uses such an environment to achieve drift-free periodic scheduling.
+
 ==== HAL interaction
 
 The various HAL functions are called as follows:

--- a/docs/sender_adaptors.adoc
+++ b/docs/sender_adaptors.adoc
@@ -175,13 +175,104 @@ auto let_sndr = async::let_value(
 This works: using the helper function `make_variant_sender`, `let_value` can
 successfully make a runtime choice about which sender to proceed with.
 
+=== `periodic`
+
+Found in the header: `async/periodic.hpp`
+
+`periodic` takes a sender and repeats it indefinitely according to the given
+time period. When the sender completes with a value, it is reconnected and
+restarted (rescheduled). A `periodic` sender will not complete on the value
+channel, but can still be stopped, or complete with an error.
+
+[source,cpp]
+----
+auto s = time_scheduler{}.sender() | ... ;
+auto p = s | async::periodic(1s);
+// when p runs, s is scheduled for 1 second in the future. If s sends an error
+// or is stopped, p reflects that. If s completes successfully, the result is
+// discarded and s runs again, another second in the future.
+----
+
+NOTE: `periodic` works hand-in-glove (and only) with a
+xref:schedulers.adoc#_time_scheduler[`time_scheduler`] sender that is not given
+a duration.
+
+IMPORTANT: To avoid drift, `periodic` reschedules itself based not on the
+current time, but on its expiration time. However the periodic invariant breaks
+down if a task takes longer to complete than its period (which may happen if
+tasks can spike in the time taken to execute them). In that case, by default,
+`periodic` will reschedule immediately - but this behaviour can be
+parameterized.
+
+[source,cpp]
+----
+auto s = time_scheduler{}.sender() | ... ;
+
+// safe_immediate_expiry is the default behaviour: if the sender exceeds 1s, so
+// that its next execution time would occur in the past, then instead it will be
+// rescheduled immediately.
+auto p1 = s | async::periodic<"name", async::safe_immediate_expiry>(1s);
+
+// safe_quantized_expiry means that if the sender's next execution time would
+// occur in the past, instead it will be rescheduled for the next time its
+// "tick" would occur. i.e. one or more "ticks" will be skipped.
+auto p2 = s | async::periodic<"name", async::safe_quantized_expiry>(1s);
+
+// unsafe_expiry means that no checks happen: if the sender's next execution
+// time occurs in the past, so be it. This is unsafe since it has the potential
+// to cause a growing backlog.
+auto p3 = s | async::periodic<"name", async::unsafe_expiry>(1s);
+----
+
+The `"name"` given to the `periodic` adaptor here will show up in
+xref:debug.adoc#_naming_senders_and_operations[debug output].
+
+=== `periodic_n`
+
+Found in the header: `async/periodic.hpp`
+
+`periodic_n` works the same way as `periodic`, but repeats a given number of times.
+
+[source,cpp]
+----
+auto s = time_scheduler{}.sender() | ... ;
+auto p = s | async::periodic_n(1s, 5);
+// p repeats s 5 times
+----
+
+NOTE: `periodic_n` must always run at least once to be able to complete. So
+`periodic_n(1s, 1)` repeats once, i.e. runs twice. `periodic_n(1s, 0)` runs once
+(thus is equivalent to instead starting the sender chain with
+`time_scheduler{1s}.sender()`).
+
+=== `periodic_until`
+
+Found in the header: `async/periodic.hpp`
+
+`periodic_until` works the same way as `periodic`, but repeats the sender until a
+given predicate returns true.
+
+[source,cpp]
+----
+auto s = time_scheduler{}.sender() | ... ;
+auto p = s | async::periodic_until(1s, [] (auto&&...) { return true; });
+----
+
+NOTE: The arguments passed to the predicate are those in the value completion(s)
+of the sender.
+
+NOTE: `periodic` never completes other than by error or cancellation, but
+`periodic_n` and `periodic_until` both complete successfully with the same
+completion as the adapted sender.
+
 === `repeat`
 
 Found in the header: `async/repeat.hpp`
 
 `repeat` takes a sender and repeats it indefinitely. When the sender completes
-with a value, it is reconnected and restarted. This is useful for periodic
-tasks. A `repeat` sender can still be stopped, or complete with an error.
+with a value, it is reconnected and restarted. This is useful for tasks that
+should repeat immediately on finishing. A `repeat` sender can still be stopped,
+or complete with an error.
 
 [source,cpp]
 ----
@@ -191,9 +282,10 @@ auto s = some_sender | async::repeat();
 // and some_sender runs again.
 ----
 
-CAUTION: `repeat` can cause stack overflows if used with a scheduler that
-doesn't break the callstack, like
-xref:schedulers.adoc#_inline_scheduler[`inline_scheduler`].
+NOTE: The difference between `periodic` and `repeat` is that `periodic`
+interacts with the `time_scheduler` to eliminate any drift caused by
+bookkeeping. `repeat` of a periodic task may exhibit drift. `periodic` must work
+with a `time_scheduler` sender; `repeat` can work with any sender.
 
 === `repeat_n`
 
@@ -219,6 +311,10 @@ auto s = some_sender | async::repeat_until([] (auto&&...) { return true; });
 
 NOTE: The arguments passed to the predicate are those in the value completion(s)
 of the sender.
+
+NOTE: `repeat` never completes other than by error or cancellation, but
+`repeat_n` and `repeat_until` both complete successfully with the same
+completion as the adapted sender.
 
 === `retry`
 

--- a/docs/synopsis.adoc
+++ b/docs/synopsis.adoc
@@ -86,6 +86,11 @@ by `let_error.hpp`, `let_stopped.hpp`, and `let_value.hpp`
 ==== https://github.com/intel/cpp-baremetal-senders-and-receivers/blob/main/include/async/let_value.hpp[let_value.hpp]
 * `let_value` - a xref:sender_adaptors.adoc#_let_value[sender adaptor] that can make runtime decisions on the value channel
 
+==== https://github.com/intel/cpp-baremetal-senders-and-receivers/blob/main/include/async/periodic.hpp[periodic.hpp]
+* `periodic` - a xref:sender_adaptors.adoc#_periodic[sender adaptor] that repeats a sender indefinitely, periodically without drift
+* `periodic_n` - a xref:sender_adaptors.adoc#_periodic_n[sender adaptor] that repeats a sender a set number of times, periodically without drift
+* `periodic_until` - a xref:sender_adaptors.adoc#_periodic_until[sender adaptor] that repeats a sender until a condition becomes true, periodically without drift
+
 ==== https://github.com/intel/cpp-baremetal-senders-and-receivers/blob/main/include/async/read_env.hpp[read_env.hpp]
 * `get_scheduler` - a sender factory equivalent to `read_env(get_scheduler_t{})`
 * `get_stop_token` - a sender factory equivalent to `read_env(get_stop_token_t{})`
@@ -247,6 +252,9 @@ contains traits and metaprogramming constructs used by many senders.
 * `operation_state<O>` - https://github.com/intel/cpp-baremetal-senders-and-receivers/blob/main/include/async/concepts.hpp[`#include <async/concepts.hpp>`]
 * `priority_t` - https://github.com/intel/cpp-baremetal-senders-and-receivers/blob/main/include/async/schedulers/task_manager_interface.hpp[`#include <async/schedulers/task_manager_interface.hpp>`]
 * `priority_task_manager<HAL, NumPriorities>` - https://github.com/intel/cpp-baremetal-senders-and-receivers/blob/main/include/async/schedulers/task_manager.hpp[`#include <async/schedulers/task_manager.hpp>`]
+* xref:sender_adaptors.adoc#_periodic[`periodic`] - https://github.com/intel/cpp-baremetal-senders-and-receivers/blob/main/include/async/periodic.hpp[`#include <async/periodic.hpp>`]
+* xref:sender_adaptors.adoc#_periodic_n[`periodic_n`] - https://github.com/intel/cpp-baremetal-senders-and-receivers/blob/main/include/async/periodic.hpp[`#include <async/periodic.hpp>`]
+* xref:sender_adaptors.adoc#_periodic_until[`periodic_until`] - https://github.com/intel/cpp-baremetal-senders-and-receivers/blob/main/include/async/periodic.hpp[`#include <async/periodic.hpp>`]
 * xref:sender_factories.adoc#_read_env[`read_env`] - https://github.com/intel/cpp-baremetal-senders-and-receivers/blob/main/include/async/read_env.hpp[`#include <async/read_env.hpp>`]
 * `receiver<R>` - https://github.com/intel/cpp-baremetal-senders-and-receivers/blob/main/include/async/concepts.hpp[`#include <async/concepts.hpp>`]
 * `receiver_base` - https://github.com/intel/cpp-baremetal-senders-and-receivers/blob/main/include/async/concepts.hpp[`#include <async/concepts.hpp>`]

--- a/include/async/periodic.hpp
+++ b/include/async/periodic.hpp
@@ -1,0 +1,312 @@
+#pragma once
+
+#include <async/completes_synchronously.hpp>
+#include <async/completion_tags.hpp>
+#include <async/compose.hpp>
+#include <async/concepts.hpp>
+#include <async/debug.hpp>
+#include <async/env.hpp>
+#include <async/schedulers/get_expiration.hpp>
+#include <async/schedulers/timer_manager_interface.hpp>
+#include <async/type_traits.hpp>
+
+#include <stdx/concepts.hpp>
+#include <stdx/ct_string.hpp>
+#include <stdx/functional.hpp>
+
+#include <boost/mp11/algorithm.hpp>
+
+#include <algorithm>
+#include <concepts>
+#include <optional>
+#include <type_traits>
+#include <utility>
+#include <variant>
+
+namespace async {
+namespace _periodic {
+template <typename Ops> struct first_expiration_provider {
+    using time_point_t = typename Ops::time_point_t;
+    Ops *ops;
+
+    template <typename Hal>
+    [[nodiscard]] auto compute_expiration() const -> time_point_t {
+        ops->tp = Hal::now() + ops->d;
+        return ops->tp;
+    }
+};
+
+template <typename Ops> struct unsafe_nth_expiration_provider {
+    using time_point_t = typename Ops::time_point_t;
+    Ops *ops;
+
+    template <typename Hal>
+    [[nodiscard]] auto compute_expiration() const -> time_point_t {
+        ops->tp += ops->d;
+        return ops->tp;
+    }
+};
+
+template <typename Ops> struct safe_immediate_nth_expiration_provider {
+    using time_point_t = typename Ops::time_point_t;
+    Ops *ops;
+
+    template <typename Hal>
+    [[nodiscard]] auto compute_expiration() const -> time_point_t {
+        ops->tp += ops->d;
+        ops->tp = std::max(ops->tp, Hal::now());
+        return ops->tp;
+    }
+};
+
+template <typename Ops> struct safe_quantized_nth_expiration_provider {
+    using time_point_t = typename Ops::time_point_t;
+    Ops *ops;
+
+    template <typename Hal>
+    [[nodiscard]] auto compute_expiration() const -> time_point_t {
+        ops->tp += ops->d;
+        if (auto now = Hal::now(); ops->tp < now) {
+            auto diff = --(now - ops->tp);
+            auto num_ticks = (diff / ops->d) + 1;
+            ops->tp += ops->d * num_ticks;
+        }
+        return ops->tp;
+    }
+};
+
+template <typename Ops, template <typename> typename Expiry> struct receiver {
+    using is_receiver = void;
+
+    Ops *ops;
+
+    template <typename... Args>
+    auto set_value(Args &&...args) const && -> void {
+        ops->repeat(std::forward<Args>(args)...);
+    }
+    template <typename... Args>
+    auto set_error(Args &&...args) const && -> void {
+        ops->template passthrough<set_error_t>(std::forward<Args>(args)...);
+    }
+    auto set_stopped() const && -> void {
+        ops->template passthrough<set_stopped_t>();
+    }
+
+    [[nodiscard]] constexpr auto query(get_env_t) const
+        -> overriding_env<timer_mgr::get_expiration_t, Expiry<Ops>,
+                          typename Ops::downstream_receiver_t> {
+        return override_env_with<timer_mgr::get_expiration_t>(
+            Expiry<Ops>{this->ops}, this->ops->get_receiver());
+    }
+};
+
+constexpr auto never_stop = [](auto &&...) { return false; };
+
+template <typename Pred, typename Sig, typename = void>
+struct is_callable : std::false_type {};
+template <typename Pred, typename... Args>
+struct is_callable<Pred, set_value_t(Args...),
+                   std::void_t<std::invoke_result_t<Pred, Args...>>>
+    : std::true_type {};
+
+template <typename Pred> struct callable_with {
+    template <typename Sig> using fn = is_callable<Pred, Sig>;
+};
+
+template <template <typename> typename Expiry> struct expiry_wrapper {
+    template <typename T> using fn = Expiry<T>;
+};
+
+template <stdx::ct_string Name, typename Expiry, typename Sndr, typename Rcvr,
+          typename Duration, stdx::callable Pred>
+// NOLINTNEXTLINE(cppcoreguidelines-special-member-functions)
+struct op_state {
+    using downstream_receiver_t = Rcvr;
+    using time_point_t = timer_mgr::time_point_for_t<Duration>;
+
+    using first_receiver_t = receiver<op_state, first_expiration_provider>;
+    using nth_receiver_t = receiver<op_state, Expiry::template fn>;
+
+    using value_completions =
+        value_signatures_of_t<Sndr, env_of_t<nth_receiver_t>>;
+    static_assert(
+        boost::mp11::mp_all_of_q<value_completions, callable_with<Pred>>::value,
+        "Predicate is not callable with value completions of sender");
+
+    using first_state_t = async::connect_result_t<Sndr &, first_receiver_t>;
+    using nth_state_t = async::connect_result_t<Sndr &, nth_receiver_t>;
+
+    template <stdx::same_as_unqualified<Sndr> S,
+              stdx::same_as_unqualified<Rcvr> R,
+              stdx::same_as_unqualified<Pred> P>
+    // NOLINTNEXTLINE(bugprone-forwarding-reference-overload)
+    constexpr op_state(S &&s, R &&r, Duration dur, P &&p)
+        : sndr{std::forward<S>(s)}, rcvr{std::forward<R>(r)}, d{dur},
+          pred{std::forward<P>(p)} {}
+    constexpr op_state(op_state &&) = delete;
+
+    constexpr auto start() & -> void {
+        static_assert(not synchronous_t<first_state_t>::value,
+                      "periodic doesn't make sense with synchronous senders");
+
+        state.template emplace<1>(stdx::with_result_of{
+            [&] { return connect(sndr, first_receiver_t{this}); }});
+        debug_signal<"start", debug::erased_context_for<op_state>>(
+            get_env(rcvr));
+        async::start(std::get<1>(state));
+    }
+
+    constexpr auto restart() & -> void {
+        state.template emplace<2>(stdx::with_result_of{
+            [&] { return connect(sndr, nth_receiver_t{this}); }});
+        debug_signal<"start", debug::erased_context_for<op_state>>(
+            get_env(rcvr));
+        async::start(std::get<2>(state));
+    }
+
+    template <typename... Args> auto repeat(Args &&...args) -> void {
+        if constexpr (not std::same_as<
+                          Pred, std::remove_cvref_t<decltype(never_stop)>>) {
+            debug_signal<"eval_predicate", debug::erased_context_for<op_state>>(
+                get_env(rcvr));
+            if (pred(args...)) {
+                debug_signal<set_value_t::name,
+                             debug::erased_context_for<op_state>>(
+                    get_env(rcvr));
+                set_value(std::move(rcvr), std::forward<Args>(args)...);
+                state.template emplace<0>();
+                return;
+            }
+        }
+        restart();
+    }
+
+    template <channel_tag Tag, typename... Args>
+    auto passthrough(Args &&...args) -> void {
+        debug_signal<Tag::name, debug::erased_context_for<op_state>>(
+            get_env(rcvr));
+        Tag{}(std::move(rcvr), std::forward<Args>(args)...);
+        state.template emplace<0>();
+    }
+
+    [[nodiscard]] auto get_receiver() const -> Rcvr const & { return rcvr; }
+
+    [[no_unique_address]] Sndr sndr;
+    [[no_unique_address]] Rcvr rcvr;
+    Duration d;
+    [[no_unique_address]] Pred pred;
+    time_point_t tp{};
+    std::variant<std::monostate, first_state_t, nth_state_t> state{};
+};
+
+template <stdx::ct_string Name, typename Expiry, typename Sndr,
+          typename Duration, typename Pred>
+struct sender {
+    using is_sender = void;
+    [[no_unique_address]] Sndr sndr;
+    Duration d;
+    [[no_unique_address]] Pred p;
+
+    [[nodiscard]] constexpr auto query(async::get_env_t) const {
+        return forward_env_of(sndr);
+    }
+
+    template <typename...> using signatures = completion_signatures<>;
+
+    template <typename Env>
+    [[nodiscard]] constexpr static auto get_completion_signatures(Env const &) {
+        if constexpr (std::same_as<Pred,
+                                   std::remove_cvref_t<decltype(never_stop)>>) {
+            return transform_completion_signatures_of<
+                Sndr, Env, completion_signatures<>, signatures>{};
+        } else {
+            return completion_signatures_of_t<Sndr, Env>{};
+        }
+    }
+
+    template <async::receiver R>
+        requires multishot_sender<
+            Sndr, typename op_state<Name, Expiry, Sndr, std::remove_cvref_t<R>,
+                                    Duration, Pred>::nth_receiver_t>
+    [[nodiscard]] constexpr auto
+    connect(R &&r) const & -> op_state<Name, Expiry, Sndr,
+                                       std::remove_cvref_t<R>, Duration, Pred> {
+        return {sndr, std::forward<R>(r), d, p};
+    }
+};
+
+template <stdx::ct_string Name, typename Expiry, typename Duration,
+          stdx::callable Pred>
+struct pipeable {
+    Duration d;
+    Pred p;
+
+  private:
+    template <async::sender S, stdx::same_as_unqualified<pipeable> Self>
+    friend constexpr auto operator|(S &&s, Self &&self) -> async::sender auto {
+        return sender<Name, Expiry, std::remove_cvref_t<S>, Duration, Pred>{
+            std::forward<S>(s), std::forward<Self>(self).d,
+            std::forward<Self>(self).p};
+    }
+};
+} // namespace _periodic
+
+using safe_immediate_expiry = _periodic::expiry_wrapper<
+    _periodic::safe_immediate_nth_expiration_provider>;
+using safe_quantized_expiry = _periodic::expiry_wrapper<
+    _periodic::safe_quantized_nth_expiration_provider>;
+using unsafe_expiry =
+    _periodic::expiry_wrapper<_periodic::unsafe_nth_expiration_provider>;
+
+template <stdx::ct_string Name = "periodic_until",
+          typename Expiry = safe_immediate_expiry, typename Duration,
+          typename P>
+[[nodiscard]] constexpr auto periodic_until(Duration d, P &&p)
+    -> _periodic::pipeable<Name, Expiry, Duration, std::remove_cvref_t<P>> {
+    return {d, std::forward<P>(p)};
+}
+
+template <stdx::ct_string Name = "periodic_until",
+          typename Expiry = safe_immediate_expiry, sender S, typename Duration,
+          typename P>
+[[nodiscard]] auto periodic_until(S &&s, Duration d, P &&p) {
+    return std::forward<S>(s) |
+           periodic_until<Name, Expiry>(d, std::forward<P>(p));
+}
+
+template <stdx::ct_string Name = "periodic",
+          typename Expiry = safe_immediate_expiry, typename Duration>
+[[nodiscard]] constexpr auto periodic(Duration d) {
+    return periodic_until<Name, Expiry>(d, _periodic::never_stop);
+}
+
+template <stdx::ct_string Name = "periodic",
+          typename Expiry = safe_immediate_expiry, sender S, typename Duration>
+[[nodiscard]] auto periodic(S &&s, Duration d) {
+    return std::forward<S>(s) | periodic<Name, Expiry>(d);
+}
+
+template <stdx::ct_string Name = "periodic_n",
+          typename Expiry = safe_immediate_expiry, typename Duration>
+[[nodiscard]] constexpr auto periodic_n(Duration d, unsigned int n) {
+    return periodic_until<Name, Expiry>(
+        d, [n](auto &&...) mutable { return n-- == 0; });
+}
+
+template <stdx::ct_string Name = "periodic_n",
+          typename Expiry = safe_immediate_expiry, sender S, typename Duration>
+[[nodiscard]] auto periodic_n(S &&s, Duration d, unsigned int n) {
+    return std::forward<S>(s) | periodic_n<Name, Expiry>(d, n);
+}
+
+struct periodic_t;
+
+template <stdx::ct_string Name, typename Expiry, typename... Ts>
+struct debug::context_for<_periodic::op_state<Name, Expiry, Ts...>> {
+    using tag = periodic_t;
+    constexpr static auto name = Name;
+    using type = _periodic::op_state<Name, Expiry, Ts...>;
+    using children = stdx::type_list<
+        debug::erased_context_for<typename type::first_state_t>>;
+};
+} // namespace async

--- a/include/async/schedulers/get_expiration.hpp
+++ b/include/async/schedulers/get_expiration.hpp
@@ -3,6 +3,7 @@
 #include <async/forwarding_query.hpp>
 
 #include <stdx/ct_string.hpp>
+#include <stdx/type_traits.hpp>
 
 #include <utility>
 
@@ -12,10 +13,24 @@ constexpr inline struct get_expiration_t : forwarding_query_t {
     constexpr static auto name = stdx::ct_string{"get_expiration"};
 
     template <typename T>
+        requires true
     constexpr auto operator()(T &&t) const noexcept(
         noexcept(std::forward<T>(t).query(std::declval<get_expiration_t>())))
         -> decltype(std::forward<T>(t).query(*this)) {
         return std::forward<T>(t).query(*this);
+    }
+
+    struct default_expiration_provider {
+        struct time_point_t {};
+    };
+
+    template <typename T>
+    constexpr auto operator()(T &&) const -> default_expiration_provider {
+        static_assert(stdx::always_false_v<T>,
+                      "Attempting to connect an externally controlled "
+                      "time_scheduler sender to a receiver whose environment "
+                      "does not provide an expiration provider");
+        return {};
     }
 } get_expiration{};
 } // namespace timer_mgr

--- a/include/async/sequence.hpp
+++ b/include/async/sequence.hpp
@@ -186,8 +186,6 @@ template <stdx::ct_string Name = "seq", sender... S>
 
 struct sequence_t;
 
-template <typename...> struct undef;
-
 template <stdx::ct_string Name, typename Sndr, typename Func, typename Rcvr>
 struct debug::context_for<_sequence::op_state<Name, Sndr, Func, Rcvr>> {
     using tag = sequence_t;

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -39,6 +39,7 @@ add_tests(
     let_multichannel
     let_stopped
     let_value
+    periodic
     read_env
     repeat
     retry

--- a/test/periodic.cpp
+++ b/test/periodic.cpp
@@ -1,0 +1,411 @@
+#include "detail/common.hpp"
+
+#include <async/concepts.hpp>
+#include <async/connect.hpp>
+#include <async/debug.hpp>
+#include <async/just.hpp>
+#include <async/periodic.hpp>
+#include <async/schedulers/time_scheduler.hpp>
+#include <async/schedulers/timer_manager.hpp>
+#include <async/sequence.hpp>
+#include <async/then.hpp>
+
+#include <stdx/ct_format.hpp>
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <chrono>
+#include <concepts>
+
+using namespace std::chrono_literals;
+
+namespace {
+using default_domain = async::timer_mgr::default_domain;
+
+template <typename Domain, typename TP> inline auto current_time = TP{};
+template <typename Domain> inline auto enabled = false;
+template <typename Domain, typename TP> inline auto calls = std::vector<TP>{};
+
+template <typename Domain> struct hal {
+    using time_point_t = std::chrono::steady_clock::time_point;
+    using task_t = async::timer_task<time_point_t>;
+
+    static auto enable() -> void { enabled<Domain> = true; }
+    static auto disable() -> void { enabled<Domain> = false; }
+    static auto set_event_time(time_point_t tp) -> void {
+        CHECK(enabled<Domain>);
+        calls<Domain, time_point_t>.push_back(tp);
+    }
+    static auto now() -> time_point_t {
+        CHECK(enabled<Domain>);
+        return current_time<Domain, time_point_t>;
+    }
+};
+
+using timer_manager_t = async::generic_timer_manager<hal<default_domain>>;
+} // namespace
+
+template <typename Rep, typename Period>
+struct async::timer_mgr::time_point_for<std::chrono::duration<Rep, Period>> {
+    using type = std::chrono::steady_clock::time_point;
+};
+
+template <>
+[[maybe_unused]] inline auto async::injected_timer_manager<> =
+    timer_manager_t{};
+
+TEST_CASE("periodic advertises what it sends", "[periodic]") {
+    [[maybe_unused]] auto s =
+        async::time_scheduler{}.schedule() | async::periodic(1s);
+    static_assert(std::same_as<async::completion_signatures_of_t<decltype(s)>,
+                               async::completion_signatures<>>);
+}
+
+TEST_CASE("periodic advertises sending error", "[periodic]") {
+    [[maybe_unused]] auto s = async::time_scheduler{}.schedule() |
+                              async::seq(async::just_error(42)) |
+                              async::periodic(1s);
+    static_assert(
+        std::same_as<async::completion_signatures_of_t<decltype(s)>,
+                     async::completion_signatures<async::set_error_t(int)>>);
+}
+
+TEST_CASE("periodic advertises sending stopped", "[periodic]") {
+    [[maybe_unused]] auto s = async::time_scheduler{}.schedule() |
+                              async::seq(async::just_stopped()) |
+                              async::periodic(1s);
+    static_assert(
+        std::same_as<async::completion_signatures_of_t<decltype(s)>,
+                     async::completion_signatures<async::set_stopped_t()>>);
+}
+
+TEST_CASE("periodic propagates forwarding queries to its child environment",
+          "[periodic]") {
+    auto s = custom_sender{};
+    CHECK(get_fwd(async::get_env(s)) == 42);
+
+    auto r = async::periodic(s, 1s);
+    CHECK(get_fwd(async::get_env(r)) == 42);
+}
+
+TEST_CASE("periodic_until advertises what it sends", "[periodic]") {
+    [[maybe_unused]] auto s =
+        async::time_scheduler{}.schedule() | async::then([] { return 42; }) |
+        async::periodic_until(1s, [](auto) { return true; });
+    static_assert(
+        std::same_as<async::completion_signatures_of_t<decltype(s)>,
+                     async::completion_signatures<async::set_value_t(int)>>);
+}
+
+TEST_CASE("periodic_n advertises what it sends", "[periodic]") {
+    [[maybe_unused]] auto s = async::time_scheduler{}.schedule() |
+                              async::then([] { return 42; }) |
+                              async::periodic_n(1s, 2);
+    static_assert(
+        std::same_as<async::completion_signatures_of_t<decltype(s)>,
+                     async::completion_signatures<async::set_value_t(int)>>);
+}
+
+TEST_CASE("periodic repeats periodically", "[periodic]") {
+    int var{};
+    [[maybe_unused]] auto s =
+        async::time_scheduler{}.schedule() | async::then([&] { ++var; }) |
+        async::periodic_until(1s, [&] { return var == 2; });
+    auto op = async::connect(s, receiver{[&] { var = 42; }});
+    async::start(op);
+    CHECK(enabled<default_domain>);
+    CHECK(not async::timer_mgr::is_idle());
+    async::timer_mgr::service_task();
+    CHECK(var == 1);
+    CHECK(not async::timer_mgr::is_idle());
+    async::timer_mgr::service_task();
+    CHECK(async::timer_mgr::is_idle());
+    CHECK(var == 42);
+}
+
+TEST_CASE("periodic_n repeats n times", "[periodic]") {
+    int var{};
+    [[maybe_unused]] auto s = async::time_scheduler{}.schedule() |
+                              async::then([&] { ++var; }) |
+                              async::periodic_n(1s, 2);
+    auto op = async::connect(s, receiver{[&] { var = 42; }});
+    async::start(op);
+    CHECK(enabled<default_domain>);
+    CHECK(not async::timer_mgr::is_idle());
+    async::timer_mgr::service_task();
+    CHECK(var == 1);
+    CHECK(not async::timer_mgr::is_idle());
+    async::timer_mgr::service_task();
+    CHECK(var == 2);
+    CHECK(not async::timer_mgr::is_idle());
+    async::timer_mgr::service_task();
+    CHECK(async::timer_mgr::is_idle());
+    CHECK(var == 42);
+}
+
+TEST_CASE("periodic can be cancelled", "[periodic]") {
+    int var{};
+    stoppable_receiver r{[&] { var += 42; }};
+
+    [[maybe_unused]] auto s = async::time_scheduler{}.schedule() |
+                              async::then([&] { ++var; }) | async::periodic(1s);
+    auto op = async::connect(s, r);
+    async::start(op);
+    async::timer_mgr::service_task();
+    CHECK(var == 1);
+    async::timer_mgr::service_task();
+    CHECK(var == 2);
+    r.request_stop();
+    CHECK(async::timer_mgr::is_idle());
+    CHECK(var == 44);
+}
+
+TEST_CASE("periodic sets the correct first expiration time", "[periodic]") {
+    int var{};
+    stoppable_receiver r{[&] { var = 42; }};
+
+    using hal_t = hal<default_domain>;
+    using TP = typename hal_t::time_point_t;
+
+    [[maybe_unused]] auto s =
+        async::time_scheduler{}.schedule() | async::periodic(1s);
+    auto op = async::connect(s, r);
+
+    current_time<default_domain, TP> = TP{1s};
+    calls<default_domain, TP>.clear();
+
+    async::start(op);
+
+    REQUIRE(calls<default_domain, TP>.size() == 1);
+    CHECK(calls<default_domain, TP>[0] == TP{2s});
+    CHECK(not async::timer_mgr::is_idle());
+
+    r.request_stop();
+    CHECK(async::timer_mgr::is_idle());
+    CHECK(var == 42);
+}
+
+TEST_CASE("periodic sets the nth expiration time without drift", "[periodic]") {
+    int var{};
+    stoppable_receiver r{[&] { var = 42; }};
+
+    using hal_t = hal<default_domain>;
+    using TP = typename hal_t::time_point_t;
+
+    [[maybe_unused]] auto s =
+        async::time_scheduler{}.schedule() | async::periodic(1s);
+    auto op = async::connect(s, r);
+
+    current_time<default_domain, TP> = TP{1s};
+    calls<default_domain, TP>.clear();
+
+    async::start(op);
+
+    REQUIRE(calls<default_domain, TP>.size() == 1);
+    CHECK(calls<default_domain, TP>[0] == TP{2s});
+    CHECK(not async::timer_mgr::is_idle());
+
+    current_time<default_domain, TP> = TP{2001ms};
+    async::timer_mgr::service_task();
+    REQUIRE(calls<default_domain, TP>.size() == 2);
+    CHECK(calls<default_domain, TP>[1] == TP{3s});
+    CHECK(not async::timer_mgr::is_idle());
+
+    r.request_stop();
+    CHECK(async::timer_mgr::is_idle());
+    CHECK(var == 42);
+}
+
+TEST_CASE("periodic sets the nth expiration time safely", "[periodic]") {
+    int var{};
+    stoppable_receiver r{[&] { var = 42; }};
+
+    using hal_t = hal<default_domain>;
+    using TP = typename hal_t::time_point_t;
+
+    [[maybe_unused]] auto s =
+        async::time_scheduler{}.schedule() | async::periodic(1s);
+    auto op = async::connect(s, r);
+
+    current_time<default_domain, TP> = TP{1s};
+    calls<default_domain, TP>.clear();
+
+    async::start(op);
+
+    REQUIRE(calls<default_domain, TP>.size() == 1);
+    CHECK(calls<default_domain, TP>[0] == TP{2s});
+    CHECK(not async::timer_mgr::is_idle());
+
+    current_time<default_domain, TP> = TP{3500ms};
+    async::timer_mgr::service_task();
+    REQUIRE(calls<default_domain, TP>.size() == 2);
+    CHECK(calls<default_domain, TP>[1] == TP{3500ms});
+    CHECK(not async::timer_mgr::is_idle());
+
+    r.request_stop();
+    CHECK(async::timer_mgr::is_idle());
+    CHECK(var == 42);
+}
+
+namespace {
+struct ops_time {
+    using time_point_t = std::chrono::steady_clock::time_point;
+    time_point_t tp{};
+    std::chrono::milliseconds d{};
+};
+} // namespace
+
+TEST_CASE("quantized provider advances to next tick", "[periodic]") {
+    using hal_t = hal<default_domain>;
+    using TP = typename hal_t::time_point_t;
+
+    ops_time t{TP{1s}, 1s};
+    async::safe_quantized_expiry::fn<ops_time> e{&t};
+
+    hal_t::enable();
+
+    current_time<default_domain, TP> = TP{1001ms};
+    CHECK(e.compute_expiration<hal_t>() == TP{2s});
+
+    t.tp = TP{1s};
+    current_time<default_domain, TP> = TP{2s};
+    CHECK(e.compute_expiration<hal_t>() == TP{2s});
+
+    t.tp = TP{1s};
+    current_time<default_domain, TP> = TP{2001ms};
+    CHECK(e.compute_expiration<hal_t>() == TP{3s});
+
+    t.tp = TP{1s};
+    current_time<default_domain, TP> = TP{3999ms};
+    CHECK(e.compute_expiration<hal_t>() == TP{4s});
+
+    t.tp = TP{1s};
+    current_time<default_domain, TP> = TP{4s};
+    CHECK(e.compute_expiration<hal_t>() == TP{4s});
+
+    hal_t::disable();
+}
+
+TEST_CASE("periodic can be parameterized with a quantized provider",
+          "[periodic]") {
+    int var{};
+    stoppable_receiver r{[&] { var = 42; }};
+
+    using hal_t = hal<default_domain>;
+    using TP = typename hal_t::time_point_t;
+
+    [[maybe_unused]] auto s =
+        async::time_scheduler{}.schedule() |
+        async::periodic<"", async::safe_quantized_expiry>(1s);
+    auto op = async::connect(s, r);
+
+    current_time<default_domain, TP> = TP{1s};
+    calls<default_domain, TP>.clear();
+
+    async::start(op);
+
+    REQUIRE(calls<default_domain, TP>.size() == 1);
+    CHECK(calls<default_domain, TP>[0] == TP{2s});
+    CHECK(not async::timer_mgr::is_idle());
+
+    current_time<default_domain, TP> = TP{5500ms};
+    async::timer_mgr::service_task();
+    REQUIRE(calls<default_domain, TP>.size() == 2);
+    CHECK(calls<default_domain, TP>[1] == TP{6s});
+    CHECK(not async::timer_mgr::is_idle());
+
+    r.request_stop();
+    CHECK(async::timer_mgr::is_idle());
+    CHECK(var == 42);
+}
+
+namespace {
+std::vector<std::string> debug_events{};
+
+struct debug_handler {
+    template <stdx::ct_string C, stdx::ct_string S, typename Ctx>
+    constexpr auto signal(auto &&...) {
+        if constexpr (std::same_as<async::debug::tag_of<Ctx>,
+                                   async::periodic_t>) {
+            static_assert(not boost::mp11::mp_empty<
+                          async::debug::children_of<Ctx>>::value);
+            debug_events.push_back(
+                fmt::format("{} {} {}", C, async::debug::name_of<Ctx>, S));
+        }
+    }
+};
+} // namespace
+
+template <> inline auto async::injected_debug_handler<> = debug_handler{};
+
+TEST_CASE("periodic_until can be debugged", "[periodic]") {
+    using namespace std::string_literals;
+    debug_events.clear();
+
+    auto s = async::time_scheduler{}.schedule() |
+             async::periodic_until(1s, [] { return true; });
+    auto op = async::connect(
+        s, with_env{universal_receiver{},
+                    async::prop{async::get_debug_interface_t{},
+                                async::debug::named_interface<"op">{}}});
+
+    async::start(op);
+    async::timer_mgr::service_task();
+    CHECK(async::timer_mgr::is_idle());
+    CHECK(debug_events == std::vector{"op periodic_until start"s,
+                                      "op periodic_until eval_predicate"s,
+                                      "op periodic_until set_value"s});
+}
+
+TEST_CASE("periodic_n can be debugged", "[periodic]") {
+    using namespace std::string_literals;
+    debug_events.clear();
+
+    auto s = async::time_scheduler{}.schedule() | async::periodic_n(1s, 0);
+    auto op = async::connect(
+        s, with_env{universal_receiver{},
+                    async::prop{async::get_debug_interface_t{},
+                                async::debug::named_interface<"op">{}}});
+
+    async::start(op);
+    async::timer_mgr::service_task();
+    CHECK(async::timer_mgr::is_idle());
+    CHECK(debug_events == std::vector{"op periodic_n start"s,
+                                      "op periodic_n eval_predicate"s,
+                                      "op periodic_n set_value"s});
+}
+
+TEST_CASE("periodic can be debugged", "[periodic]") {
+    using namespace std::string_literals;
+    debug_events.clear();
+
+    auto s = async::time_scheduler{}.schedule() | async::periodic(1s);
+    stoppable_receiver r{[] {}};
+    auto op = async::connect(
+        s, with_env{r, async::prop{async::get_debug_interface_t{},
+                                   async::debug::named_interface<"op">{}}});
+
+    async::start(op);
+    r.request_stop();
+    CHECK(async::timer_mgr::is_idle());
+    CHECK(debug_events ==
+          std::vector{"op periodic start"s, "op periodic set_stopped"s});
+}
+
+TEST_CASE("periodic can be named and debugged", "[periodic]") {
+    using namespace std::string_literals;
+    debug_events.clear();
+
+    auto s = async::time_scheduler{}.schedule() |
+             async::periodic<"periodic_name">(1s);
+    stoppable_receiver r{[] {}};
+    auto op = async::connect(
+        s, with_env{r, async::prop{async::get_debug_interface_t{},
+                                   async::debug::named_interface<"op">{}}});
+
+    async::start(op);
+    r.request_stop();
+    CHECK(async::timer_mgr::is_idle());
+    CHECK(debug_events == std::vector{"op periodic_name start"s,
+                                      "op periodic_name set_stopped"s});
+}


### PR DESCRIPTION
Problem:
- There is no way to periodically run a sender without drift.

Solution:
- Introduce `periodic`, `periodic_n`, and `periodic_until`.

Notes:
- `periodic` interacts with the durationless `time_scheduler`. On first `start`, it schedules an expiry time of `now + duration`. On subsequent `start`s, it schedules an expiry time of `previous expiry + duration`. In this way it eliminates drift caused by the small amount of time taken to manage the timer interrupt.
- The `get_expiration` query returns an `expiration_provider` rather than a bare expiration time because computing an expiration time typically involves calling `HAL::now()`, which entails making sure that `HAL::enable()` has been called.