### PR TITLE
:sparkles: Add `transform_error`

### DIFF
--- a/docs/external.adoc
+++ b/docs/external.adoc
@@ -3,9 +3,13 @@
 
 - https://wg21.link/p2300[P2300] - the paper that sets out a complete
   motivation, examples and taxonomy of asynchronous building blocks
+- https://en.cppreference.com/w/cpp/execution[Execution control library] page on
+  https://cppreference.com/[cppreference.com]
 - https://www.youtube.com/watch?v=xLboNIf7BTg[Working with Asynchrony
-  Generically (Part 1)] - Eric Niebler's talk from CppCon 2021
+  Generically (Part 1)] - Eric Niebler, CppCon 2021
 - https://www.youtube.com/watch?v=6a0zzUBUNW4[Working with Asynchrony
-  Generically (Part 2)] - Eric Niebler's talk from CppCon 2021
+  Generically (Part 2)] - Eric Niebler, CppCon 2021
 - https://www.youtube.com/watch?v=xXncLUD-4bA[Using Sender/Receiver to Implement
-  Control Flow for Async Processing] - Steve Downey's talk from C++Now 2023
+  Control Flow for Async Processing] - Steve Downey, C++Now 2023
+- https://www.youtube.com/watch?v=eI5b-q4K9vo[Embedded Async Abstraction:
+  Implementing Senders and Receivers Without an OS] - Ben Deane, C++Now 2024

--- a/docs/sender_adaptors.adoc
+++ b/docs/sender_adaptors.adoc
@@ -514,6 +514,22 @@ auto sndr = async::start_on(my_scheduler{}, async::just(42))
 
 NOTE: `timeout_after` is implemented using xref:_when_any[`stop_when`].
 
+=== `transform_error`
+
+Found in the header: `async/then.hpp`
+
+`transform_error` works like `then`, but instead of applying the function to values, it applies to errors.
+
+[source,cpp]
+----
+auto sndr = async::just_error(42);
+auto te_sndr = async::transform_error(sndr, [] (int i) { return std::to_string(i); });
+// when run, te_sndr will produce the string "42" on the error channel
+----
+
+NOTE: Like `then`, `transform_error` can distribute the sent values to the
+functions by arity. However, only one value is normally sent on the error channel.
+
 === `upon_error`
 
 Found in the header: `async/then.hpp`
@@ -523,9 +539,13 @@ Found in the header: `async/then.hpp`
 [source,cpp]
 ----
 auto sndr = async::just_error(42);
-auto then_sndr = async::upon_error(sndr, [] (int i) { return std::to_string(i); });
-// when run, then_sndr will produce the string "42" as an error
+auto ue_sndr = async::upon_error(sndr, [] (int i) { return std::to_string(i); });
+// when run, ue_sndr will produce the string "42" on the value channel
 ----
+
+NOTE: The difference between `transform_error` and `upon_error` is that
+`transform_error` completes on the error channel, and `upon_error` completes on
+the value channel.
 
 === `upon_stopped`
 
@@ -537,8 +557,8 @@ values, it applies to the stopped signal. Therefore the function takes no argume
 [source,cpp]
 ----
 auto sndr = async::just_stopped();
-auto then_sndr = async::upon_stopped(sndr, [] { return 42; });
-// when run, then_sndr will produce 42
+auto us_sndr = async::upon_stopped(sndr, [] { return 42; });
+// when run, us_sndr will produce 42 on the value channel
 ----
 
 === `when_all`

--- a/docs/sender_factories.adoc
+++ b/docs/sender_factories.adoc
@@ -49,6 +49,8 @@ is `"just_error"`.
 auto sndr = async::just_error<"oops">(42);
 ----
 
+NOTE: Unlike the value channel, only one value is normally sent on the error channel.
+
 === `just_error_result_of`
 
 Found in the header: `async/just_result_of.hpp`
@@ -78,9 +80,9 @@ auto sndr = async::just_error_result_of<"oops">([] { return 42; });
 NOTE: Do not rely on the order of evaluation of the functions given to
 `just_error_result_of`!
 
