### PR TITLE
:bug: Fix multishot constraints on `when_all` and `when_any` connect

### DIFF
--- a/include/async/start_detached.hpp
+++ b/include/async/start_detached.hpp
@@ -60,7 +60,7 @@ template <typename StopSource, typename Env>
 struct op_state_base {
     using env_t = env<prop<get_stop_token_t,
                            decltype(std::declval<StopSource>().get_token())>,
-                      Env const &>;
+                      Env>;
 
     constexpr explicit(true) op_state_base(Env &&env) : e{std::move(env)} {}
     constexpr op_state_base(op_state_base &&) = delete;
@@ -68,8 +68,7 @@ struct op_state_base {
     template <stdx::ct_string> auto die() {}
 
     [[nodiscard]] constexpr auto query(get_env_t) const -> env_t {
-        return env{prop{get_stop_token_t{}, stop_src.get_token()},
-                   std::cref(e)};
+        return env{prop{get_stop_token_t{}, stop_src.get_token()}, e};
     }
 
     using stop_source_t = StopSource;

--- a/include/async/sync_wait.hpp
+++ b/include/async/sync_wait.hpp
@@ -60,7 +60,7 @@ using sync_wait_type = value_types_of_t<S, E, decayed_tuple, std::optional>;
 template <typename Uniq, sender S, typename Env> auto wait(S &&s, Env &&e) {
     run_loop<Uniq> rl{};
     auto sched = rl.get_scheduler();
-    auto new_env = env{prop{get_scheduler_t{}, sched}, std::cref(e)};
+    auto new_env = env{prop{get_scheduler_t{}, sched}, std::forward<Env>(e)};
 
     using E = decltype(new_env);
     using V = detail::sync_wait_type<E, S>;

--- a/include/async/when_all.hpp
+++ b/include/async/when_all.hpp
@@ -448,7 +448,9 @@ template <stdx::ct_string Name, typename... Sndrs> struct sender : Sndrs... {
     template <typename R>
         requires(
             ... and
-            multishot_sender<typename Sndrs::sender_t, std::remove_cvref_t<R>>)
+            multishot_sender<
+                typename Sndrs::sender_t,
+                detail::universal_receiver<env_of_t<std::remove_cvref_t<R>>>>)
     [[nodiscard]] constexpr auto connect(
         R &&r) const & -> op_state_t<Name, std::remove_cvref_t<R>, Sndrs...> {
         check_connect<sender const &, R>();

--- a/include/async/when_any.hpp
+++ b/include/async/when_any.hpp
@@ -420,7 +420,9 @@ struct sender : Sndrs... {
     template <typename R>
         requires(
             ... and
-            multishot_sender<typename Sndrs::sender_t, std::remove_cvref_t<R>>)
+            multishot_sender<
+                typename Sndrs::sender_t,
+                detail::universal_receiver<env_of_t<std::remove_cvref_t<R>>>>)
     [[nodiscard]] constexpr auto connect(R &&r) const
         & -> op_state_t<Name, StopPolicy, std::remove_cvref_t<R>, Sndrs...> {
         check_connect<sender const &, R>();


### PR DESCRIPTION
Problem:
- The multishot sender constraints on `when_all` (and `when_any`) erroneously try to connect the given senders to the final receiver, when in fact they are never required to do that. The `sub_receiver`s are used instead.

Solution:
- Check multishot sending using the `universal_receiver` and the passed-in receiver's environment.

Closes #167 