### PR TITLE
:art: Add `make_optional_sender`

### DIFF
--- a/docs/variant_senders.adoc
+++ b/docs/variant_senders.adoc
@@ -16,6 +16,17 @@ auto s = async::make_variant_sender(/* boolean-expression */,
                                     [] { return /* a different sender */; });
 ----
 
+There is also an even simpler formulation, for when the alternative sender is `just()`:
+
+[source,cpp]
+----
+auto s = async::make_optional_sender(/* boolean-expression */,
+                                     [] { return /* a sender */; });
+----
+
+In this case, if the boolean expression evaluates to `false`, the returned
+sender will complete on the value channel as if it were `just()`.
+
 This often suffices for a binary choice, but if we want a choice of more
 possibilities, the same function supports that:
 

--- a/include/async/variant_sender.hpp
+++ b/include/async/variant_sender.hpp
@@ -5,6 +5,7 @@
 #include <async/connect.hpp>
 #include <async/debug.hpp>
 #include <async/env.hpp>
+#include <async/just.hpp>
 #include <async/type_traits.hpp>
 
 #include <stdx/concepts.hpp>
@@ -252,6 +253,11 @@ constexpr auto make_variant_sender(bool b, F1 &&f1, F2 &&f2) {
 
     return boost::mp11::mp_apply<_variant::sender, senders>{
         select(b, std::forward<F1>(f1), std::forward<F2>(f2))};
+}
+
+template <stdx::callable F> constexpr auto make_optional_sender(bool b, F &&f) {
+    return make_variant_sender(b, std::forward<F>(f),
+                               [] { return just<"opt-else">(); });
 }
 
 struct variant_t;

--- a/test/variant_sender.cpp
+++ b/test/variant_sender.cpp
@@ -141,6 +141,26 @@ TEST_CASE("make_variant_sender (general choice)", "[variant_sender]") {
     CHECK(value == 42);
 }
 
+TEST_CASE("make_optional_sender (unary choice)", "[variant_sender]") {
+    auto const i = 0;
+    auto const s =
+        async::make_optional_sender(i == 0, [] { return async::just(42); });
+
+    static_assert(
+        std::is_same_v<async::completion_signatures_of_t<decltype(s)>,
+                       async::completion_signatures<async::set_value_t(int),
+                                                    async::set_value_t()>>);
+
+    int value{};
+    auto op = async::connect(s, receiver{[&](auto... v) {
+                                 if constexpr (sizeof...(v) == 1) {
+                                     value = (v, ...);
+                                 }
+                             }});
+    async::start(op);
+    CHECK(value == 42);
+}
+
 TEST_CASE("make_variant_sender (simplified binary choice)",
           "[variant_sender]") {
     auto const i = 0;


### PR DESCRIPTION
Problem:
- It's common to want to run a sender only based on a runtime bool, and if the bool is false, complete trivially with `just`.
- It's verbose to have to type `make_variant_sender(b, [] { return s; }, [] { return just(); });`

Solution:
- Use `make_optional_sender(b, [] { return s; })` instead, where if `b` is `false`, the sender will complete as if by `just()`.