### PR TITLE
:bug: Fix `incite_on` op state lifetimes

### DIFF
--- a/include/async/incite_on.hpp
+++ b/include/async/incite_on.hpp
@@ -68,13 +68,13 @@ struct op_state {
                 }}} {}
     constexpr op_state(op_state &&) = delete;
 
-    template <typename F> auto complete_first(F &&f) -> void {
+    template <typename F> auto complete_first(F f) -> void {
         debug_signal<set_value_t::name, debug::erased_context_for<op_state>>(
             get_env(rcvr));
         auto &op = state.template emplace<1>(stdx::with_result_of{
             [&] { return connect(sched.schedule(), std::move(rcvr)); }});
         async::start(op);
-        std::forward<F>(f)();
+        std::move(f)();
     }
 
     template <channel_tag Tag, typename... Args>

--- a/test/incite_on.cpp
+++ b/test/incite_on.cpp
@@ -55,6 +55,17 @@ TEST_CASE("incite_on send a value with trigger", "[incite_on]") {
     CHECK(value == 42);
 }
 
+TEST_CASE("incite_on works being incited by a non-empty lambda",
+          "[incite_on]") {
+    int value{};
+    auto const s = async::incite_on(
+        async::just([value = 42] { async::run_triggers<"value">(value); }),
+        async::trigger_scheduler<"value", int>{});
+    auto op = async::connect(s, receiver{[&](auto i) { value = i; }});
+    async::start(op);
+    CHECK(value == 42);
+}
+
 TEST_CASE("incite_on advertises what it sends", "[incite_on]") {
     [[maybe_unused]] auto const s =
         async::incite_on(async::just([] { async::run_triggers<"basic">(); }),


### PR DESCRIPTION
Problem:
- The operation states for `incite_on` are kept in a variant, switching between the first and second op states on completion of the first. But switching to the second op state (and ending the lifetime of the first) before calling the function sent by the first would result in a use-after-free.

Solution:
- Copy (move) the function before ending the op state lifetime.