-NOTE: Only one value can be sent on the error channel. Hence `just_error` is a
-unary function. However `just_error_result_of` is an n-ary function: exactly one
-of the functions passed must return something other than `void`.
+NOTE: Only one value is normally sent on the error channel. So exactly one of
+the functions passed to `just_error_result_of` should return something other than
+`void`.
 
 === `just_result_of`
 

--- a/docs/synopsis.adoc
+++ b/docs/synopsis.adoc
@@ -192,8 +192,9 @@ xref:schedulers.adoc#_time_scheduler[time_scheduler].
 
 ==== https://github.com/intel/cpp-baremetal-senders-and-receivers/blob/main/include/async/then.hpp[then.hpp]
 * `then` - a xref:sender_adaptors.adoc#_then[sender adaptor] that transforms what a sender sends on the value channel
-* `upon error` - a xref:sender_adaptors.adoc#_upon_error[sender adaptor] that transforms what a sender sends on the error channel
-* `upon stopped` - a xref:sender_adaptors.adoc#_upon_stopped[sender adaptor] that transforms what a sender sends on the stopped channel
+* `transform error` - a xref:sender_adaptors.adoc#_transform_error[sender adaptor] that transforms what a sender sends on the error channel
+* `upon error` - a xref:sender_adaptors.adoc#_upon_error[sender adaptor] that transforms what a sender sends on the error channel, and completes on the value channel
+* `upon stopped` - a xref:sender_adaptors.adoc#_upon_stopped[sender adaptor] that transforms what a sender sends on the stopped channel, and completes on the value channel
 
 ==== https://github.com/intel/cpp-baremetal-senders-and-receivers/blob/main/include/async/timeout_after.hpp[timeout_after.hpp]
 * `timeout_after` - a xref:sender_adaptors.adoc#_timeout_after[sender adaptor] that races a sender against a time limit
@@ -302,6 +303,7 @@ contains traits and metaprogramming constructs used by many senders.
 * `timer_mgr::time_point_for` - https://github.com/intel/cpp-baremetal-senders-and-receivers/blob/main/include/async/schedulers/timer_manager_interface.hpp[`#include <async/schedulers/timer_manager_interface.hpp>`]
 * xref:schedulers.adoc#_trigger_scheduler[`trigger_scheduler<"name">`] - https://github.com/intel/cpp-baremetal-senders-and-receivers/blob/main/include/async/schedulers/trigger_scheduler.hpp[`#include <async/schedulers/trigger_scheduler.hpp>`]
 * xref:schedulers.adoc#_trigger_scheduler[`triggers<"name">`] - https://github.com/intel/cpp-baremetal-senders-and-receivers/blob/main/include/async/schedulers/trigger_manager.hpp[`#include <async/schedulers/trigger_manager.hpp>`]
+* xref:sender_adaptors.adoc#_transform_error[`transform error`] - https://github.com/intel/cpp-baremetal-senders-and-receivers/blob/main/include/async/schedulers/then.hpp[`#include <async/then.hpp>`]
 * xref:sender_adaptors.adoc#_upon_error[`upon error`] - https://github.com/intel/cpp-baremetal-senders-and-receivers/blob/main/include/async/schedulers/then.hpp[`#include <async/then.hpp>`]
 * xref:sender_adaptors.adoc#_upon_stopped[`upon stopped`] - https://github.com/intel/cpp-baremetal-senders-and-receivers/blob/main/include/async/schedulers/then.hpp[`#include <async/then.hpp>`]
 * xref:sender_adaptors.adoc#_when_all[`when_all`] - https://github.com/intel/cpp-baremetal-senders-and-receivers/blob/main/include/async/schedulers/when_all.hpp[`#include <async/when_all.hpp>`]

--- a/include/async/just.hpp
+++ b/include/async/just.hpp
@@ -71,10 +71,10 @@ template <stdx::ct_string Name = "just", typename... Vs>
         {std::forward<Vs>(vs)...}};
 }
 
-template <stdx::ct_string Name = "just_error", typename V>
-[[nodiscard]] constexpr auto just_error(V &&v) -> sender auto {
-    return _just::sender<Name, set_error_t, std::remove_cvref_t<V>>{
-        {std::forward<V>(v)}};
+template <stdx::ct_string Name = "just_error", typename... Vs>
+[[nodiscard]] constexpr auto just_error(Vs &&...vs) -> sender auto {
+    return _just::sender<Name, set_error_t, std::remove_cvref_t<Vs>...>{
+        {std::forward<Vs>(vs)...}};
 }
 
 template <stdx::ct_string Name = "just_stopped">

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -50,6 +50,7 @@ add_tests(
     stop_token
     then
     timeout_after
+    transform_error
     type_traits
     upon_error
     upon_stopped

--- a/test/transform_error.cpp
+++ b/test/transform_error.cpp
@@ -1,0 +1,302 @@
+#include "detail/common.hpp"
+
+#include <async/concepts.hpp>
+#include <async/connect.hpp>
+#include <async/env.hpp>
+#include <async/just.hpp>
+#include <async/schedulers/inline_scheduler.hpp>
+#include <async/then.hpp>
+
+#include <stdx/ct_format.hpp>
+
+#include <catch2/catch_test_macros.hpp>
+#include <fmt/format.h>
+
+#include <concepts>
+#include <memory>
+#include <string>
+#include <utility>
+#include <vector>
+
+TEST_CASE("transform_error", "[transform_error]") {
+    int value{};
+
+    auto s = async::just_error(17);
+    auto n = async::transform_error(s, [] { return 42; });
+    auto op = async::connect(n, error_receiver{[&](auto i) { value = i; }});
+    async::start(op);
+    CHECK(value == 42);
+}
+
+TEST_CASE("transform_error propagates a value", "[transform_error]") {
+    int value{};
+
+    auto s = async::just_error(42);
+    auto n = async::transform_error(s, [](auto i) { return i * 2; });
+    auto op = async::connect(n, error_receiver{[&](auto i) { value = i; }});
+    async::start(op);
+    CHECK(value == 84);
+}
+
+TEST_CASE("transform_error advertises what it sends", "[transform_error]") {
+    auto s = async::just_error(17);
+    [[maybe_unused]] auto n = async::transform_error(s, [] { return 42; });
+    static_assert(async::sender_of<decltype(n), async::set_error_t(int)>);
+}
+
+TEST_CASE("transform_error can send a reference", "[transform_error]") {
+    int value{};
+    auto s = async::just_error(17);
+    [[maybe_unused]] auto n =
+        async::transform_error(s, [&]() -> int & { return value; });
+    static_assert(async::sender_of<decltype(n), async::set_error_t(int &)>);
+}
+
+TEST_CASE("transform_error is pipeable", "[transform_error]") {
+    int value{};
+
+    auto n = async::just_error(17) | async::transform_error([] { return 42; });
+    auto op = async::connect(n, error_receiver{[&](auto i) { value = i; }});
+    async::start(op);
+    CHECK(value == 42);
+}
+
+TEST_CASE("transform_error is adaptor-pipeable", "[transform_error]") {
+    int value{};
+
+    auto n = async::transform_error([] { return 42; }) |
+             async::transform_error([](int i) { return i * 2; });
+    auto op = async::connect(async::just_error(17) | n,
+                             error_receiver{[&](auto i) { value = i; }});
+    async::start(op);
+    CHECK(value == 84);
+}
+
+TEST_CASE("transform_error can send nothing", "[transform_error]") {
+    int value{};
+
+    auto s = async::just_error(17);
+    auto n1 = async::transform_error(s, [] {});
+    static_assert(async::sender_of<decltype(n1), async::set_error_t()>);
+    auto n2 = async::transform_error(n1, [] {});
+    static_assert(async::sender_of<decltype(n2), async::set_error_t()>);
+    auto op = async::connect(n2, error_receiver{[&] { value = 42; }});
+    async::start(op);
+    CHECK(value == 42);
+}
+
+TEST_CASE("move-only value", "[transform_error]") {
+    int value{};
+
+    auto n = async::just_error(17) |
+             async::transform_error([] { return move_only{42}; });
+    auto op = async::connect(
+        std::move(n), error_receiver{[&](auto mo) { value = mo.value; }});
+    async::start(op);
+    CHECK(value == 42);
+}
+
+TEST_CASE("move-only lambda", "[transform_error]") {
+    int value{};
+    auto n = async::just_error(17) |
+             async::transform_error(
+                 [mo = move_only{42}]() -> move_only<int> const && {
+                     return std::move(mo);
+                 });
+    static_assert(async::singleshot_sender<decltype(n), universal_receiver>);
+    auto op = async::connect(
+        std::move(n), error_receiver{[&](auto &&mo) { value = mo.value; }});
+    async::start(op);
+    CHECK(value == 42);
+}
+
+TEST_CASE("single-shot sender", "[transform_error]") {
+    [[maybe_unused]] auto n = async::inline_scheduler<>::schedule<
+                                  async::inline_scheduler<>::singleshot>() |
+                              async::transform_error([] {});
+    static_assert(async::singleshot_sender<decltype(n), universal_receiver>);
+}
+
+TEST_CASE("transform_error propagates value", "[transform_error]") {
+    bool transform_error_called{};
+    int value{};
+
+    auto s = async::just(42) |
+             async::transform_error([&] { transform_error_called = true; });
+    static_assert(
+        std::same_as<async::completion_signatures_of_t<decltype(s)>,
+                     async::completion_signatures<async::set_value_t(int)>>);
+    auto op = async::connect(s, receiver{[&](auto i) { value = i; }});
+    async::start(op);
+    CHECK(value == 42);
+    CHECK(not transform_error_called);
+}
+
+TEST_CASE("transform_error propagates stopped", "[transform_error]") {
+    bool transform_error_called{};
+    int value{};
+
+    auto s = async::just_stopped() |
+             async::transform_error([&] { transform_error_called = true; });
+    static_assert(
+        std::same_as<async::completion_signatures_of_t<decltype(s)>,
+                     async::completion_signatures<async::set_stopped_t()>>);
+    auto op = async::connect(s, stopped_receiver{[&] { value = 42; }});
+    async::start(op);
+    CHECK(value == 42);
+    CHECK(not transform_error_called);
+}
+
+TEST_CASE(
+    "transform_error propagates forwarding queries to its child environment",
+    "[transform_error]") {
+    auto s = custom_sender{};
+    CHECK(get_fwd(async::get_env(s)) == 42);
+
+    auto t = async::transform_error(s, [] {});
+    CHECK(get_fwd(async::get_env(t)) == 42);
+}
+
+TEST_CASE("transform_error advertises what it sends (variadic)",
+          "[transform_error]") {
+    auto s = async::just_error(true, false) |
+             async::transform_error([](auto) { return 42; },
+                                    [](auto) { return 17; });
+    static_assert(async::sender_of<decltype(s), async::set_error_t(int, int)>);
+}
+
+TEST_CASE("transform_error (variadic)", "[transform_error]") {
+    int x{};
+    int y{};
+    auto s = async::just_error(2, 3) |
+             async::transform_error([](auto i) { return i * 2; },
+                                    [](auto i) { return i * 3; });
+    auto op = async::connect(s, error_receiver{[&](auto i, auto j) {
+                                 x = i;
+                                 y = j;
+                             }});
+    async::start(op);
+    CHECK(x == 4);
+    CHECK(y == 9);
+}
+
+TEST_CASE("variadic transform_error can have void-returning functions",
+          "[transform_error]") {
+    int x{};
+    int y{42};
+    auto s = async::just_error(2, 3) |
+             async::transform_error([](auto i) { return i * 2; }, [](auto) {});
+    static_assert(async::sender_of<decltype(s), async::set_error_t(int)>);
+    auto op = async::connect(s, error_receiver{[&](auto i) { x = i; }});
+    async::start(op);
+    CHECK(x == 4);
+    CHECK(y == 42);
+}
+
+TEST_CASE("move-only value (from transform_error) (variadic)",
+          "[transform_error]") {
+    int x{};
+    auto s = async::just_error(2, 3) |
+             async::transform_error([](auto i) { return move_only{i}; },
+                                    [](auto) {});
+    static_assert(
+        async::sender_of<decltype(s), async::set_error_t(move_only<int>)>);
+    auto op = async::connect(s, error_receiver{[&](auto i) { x = i.value; }});
+    async::start(op);
+    CHECK(x == 2);
+}
+
+TEST_CASE("move-only value (to transform_error) (variadic)",
+          "[transform_error]") {
+    int x{};
+    auto s =
+        async::just_error(move_only{2}, move_only{3}) |
+        async::transform_error([](auto i) { return i.value; }, [](auto) {});
+    static_assert(async::sender_of<decltype(s), async::set_error_t(int)>);
+    auto op =
+        async::connect(std::move(s), error_receiver{[&](auto i) { x = i; }});
+    async::start(op);
+    CHECK(x == 2);
+}
+
+TEST_CASE("variadic transform_error can take heteroadic functions",
+          "[transform_error]") {
+    int x{};
+    int y{42};
+    bool z{};
+    auto s =
+        async::just_error(2, 3, 4) |
+        async::transform_error([](auto i, auto j) { return i + j; },
+                               [](auto k) { return k; }, [] { return true; });
+    static_assert(
+        async::sender_of<decltype(s), async::set_error_t(int, int, bool)>);
+    auto op = async::connect(s, error_receiver{[&](auto i, auto j, auto k) {
+                                 x = i;
+                                 y = j;
+                                 z = k;
+                             }});
+    async::start(op);
+    CHECK(x == 5);
+    CHECK(y == 4);
+    CHECK(z);
+}
+
+TEST_CASE("transform_error can handle a reference", "[transform_error]") {
+    int value{};
+    auto s = async::just_error() |
+             async::transform_error([&]() -> int & { return value; });
+    auto op =
+        async::connect(s, error_receiver{[&](auto &i) {
+                           CHECK(std::addressof(value) == std::addressof(i));
+                       }});
+    async::start(op);
+}
+
+namespace {
+std::vector<std::string> debug_events{};
+
+struct debug_handler {
+    template <stdx::ct_string C, stdx::ct_string S, typename Ctx>
+    constexpr auto signal(auto &&...) {
+        using namespace stdx::literals;
+        if constexpr (std::is_same_v<async::debug::tag_of<Ctx>,
+                                     async::transform_error_t>) {
+            static_assert(not boost::mp11::mp_empty<
+                          async::debug::children_of<Ctx>>::value);
+            debug_events.push_back(
+                fmt::format("{} {} {}", C, async::debug::name_of<Ctx>, S));
+        }
+    }
+};
+} // namespace
+
+template <> inline auto async::injected_debug_handler<> = debug_handler{};
+
+TEST_CASE("transform_error can be debugged with a string",
+          "[transform_error]") {
+    using namespace std::string_literals;
+    debug_events.clear();
+
+    auto s = async::just_error() | async::transform_error([] {});
+    auto op = async::connect(
+        s, with_env{universal_receiver{},
+                    async::prop{async::get_debug_interface_t{},
+                                async::debug::named_interface<"op">{}}});
+    async::start(op);
+    CHECK(debug_events == std::vector{"op transform_error set_error"s});
+}
+
+TEST_CASE("transform_error can be named and debugged with a string",
+          "[transform_error]") {
+    using namespace std::string_literals;
+    debug_events.clear();
+
+    auto s = async::just_error() |
+             async::transform_error<"transform_error_name">([] {});
+    auto op = async::connect(
+        s, with_env{universal_receiver{},
+                    async::prop{async::get_debug_interface_t{},
+                                async::debug::named_interface<"op">{}}});
+    async::start(op);
+    CHECK(debug_events == std::vector{"op transform_error_name set_error"s});
+}


### PR DESCRIPTION
Problem:
- There is no way to transform values sent on the error channel, while staying in the error channel.

Solution:
- Add `transform_error`.

Note:
- `upon_error` completes on the value channel. `transform_error` completes on the error channel.