### PR TITLE
:white_check_mark: Use `STATIC_REQUIRE` instead of `static_assert`

### DIFF
--- a/test/allocator.cpp
+++ b/test/allocator.cpp
@@ -15,20 +15,20 @@
 #include <type_traits>
 
 TEST_CASE("default allocator is static_allocator", "[allocator]") {
-    static_assert(std::is_same_v<async::allocator_of_t<async::empty_env>,
-                                 async::static_allocator>);
+    STATIC_REQUIRE(std::is_same_v<async::allocator_of_t<async::empty_env>,
+                                  async::static_allocator>);
 }
 
 TEST_CASE("allocator is forwarded through senders", "[allocator]") {
     [[maybe_unused]] auto s1 =
         async::inline_scheduler{}.schedule() | async::then([] {});
-    static_assert(
+    STATIC_REQUIRE(
         std::is_same_v<async::allocator_of_t<async::env_of_t<decltype(s1)>>,
                        async::stack_allocator>);
 
     [[maybe_unused]] auto s2 =
         async::thread_scheduler{}.schedule() | async::then([] {});
-    static_assert(
+    STATIC_REQUIRE(
         std::is_same_v<async::allocator_of_t<async::env_of_t<decltype(s2)>>,
                        async::static_allocator>);
 }
@@ -151,17 +151,17 @@ TEST_CASE("stack allocate rvalues", "[allocator]") {
 }
 
 TEST_CASE("static allocator is an allocator", "[allocator]") {
-    static_assert(async::allocator<async::static_allocator>);
+    STATIC_REQUIRE(async::allocator<async::static_allocator>);
 }
 
 TEST_CASE("stack allocator is an allocator", "[allocator]") {
-    static_assert(async::allocator<async::stack_allocator>);
+    STATIC_REQUIRE(async::allocator<async::stack_allocator>);
 }
 
 TEST_CASE("sender that completes synchronously defaults to a stack allocator",
           "[allocator]") {
     [[maybe_unused]] auto s = async::inline_scheduler{}.schedule();
-    static_assert(
+    STATIC_REQUIRE(
         std::is_same_v<async::allocator_of_t<async::env_of_t<decltype(s)>>,
                        async::stack_allocator>);
 }
@@ -169,7 +169,7 @@ TEST_CASE("sender that completes synchronously defaults to a stack allocator",
 TEST_CASE("sender that completes asynchronously defaults to a static allocator",
           "[allocator]") {
     [[maybe_unused]] auto s = async::thread_scheduler{}.schedule();
-    static_assert(
+    STATIC_REQUIRE(
         std::is_same_v<async::allocator_of_t<async::env_of_t<decltype(s)>>,
                        async::static_allocator>);
 }

--- a/test/completes_synchronously.cpp
+++ b/test/completes_synchronously.cpp
@@ -11,39 +11,39 @@
 
 TEST_CASE("empty env doesn't complete synchronously",
           "[completes_synchronously]") {
-    static_assert(not async::completes_synchronously(async::empty_env{}));
+    STATIC_REQUIRE(not async::completes_synchronously(async::empty_env{}));
 }
 
 TEST_CASE("just completes synchronously", "[completes_synchronously]") {
     constexpr auto s = async::just(42);
-    static_assert(async::completes_synchronously(async::get_env(s)));
+    STATIC_REQUIRE(async::completes_synchronously(async::get_env(s)));
 }
 
 TEST_CASE("just_result_of completes synchronously",
           "[completes_synchronously]") {
     constexpr auto s = async::just_result_of([] { return 42; });
-    static_assert(async::completes_synchronously(async::get_env(s)));
+    STATIC_REQUIRE(async::completes_synchronously(async::get_env(s)));
 }
 
 TEST_CASE("read_env completes synchronously", "[completes_synchronously]") {
     constexpr auto s = async::get_stop_token();
-    static_assert(async::completes_synchronously(async::get_env(s)));
+    STATIC_REQUIRE(async::completes_synchronously(async::get_env(s)));
 }
 
 TEST_CASE("complete_synchronously is a forwarding query",
           "[completes_synchronously]") {
     constexpr auto s = async::just(42) | async::then([](auto v) { return v; });
-    static_assert(async::completes_synchronously(async::get_env(s)));
+    STATIC_REQUIRE(async::completes_synchronously(async::get_env(s)));
 }
 
 TEST_CASE("inline_scheduler sender completes synchronously",
           "[completes_synchronously]") {
     constexpr auto s = async::inline_scheduler{}.schedule();
-    static_assert(async::completes_synchronously(async::get_env(s)));
+    STATIC_REQUIRE(async::completes_synchronously(async::get_env(s)));
 }
 
 TEST_CASE("thread_scheduler sender does not complete synchronously",
           "[completes_synchronously]") {
     constexpr auto s = async::thread_scheduler{}.schedule();
-    static_assert(not async::completes_synchronously(async::get_env(s)));
+    STATIC_REQUIRE(not async::completes_synchronously(async::get_env(s)));
 }

--- a/test/concepts.cpp
+++ b/test/concepts.cpp
@@ -7,8 +7,8 @@
 #include <catch2/catch_test_macros.hpp>
 
 TEST_CASE("queryable", "[concepts]") {
-    static_assert(not async::queryable<void>);
-    static_assert(async::queryable<int>);
+    STATIC_REQUIRE(not async::queryable<void>);
+    STATIC_REQUIRE(async::queryable<int>);
 }
 
 namespace {
@@ -19,8 +19,8 @@ struct not_op_state {};
 } // namespace
 
 TEST_CASE("operation_state", "[concepts]") {
-    static_assert(not async::operation_state<not_op_state>);
-    static_assert(async::operation_state<op_state>);
+    STATIC_REQUIRE(not async::operation_state<not_op_state>);
+    STATIC_REQUIRE(async::operation_state<op_state>);
 }
 
 namespace {
@@ -32,9 +32,9 @@ struct not_receiver {};
 } // namespace
 
 TEST_CASE("receiver", "[concepts]") {
-    static_assert(not async::receiver<not_receiver>);
-    static_assert(async::receiver<receiver1>);
-    static_assert(async::receiver<receiver2>);
+    STATIC_REQUIRE(not async::receiver<not_receiver>);
+    STATIC_REQUIRE(async::receiver<receiver1>);
+    STATIC_REQUIRE(async::receiver<receiver2>);
 }
 
 namespace {
@@ -49,20 +49,20 @@ struct receiver : async::receiver_base {
 } // namespace
 
 TEST_CASE("receiver_of", "[concepts]") {
-    static_assert(
+    STATIC_REQUIRE(
         async::receiver_of<receiver<>,
                            async::completion_signatures<async::set_value_t()>>);
-    static_assert(async::receiver_of<
-                  receiver<>,
-                  async::completion_signatures<async::set_error_t(error)>>);
-    static_assert(
+    STATIC_REQUIRE(async::receiver_of<
+                   receiver<>,
+                   async::completion_signatures<async::set_error_t(error)>>);
+    STATIC_REQUIRE(
         async::receiver_of<
             receiver<>, async::completion_signatures<async::set_stopped_t()>>);
 
-    static_assert(async::receiver_of<
-                  receiver<error, int>,
-                  async::completion_signatures<async::set_value_t(int)>>);
-    static_assert(
+    STATIC_REQUIRE(async::receiver_of<
+                   receiver<error, int>,
+                   async::completion_signatures<async::set_value_t(int)>>);
+    STATIC_REQUIRE(
         not async::receiver_of<
             receiver<>, async::completion_signatures<async::set_value_t(int)>>);
 }
@@ -79,9 +79,9 @@ struct not_sender {};
 } // namespace
 
 TEST_CASE("sender", "[concepts]") {
-    static_assert(not async::sender<not_sender>);
-    static_assert(async::sender<typed_sender1>);
-    static_assert(async::sender<typed_sender2>);
+    STATIC_REQUIRE(not async::sender<not_sender>);
+    STATIC_REQUIRE(async::sender<typed_sender1>);
+    STATIC_REQUIRE(async::sender<typed_sender2>);
 }
 
 namespace {
@@ -104,10 +104,10 @@ struct queryable_sender2 : async::sender_base {
 } // namespace
 
 TEST_CASE("sender_in", "[concepts]") {
-    static_assert(not async::sender_in<not_sender>);
-    static_assert(async::sender_in<queryable_sender1>);
-    static_assert(not async::sender_in<queryable_sender2>);
-    static_assert(async::sender_in<queryable_sender2, dependent_env>);
+    STATIC_REQUIRE(not async::sender_in<not_sender>);
+    STATIC_REQUIRE(async::sender_in<queryable_sender1>);
+    STATIC_REQUIRE(not async::sender_in<queryable_sender2>);
+    STATIC_REQUIRE(async::sender_in<queryable_sender2, dependent_env>);
 }
 
 namespace {
@@ -130,29 +130,30 @@ template <typename... Ts> struct value_receiver : async::receiver_base {
 } // namespace
 
 TEST_CASE("sender_to", "[concepts]") {
-    static_assert(async::sender_to<sender<>, receiver<>>);
-    static_assert(async::sender_to<sender<error, int>, receiver<error, int>>);
-    static_assert(
+    STATIC_REQUIRE(async::sender_to<sender<>, receiver<>>);
+    STATIC_REQUIRE(async::sender_to<sender<error, int>, receiver<error, int>>);
+    STATIC_REQUIRE(
         not async::sender_to<sender<error, int>, receiver<error, float>>);
 }
 
 TEST_CASE("sender_to value categories", "[concepts]") {
-    static_assert(
+    STATIC_REQUIRE(
         async::sender_to<sender<error, int>, value_receiver<int const &>>);
-    static_assert(async::sender_to<sender<error, int>, value_receiver<int &&>>);
-    static_assert(
+    STATIC_REQUIRE(
+        async::sender_to<sender<error, int>, value_receiver<int &&>>);
+    STATIC_REQUIRE(
         not async::sender_to<sender<error, int>, value_receiver<int &>>);
 
-    static_assert(async::sender_to<sender<error, int &>, value_receiver<int>>);
-    static_assert(not async::sender_to<sender<error, int const &>,
-                                       value_receiver<int &>>);
+    STATIC_REQUIRE(async::sender_to<sender<error, int &>, value_receiver<int>>);
+    STATIC_REQUIRE(not async::sender_to<sender<error, int const &>,
+                                        value_receiver<int &>>);
 }
 
 TEST_CASE("sender_of", "[concepts]") {
-    static_assert(
+    STATIC_REQUIRE(
         async::sender_of<sender<error, int>, async::set_value_t(int)>);
-    static_assert(async::sender_of<sender<>, async::set_error_t(error)>);
-    static_assert(not async::sender_of<sender<>, async::set_value_t(int)>);
+    STATIC_REQUIRE(async::sender_of<sender<>, async::set_error_t(error)>);
+    STATIC_REQUIRE(not async::sender_of<sender<>, async::set_value_t(int)>);
 }
 
 namespace {
@@ -170,8 +171,8 @@ struct singleshot_sender : async::sender_base {
 } // namespace
 
 TEST_CASE("single/multishot_sender", "[concepts]") {
-    static_assert(async::multishot_sender<sender<>, receiver<>>);
-    static_assert(async::singleshot_sender<singleshot_sender<>, receiver<>>);
+    STATIC_REQUIRE(async::multishot_sender<sender<>, receiver<>>);
+    STATIC_REQUIRE(async::singleshot_sender<singleshot_sender<>, receiver<>>);
 }
 
 namespace {
@@ -218,9 +219,9 @@ struct stoppable_env {
 } // namespace
 
 TEST_CASE("stoppable sender", "[stop_token]") {
-    static_assert(not async::stoppable_sender<singleshot_sender<error, int>>);
-    static_assert(async::stoppable_sender<stoppable_sender>);
-    static_assert(not async::stoppable_sender<dependent_stoppable_sender>);
-    static_assert(
+    STATIC_REQUIRE(not async::stoppable_sender<singleshot_sender<error, int>>);
+    STATIC_REQUIRE(async::stoppable_sender<stoppable_sender>);
+    STATIC_REQUIRE(not async::stoppable_sender<dependent_stoppable_sender>);
+    STATIC_REQUIRE(
         async::stoppable_sender<dependent_stoppable_sender, stoppable_env>);
 }

--- a/test/continue_on.cpp
+++ b/test/continue_on.cpp
@@ -63,7 +63,7 @@ template <typename R> struct async::debug::context_for<test_op_state<R>> {
 };
 
 TEST_CASE("continue_on", "[continue_on]") {
-    static_assert(async::scheduler<test_scheduler<0>>);
+    STATIC_REQUIRE(async::scheduler<test_scheduler<0>>);
     test_scheduler<1>::schedule_calls = 0;
     test_scheduler<2>::schedule_calls = 0;
     int value{};
@@ -88,7 +88,7 @@ TEST_CASE("continue_on advertises what it sends", "[continue_on]") {
 
     auto n1 = async::just(42);
     [[maybe_unused]] auto t = async::continue_on(n1, sched);
-    static_assert(async::sender_of<decltype(t), async::set_value_t(int)>);
+    STATIC_REQUIRE(async::sender_of<decltype(t), async::set_value_t(int)>);
 }
 
 TEST_CASE("continue_on is pipeable", "[continue_on]") {
@@ -132,7 +132,7 @@ TEST_CASE("continue_on is adaptor-pipeable", "[continue_on]") {
 TEST_CASE("continue_on advertises pass-through completions", "[continue_on]") {
     auto sched = test_scheduler<1>{};
     [[maybe_unused]] auto t = async::just_error(42) | async::continue_on(sched);
-    static_assert(async::sender_of<decltype(t), async::set_error_t(int)>);
+    STATIC_REQUIRE(async::sender_of<decltype(t), async::set_error_t(int)>);
 }
 
 TEST_CASE("move-only value", "[continue_on]") {
@@ -162,7 +162,7 @@ TEST_CASE("singleshot continue_on", "[continue_on]") {
     [[maybe_unused]] auto n = async::inline_scheduler<>::schedule<
                                   async::inline_scheduler<>::singleshot>() |
                               async::continue_on(sched1);
-    static_assert(async::singleshot_sender<decltype(n), universal_receiver>);
+    STATIC_REQUIRE(async::singleshot_sender<decltype(n), universal_receiver>);
 }
 
 TEST_CASE("continue_on cancellation", "[continue_on]") {

--- a/test/debug.cpp
+++ b/test/debug.cpp
@@ -65,7 +65,7 @@ TEST_CASE("send a debug signal (handler for chain and link name)", "[debug]") {
 
 TEST_CASE("default debug interface", "[debug]") {
     auto i = async::get_debug_interface(async::empty_env{});
-    static_assert(std::same_as<decltype(i), async::debug::default_interface>);
+    STATIC_REQUIRE(std::same_as<decltype(i), async::debug::default_interface>);
 }
 
 TEST_CASE("supplied debug interface", "[debug]") {

--- a/test/debug_context.cpp
+++ b/test/debug_context.cpp
@@ -52,29 +52,29 @@ struct bad_context_no_type {
 } // namespace
 
 TEST_CASE("leaf context", "[debug_context]") {
-    static_assert(async::debug::contextlike<leaf_context>);
+    STATIC_REQUIRE(async::debug::contextlike<leaf_context>);
 }
 
 TEST_CASE("branch context", "[debug_context]") {
-    static_assert(async::debug::contextlike<branch_context>);
+    STATIC_REQUIRE(async::debug::contextlike<branch_context>);
 }
 
 TEST_CASE("not a context (no name)", "[debug_context]") {
-    static_assert(not async::debug::contextlike<bad_context_no_name>);
+    STATIC_REQUIRE(not async::debug::contextlike<bad_context_no_name>);
 }
 
 TEST_CASE("not a context (no tag)", "[debug_context]") {
-    static_assert(not async::debug::contextlike<bad_context_no_tag>);
+    STATIC_REQUIRE(not async::debug::contextlike<bad_context_no_tag>);
 }
 
 TEST_CASE("not a context (no children)", "[debug_context]") {
-    static_assert(not async::debug::contextlike<bad_context_no_children>);
+    STATIC_REQUIRE(not async::debug::contextlike<bad_context_no_children>);
 }
 
 TEST_CASE("not a context (children are not contexts)", "[debug_context]") {
-    static_assert(not async::debug::contextlike<bad_context_bad_children>);
+    STATIC_REQUIRE(not async::debug::contextlike<bad_context_bad_children>);
 }
 
 TEST_CASE("not a context (no type)", "[debug_context]") {
-    static_assert(not async::debug::contextlike<bad_context_no_type>);
+    STATIC_REQUIRE(not async::debug::contextlike<bad_context_no_type>);
 }

--- a/test/detail/debug_handler.hpp
+++ b/test/detail/debug_handler.hpp
@@ -1,0 +1,29 @@
+#pragma once
+
+#include <async/debug.hpp>
+
+#include <stdx/ct_format.hpp>
+
+#include <boost/mp11/list.hpp>
+#include <fmt/format.h>
+
+#include <string>
+#include <type_traits>
+#include <vector>
+
+namespace {
+std::vector<std::string> debug_events{};
+
+template <typename Tag, auto Empty = false> struct debug_handler {
+    template <stdx::ct_string C, stdx::ct_string S, typename Ctx>
+    constexpr auto signal(auto &&...) {
+        if constexpr (std::is_same_v<async::debug::tag_of<Ctx>, Tag>) {
+            static_assert(
+                Empty ==
+                boost::mp11::mp_empty<async::debug::children_of<Ctx>>::value);
+            debug_events.push_back(
+                fmt::format("{} {} {}", C, async::debug::name_of<Ctx>, S));
+        }
+    }
+};
+} // namespace

--- a/test/env.cpp
+++ b/test/env.cpp
@@ -10,7 +10,8 @@
 
 TEST_CASE("empty env", "[env]") {
     auto const r = receiver{[] {}};
-    static_assert(std::same_as<async::env_of_t<decltype(r)>, async::empty_env>);
+    STATIC_REQUIRE(
+        std::same_as<async::env_of_t<decltype(r)>, async::empty_env>);
 }
 
 TEST_CASE("nonexistent query", "[env]") {
@@ -20,7 +21,7 @@ TEST_CASE("nonexistent query", "[env]") {
 
 TEST_CASE("non-empty env", "[env]") {
     auto const r = stoppable_receiver{[] {}};
-    static_assert(
+    STATIC_REQUIRE(
         not std::same_as<async::env_of_t<decltype(r)>, async::empty_env>);
 }
 
@@ -101,16 +102,16 @@ TEST_CASE("template query prop", "[env]") {
 }
 
 TEST_CASE("valid_query_for", "[env]") {
-    static_assert(
+    STATIC_REQUIRE(
         async::detail::valid_query_for<async::get_env_t, test_queryable>);
-    static_assert(
+    STATIC_REQUIRE(
         not async::detail::valid_query_for<async::get_env_t, async::empty_env>);
 }
 
 TEST_CASE("valid_query_over", "[env]") {
-    static_assert(
+    STATIC_REQUIRE(
         async::detail::valid_query_over<async::get_env_t, async::empty_env,
                                         test_queryable>);
-    static_assert(not async::detail::valid_query_over<async::get_env_t,
-                                                      async::empty_env>);
+    STATIC_REQUIRE(not async::detail::valid_query_over<async::get_env_t,
+                                                       async::empty_env>);
 }

--- a/test/forwarding_query.cpp
+++ b/test/forwarding_query.cpp
@@ -16,13 +16,13 @@ struct query3 : async::forwarding_query_t {};
 } // namespace
 
 TEST_CASE("non-forwarding", "[forwarding_query]") {
-    static_assert(not async::forwarding_query(query1{}));
+    STATIC_REQUIRE(not async::forwarding_query(query1{}));
 }
 
 TEST_CASE("forwarding by query", "[forwarding_query]") {
-    static_assert(async::forwarding_query(query2{}));
+    STATIC_REQUIRE(async::forwarding_query(query2{}));
 }
 
 TEST_CASE("forwarding by inheritance", "[forwarding_query]") {
-    static_assert(async::forwarding_query(query3{}));
+    STATIC_REQUIRE(async::forwarding_query(query3{}));
 }

--- a/test/freestanding_sync_wait.cpp
+++ b/test/freestanding_sync_wait.cpp
@@ -1,7 +1,7 @@
 #include "detail/common.hpp"
+#include "detail/debug_handler.hpp"
 
 #include <async/concepts.hpp>
-#include <async/debug.hpp>
 #include <async/just.hpp>
 #include <async/let_value.hpp>
 #include <async/read_env.hpp>
@@ -15,11 +15,9 @@
 #define SIMULATE_FREESTANDING
 #include <async/sync_wait.hpp>
 
-#include <stdx/ct_format.hpp>
 #include <stdx/type_traits.hpp>
 
 #include <catch2/catch_test_macros.hpp>
-#include <fmt/format.h>
 
 TEST_CASE("sync_wait for inline scheduler", "[freestanding_sync_wait]") {
     auto value = async::inline_scheduler<>::schedule() |
@@ -87,22 +85,9 @@ TEST_CASE("sync_wait can use a custom environment",
     CHECK(var == 42);
 }
 
-namespace {
-std::vector<std::string> debug_events{};
-
-struct debug_handler {
-    template <stdx::ct_string C, stdx::ct_string S, typename Ctx>
-    constexpr auto signal(auto &&...) {
-        if constexpr (std::is_same_v<async::debug::tag_of<Ctx>,
-                                     async::sync_wait_t>) {
-            debug_events.push_back(
-                fmt::format("{} {} {}", C, async::debug::name_of<Ctx>, S));
-        }
-    }
-};
-} // namespace
-
-template <> inline auto async::injected_debug_handler<> = debug_handler{};
+template <>
+inline auto async::injected_debug_handler<> =
+    debug_handler<async::sync_wait_t, true>{};
 
 TEST_CASE("sync_wait can be named and debugged with a string",
           "[freestanding_sync_wait]") {

--- a/test/just.cpp
+++ b/test/just.cpp
@@ -1,19 +1,14 @@
 #include "detail/common.hpp"
+#include "detail/debug_handler.hpp"
 
 #include <async/allocator.hpp>
 #include <async/completes_synchronously.hpp>
 #include <async/concepts.hpp>
 #include <async/connect.hpp>
-#include <async/debug.hpp>
 #include <async/env.hpp>
 #include <async/just.hpp>
 
-#include <stdx/ct_format.hpp>
-#include <stdx/type_traits.hpp>
-
-#include <boost/mp11/list.hpp>
 #include <catch2/catch_test_macros.hpp>
-#include <fmt/format.h>
 
 #include <string>
 #include <type_traits>
@@ -39,14 +34,14 @@ TEST_CASE("multiple values", "[just]") {
 }
 
 TEST_CASE("just advertises what it sends", "[just]") {
-    static_assert(
+    STATIC_REQUIRE(
         async::sender_of<decltype(async::just(42)), async::set_value_t(int)>);
 }
 
 TEST_CASE("move-only value", "[just]") {
     int value{};
     auto s = async::just(move_only{42});
-    static_assert(async::singleshot_sender<decltype(s), universal_receiver>);
+    STATIC_REQUIRE(async::singleshot_sender<decltype(s), universal_receiver>);
     auto op = async::connect(
         std::move(s), receiver{[&](move_only<int> mo) { value = mo.value; }});
     async::start(op);
@@ -56,7 +51,7 @@ TEST_CASE("move-only value", "[just]") {
 TEST_CASE("copy sender", "[just]") {
     int value{};
     auto const s = async::just(42);
-    static_assert(async::multishot_sender<decltype(s), universal_receiver>);
+    STATIC_REQUIRE(async::multishot_sender<decltype(s), universal_receiver>);
     auto op = async::connect(s, receiver{[&](auto i) { value = i; }});
     async::start(op);
     CHECK(value == 42);
@@ -65,7 +60,7 @@ TEST_CASE("copy sender", "[just]") {
 TEST_CASE("move sender", "[just]") {
     int value{};
     auto s = async::just(42);
-    static_assert(async::multishot_sender<decltype(s), universal_receiver>);
+    STATIC_REQUIRE(async::multishot_sender<decltype(s), universal_receiver>);
     auto op =
         async::connect(std::move(s), receiver{[&](auto i) { value = i; }});
     async::start(op);
@@ -81,7 +76,7 @@ TEST_CASE("void sender", "[just]") {
 }
 
 TEST_CASE("just has a stack allocator", "[just]") {
-    static_assert(
+    STATIC_REQUIRE(
         std::is_same_v<
             async::allocator_of_t<async::env_of_t<decltype(async::just(42))>>,
             async::stack_allocator>);
@@ -89,25 +84,12 @@ TEST_CASE("just has a stack allocator", "[just]") {
 
 TEST_CASE("just op state is synchronous", "[just]") {
     [[maybe_unused]] auto op = async::connect(async::just(42), receiver{[] {}});
-    static_assert(async::synchronous<decltype(op)>);
+    STATIC_REQUIRE(async::synchronous<decltype(op)>);
 }
 
-namespace {
-std::vector<std::string> debug_events{};
-
-struct debug_handler {
-    template <stdx::ct_string C, stdx::ct_string S, typename Ctx>
-    constexpr auto signal(auto &&...) {
-        static_assert(std::is_same_v<async::debug::tag_of<Ctx>, async::just_t>);
-        static_assert(
-            boost::mp11::mp_empty<async::debug::children_of<Ctx>>::value);
-        debug_events.push_back(
-            fmt::format("{} {} {}", C, async::debug::name_of<Ctx>, S));
-    }
-};
-} // namespace
-
-template <> inline auto async::injected_debug_handler<> = debug_handler{};
+template <>
+inline auto async::injected_debug_handler<> =
+    debug_handler<async::just_t, true>{};
 
 TEST_CASE("just can be debugged with a string", "[just]") {
     using namespace std::string_literals;

--- a/test/just_error_result_of.cpp
+++ b/test/just_error_result_of.cpp
@@ -1,4 +1,5 @@
 #include "detail/common.hpp"
+#include "detail/debug_handler.hpp"
 
 #include <async/allocator.hpp>
 #include <async/completes_synchronously.hpp>
@@ -8,12 +9,7 @@
 #include <async/just_result_of.hpp>
 #include <async/stack_allocator.hpp>
 
-#include <stdx/ct_format.hpp>
-#include <stdx/type_traits.hpp>
-
-#include <boost/mp11/list.hpp>
 #include <catch2/catch_test_macros.hpp>
-#include <fmt/format.h>
 
 #include <concepts>
 #include <string>
@@ -59,14 +55,14 @@ TEST_CASE("multiple functions, some returning void", "[just_error_result_of]") {
 
 TEST_CASE("just_error_result_of advertises what it sends",
           "[just_error_result_of]") {
-    static_assert(async::sender_of<decltype(async::just_error_result_of(
-                                       [] { return 42; })),
-                                   async::set_error_t(int)>);
+    STATIC_REQUIRE(async::sender_of<decltype(async::just_error_result_of(
+                                        [] { return 42; })),
+                                    async::set_error_t(int)>);
 }
 
 TEST_CASE("just_error_result_of advertises what it sends (excluding voids)",
           "[just_error_result_of]") {
-    static_assert(
+    STATIC_REQUIRE(
         std::same_as<async::completion_signatures_of_t<
                          decltype(async::just_error_result_of([] { return 42; },
                                                               [] {}))>,
@@ -76,7 +72,7 @@ TEST_CASE("just_error_result_of advertises what it sends (excluding voids)",
 TEST_CASE("move-only value", "[just_error_result_of]") {
     int value{};
     auto s = async::just_error_result_of([] { return move_only{42}; });
-    static_assert(async::multishot_sender<decltype(s), universal_receiver>);
+    STATIC_REQUIRE(async::multishot_sender<decltype(s), universal_receiver>);
     auto op = async::connect(
         std::move(s), error_receiver{[&](auto &&mo) { value = mo.value; }});
     async::start(op);
@@ -89,7 +85,7 @@ TEST_CASE("move-only lambda", "[just_error_result_of]") {
         [mo = move_only{42}]() -> move_only<int> const && {
             return std::move(mo);
         });
-    static_assert(async::singleshot_sender<decltype(s), universal_receiver>);
+    STATIC_REQUIRE(async::singleshot_sender<decltype(s), universal_receiver>);
     auto op = async::connect(
         std::move(s), error_receiver{[&](auto &&mo) { value = mo.value; }});
     async::start(op);
@@ -97,14 +93,14 @@ TEST_CASE("move-only lambda", "[just_error_result_of]") {
 }
 
 TEST_CASE("copyable lambda", "[just_error_result_of]") {
-    static_assert(async::multishot_sender<decltype(async::just_error_result_of(
-                                              [] { return 42; })),
-                                          universal_receiver>);
+    STATIC_REQUIRE(async::multishot_sender<decltype(async::just_error_result_of(
+                                               [] { return 42; })),
+                                           universal_receiver>);
 }
 
 TEST_CASE("just_error_result_of has a stack allocator",
           "[just_error_result_of]") {
-    static_assert(
+    STATIC_REQUIRE(
         std::is_same_v<
             async::allocator_of_t<async::env_of_t<
                 decltype(async::just_error_result_of([] { return 42; }))>>,
@@ -115,26 +111,12 @@ TEST_CASE("just_error_result_of op state is synchronous",
           "[just_error_result_of]") {
     [[maybe_unused]] auto op = async::connect(
         async::just_error_result_of([] { return 42; }), receiver{[] {}});
-    static_assert(async::synchronous<decltype(op)>);
+    STATIC_REQUIRE(async::synchronous<decltype(op)>);
 }
 
-namespace {
-std::vector<std::string> debug_events{};
-
-struct debug_handler {
-    template <stdx::ct_string C, stdx::ct_string S, typename Ctx>
-    constexpr auto signal(auto &&...) {
-        static_assert(std::is_same_v<async::debug::tag_of<Ctx>,
-                                     async::just_error_result_of_t>);
-        static_assert(
-            boost::mp11::mp_empty<async::debug::children_of<Ctx>>::value);
-        debug_events.push_back(
-            fmt::format("{} {} {}", C, async::debug::name_of<Ctx>, S));
-    }
-};
-} // namespace
-
-template <> inline auto async::injected_debug_handler<> = debug_handler{};
+template <>
+inline auto async::injected_debug_handler<> =
+    debug_handler<async::just_error_result_of_t, true>{};
 
 TEST_CASE("just_error_result_of can be debugged with a string",
           "[just_error_result_of]") {

--- a/test/just_result_of.cpp
+++ b/test/just_result_of.cpp
@@ -1,20 +1,15 @@
 #include "detail/common.hpp"
+#include "detail/debug_handler.hpp"
 
 #include <async/allocator.hpp>
 #include <async/completes_synchronously.hpp>
 #include <async/concepts.hpp>
 #include <async/connect.hpp>
-#include <async/debug.hpp>
 #include <async/env.hpp>
 #include <async/just_result_of.hpp>
 #include <async/stack_allocator.hpp>
 
-#include <stdx/ct_format.hpp>
-#include <stdx/type_traits.hpp>
-
-#include <boost/mp11/list.hpp>
 #include <catch2/catch_test_macros.hpp>
-#include <fmt/format.h>
 
 #include <concepts>
 #include <string>
@@ -58,16 +53,16 @@ TEST_CASE("multiple functions, some returning void", "[just_result_of]") {
 }
 
 TEST_CASE("just_result_of advertises what it sends", "[just_result_of]") {
-    static_assert(
+    STATIC_REQUIRE(
         async::sender_of<decltype(async::just_result_of([] { return 42; })),
                          async::set_value_t(int)>);
-    static_assert(async::sender_of<decltype(async::just_result_of([] {})),
-                                   async::set_value_t()>);
+    STATIC_REQUIRE(async::sender_of<decltype(async::just_result_of([] {})),
+                                    async::set_value_t()>);
 }
 
 TEST_CASE("just_result_of advertises what it sends (excluding voids)",
           "[just_result_of]") {
-    static_assert(
+    STATIC_REQUIRE(
         std::same_as<
             async::completion_signatures_of_t<decltype(async::just_result_of(
                 [] { return 42; }, [] {}, [] { return 17; }))>,
@@ -77,7 +72,7 @@ TEST_CASE("just_result_of advertises what it sends (excluding voids)",
 TEST_CASE("move-only value", "[just_result_of]") {
     int value{};
     auto s = async::just_result_of([] { return move_only{42}; });
-    static_assert(async::multishot_sender<decltype(s), universal_receiver>);
+    STATIC_REQUIRE(async::multishot_sender<decltype(s), universal_receiver>);
     auto op = async::connect(std::move(s),
                              receiver{[&](auto &&mo) { value = mo.value; }});
     async::start(op);
@@ -90,7 +85,7 @@ TEST_CASE("move-only lambda", "[just_result_of]") {
         [mo = move_only{42}]() -> move_only<int> const && {
             return std::move(mo);
         });
-    static_assert(async::singleshot_sender<decltype(s), universal_receiver>);
+    STATIC_REQUIRE(async::singleshot_sender<decltype(s), universal_receiver>);
     auto op = async::connect(std::move(s),
                              receiver{[&](auto &&mo) { value = mo.value; }});
     async::start(op);
@@ -98,13 +93,13 @@ TEST_CASE("move-only lambda", "[just_result_of]") {
 }
 
 TEST_CASE("copyable lambda", "[just_result_of]") {
-    static_assert(async::multishot_sender<decltype(async::just_result_of(
-                                              [] { return 42; })),
-                                          universal_receiver>);
+    STATIC_REQUIRE(async::multishot_sender<decltype(async::just_result_of(
+                                               [] { return 42; })),
+                                           universal_receiver>);
 }
 
 TEST_CASE("just_result_of has a stack allocator", "[just_result_of]") {
-    static_assert(
+    STATIC_REQUIRE(
         std::is_same_v<async::allocator_of_t<async::env_of_t<
                            decltype(async::just_result_of([] { return 42; }))>>,
                        async::stack_allocator>);
@@ -113,26 +108,12 @@ TEST_CASE("just_result_of has a stack allocator", "[just_result_of]") {
 TEST_CASE("just_result_of op state is synchronous", "[just_result_of]") {
     [[maybe_unused]] auto op = async::connect(
         async::just_result_of([] { return 42; }), universal_receiver{});
-    static_assert(async::synchronous<decltype(op)>);
+    STATIC_REQUIRE(async::synchronous<decltype(op)>);
 }
 
-namespace {
-std::vector<std::string> debug_events{};
-
-struct debug_handler {
-    template <stdx::ct_string C, stdx::ct_string S, typename Ctx>
-    constexpr auto signal(auto &&...) {
-        static_assert(
-            std::is_same_v<async::debug::tag_of<Ctx>, async::just_result_of_t>);
-        static_assert(
-            boost::mp11::mp_empty<async::debug::children_of<Ctx>>::value);
-        debug_events.push_back(
-            fmt::format("{} {} {}", C, async::debug::name_of<Ctx>, S));
-    }
-};
-} // namespace
-
-template <> inline auto async::injected_debug_handler<> = debug_handler{};
+template <>
+inline auto async::injected_debug_handler<> =
+    debug_handler<async::just_result_of_t, true>{};
 
 TEST_CASE("just_result_of can be debugged with a string", "[just_result_of]") {
     using namespace std::string_literals;

--- a/test/let_multichannel.cpp
+++ b/test/let_multichannel.cpp
@@ -54,28 +54,28 @@ TEST_CASE("multi-channel let advertises what it sends", "[let_multichannel]") {
     [[maybe_unused]] auto l = async::just(42) | multilet([](auto...) {
                                   return async::just(wrapped_int{42});
                               });
-    static_assert(
+    STATIC_REQUIRE(
         async::sender_of<decltype(l), async::set_value_t(wrapped_int)>);
 }
 
 TEST_CASE("multi-channel let advertises pass-through completions",
           "[let_multichannel]") {
     [[maybe_unused]] auto l = async::just_error(42) | multilet([](auto) {});
-    static_assert(async::sender_of<decltype(l), async::set_error_t(int)>);
+    STATIC_REQUIRE(async::sender_of<decltype(l), async::set_error_t(int)>);
 }
 
 TEST_CASE("multi-channel let can be single shot", "[let_multichannel]") {
     [[maybe_unused]] auto l = async::just(42) | multilet([](auto i) {
                                   return async::just(move_only{i});
                               });
-    static_assert(async::singleshot_sender<decltype(l)>);
+    STATIC_REQUIRE(async::singleshot_sender<decltype(l)>);
 }
 
 TEST_CASE("multi-channel let can be single shot with passthrough",
           "[let_multichannel]") {
     [[maybe_unused]] auto l =
         async::just_error(move_only{42}) | multilet([](auto) { return 42; });
-    static_assert(async::singleshot_sender<decltype(l)>);
+    STATIC_REQUIRE(async::singleshot_sender<decltype(l)>);
 }
 
 namespace {
@@ -103,7 +103,7 @@ TEST_CASE("multi-channel let supports compile-time channel differentiation",
         } else if constexpr (std::is_same_v<Tag, async::set_stopped_t>) {
             return async::just(3);
         } else {
-            static_assert(stdx::always_false_v<Tag>);
+            STATIC_REQUIRE(stdx::always_false_v<Tag>);
         }
     };
     {

--- a/test/let_stopped.cpp
+++ b/test/let_stopped.cpp
@@ -1,8 +1,8 @@
 #include "detail/common.hpp"
+#include "detail/debug_handler.hpp"
 
 #include <async/concepts.hpp>
 #include <async/connect.hpp>
-#include <async/debug.hpp>
 #include <async/just.hpp>
 #include <async/let_stopped.hpp>
 #include <async/schedulers/inline_scheduler.hpp>
@@ -11,11 +11,7 @@
 #include <async/then.hpp>
 #include <async/variant_sender.hpp>
 
-#include <stdx/ct_format.hpp>
-
-#include <boost/mp11/list.hpp>
 #include <catch2/catch_test_macros.hpp>
-#include <fmt/format.h>
 
 #include <string>
 #include <utility>
@@ -45,14 +41,14 @@ TEST_CASE("let_stopped advertises what it sends", "[let_stopped]") {
     auto s = async::just_stopped();
     [[maybe_unused]] auto l =
         async::let_stopped(s, [] { return async::just(42); });
-    static_assert(async::sender_of<decltype(l), async::set_value_t(int)>);
+    STATIC_REQUIRE(async::sender_of<decltype(l), async::set_value_t(int)>);
 }
 
 TEST_CASE("let_stopped advertises errors", "[let_stopped]") {
     auto s = async::just_stopped();
     [[maybe_unused]] auto l =
         async::let_stopped(s, [] { return async::just_error(42); });
-    static_assert(async::sender_of<decltype(l), async::set_error_t(int)>);
+    STATIC_REQUIRE(async::sender_of<decltype(l), async::set_error_t(int)>);
 }
 
 TEST_CASE("let_stopped is pipeable", "[let_stopped]") {
@@ -81,7 +77,7 @@ TEST_CASE("move-only value", "[let_stopped]") {
 
     auto s = async::just_stopped();
     auto l = async::let_stopped(s, [] { return async::just(move_only{42}); });
-    static_assert(async::singleshot_sender<decltype(l), universal_receiver>);
+    STATIC_REQUIRE(async::singleshot_sender<decltype(l), universal_receiver>);
     auto op = async::connect(std::move(l),
                              receiver{[&](auto &&mo) { value = mo.value; }});
     async::start(op);
@@ -118,27 +114,27 @@ TEST_CASE("let_stopped propagates error", "[let_stopped]") {
 
 TEST_CASE("let_stopped advertises pass-through completions", "[let_stopped]") {
     [[maybe_unused]] auto l = async::just(42) | async::let_stopped([] {});
-    static_assert(async::sender_of<decltype(l), async::set_value_t(int)>);
+    STATIC_REQUIRE(async::sender_of<decltype(l), async::set_value_t(int)>);
 }
 
 TEST_CASE("let_stopped can be single shot", "[let_stopped]") {
     [[maybe_unused]] auto l = async::just_stopped() | async::let_stopped([] {
                                   return async::just(move_only{42});
                               });
-    static_assert(async::singleshot_sender<decltype(l)>);
+    STATIC_REQUIRE(async::singleshot_sender<decltype(l)>);
 }
 
 TEST_CASE("let_stopped can be single shot with passthrough", "[let_stopped]") {
     [[maybe_unused]] auto l = async::just(move_only{42}) |
                               async::let_stopped([](auto) { return 42; });
-    static_assert(async::singleshot_sender<decltype(l)>);
+    STATIC_REQUIRE(async::singleshot_sender<decltype(l)>);
 }
 
 TEST_CASE("let_stopped op state may complete synchronously", "[let_stopped]") {
     auto s = async::just_stopped() |
              async::let_stopped([] { return async::just(); });
     [[maybe_unused]] auto op = async::connect(s, receiver{[] {}});
-    static_assert(async::synchronous<decltype(op)>);
+    STATIC_REQUIRE(async::synchronous<decltype(op)>);
 }
 
 TEST_CASE("let_stopped op state may not complete synchronously if antecedent "
@@ -148,7 +144,7 @@ TEST_CASE("let_stopped op state may not complete synchronously if antecedent "
         async::start_on(async::thread_scheduler{}, async::just_stopped()) |
         async::let_stopped([] { return async::just(); });
     [[maybe_unused]] auto op = async::connect(s, receiver{[] {}});
-    static_assert(not async::synchronous<decltype(op)>);
+    STATIC_REQUIRE(not async::synchronous<decltype(op)>);
 }
 
 TEST_CASE("let_stopped op state may not complete synchronously if subsequent "
@@ -158,27 +154,12 @@ TEST_CASE("let_stopped op state may not complete synchronously if subsequent "
                        return async::thread_scheduler{}.schedule();
                    });
     [[maybe_unused]] auto op = async::connect(s, receiver{[] {}});
-    static_assert(not async::synchronous<decltype(op)>);
+    STATIC_REQUIRE(not async::synchronous<decltype(op)>);
 }
 
-namespace {
-std::vector<std::string> debug_events{};
-
-struct debug_handler {
-    template <stdx::ct_string C, stdx::ct_string S, typename Ctx>
-    constexpr auto signal(auto &&...) {
-        if constexpr (std::is_same_v<async::debug::tag_of<Ctx>,
-                                     async::let_t<async::set_stopped_t>>) {
-            static_assert(not boost::mp11::mp_empty<
-                          async::debug::children_of<Ctx>>::value);
-            debug_events.push_back(
-                fmt::format("{} {} {}", C, async::debug::name_of<Ctx>, S));
-        }
-    }
-};
-} // namespace
-
-template <> inline auto async::injected_debug_handler<> = debug_handler{};
+template <>
+inline auto async::injected_debug_handler<> =
+    debug_handler<async::let_t<async::set_stopped_t>>{};
 
 TEST_CASE("let_stopped can be debugged with a string", "[let_stopped]") {
     using namespace std::string_literals;

--- a/test/read_env.cpp
+++ b/test/read_env.cpp
@@ -28,14 +28,14 @@ TEST_CASE("read_env advertises what it sends", "[read_env]") {
     [[maybe_unused]] auto r = stoppable_receiver{[] {}};
     using E = async::env_of_t<decltype(r)>;
     using ST = async::stop_token_of_t<E>;
-    static_assert(
+    STATIC_REQUIRE(
         async::sender_of<decltype(async::read_env(async::get_stop_token_t{})),
                          async::set_value_t(ST const &), E>);
-    static_assert(std::is_same_v<
-                  async::completion_signatures_of_t<decltype(async::read_env(
-                      async::get_stop_token_t{}))>,
-                  async::completion_signatures<async::set_value_t(
-                      async::never_stop_token)>>);
+    STATIC_REQUIRE(std::is_same_v<
+                   async::completion_signatures_of_t<decltype(async::read_env(
+                       async::get_stop_token_t{}))>,
+                   async::completion_signatures<async::set_value_t(
+                       async::never_stop_token)>>);
 }
 
 TEST_CASE("read_env sends a value", "[read_env]") {
@@ -61,14 +61,14 @@ TEST_CASE("read_env with sync_wait", "[read_env]") {
 
 TEST_CASE("read_env completes synchronously", "[read_env]") {
     [[maybe_unused]] auto const s = async::get_scheduler();
-    static_assert(async::synchronous<decltype(s)>);
+    STATIC_REQUIRE(async::synchronous<decltype(s)>);
 }
 
 TEST_CASE("read_env op state is synchronous", "[read_env]") {
     auto const s = async::get_stop_token();
     [[maybe_unused]] auto const op =
         async::connect(s, stoppable_receiver{[] {}});
-    static_assert(async::synchronous<decltype(op)>);
+    STATIC_REQUIRE(async::synchronous<decltype(op)>);
 }
 
 namespace {

--- a/test/retry.cpp
+++ b/test/retry.cpp
@@ -1,8 +1,8 @@
 #include "detail/common.hpp"
+#include "detail/debug_handler.hpp"
 
 #include <async/concepts.hpp>
 #include <async/connect.hpp>
-#include <async/debug.hpp>
 #include <async/just.hpp>
 #include <async/just_result_of.hpp>
 #include <async/retry.hpp>
@@ -14,11 +14,7 @@
 #include <async/variant_sender.hpp>
 #include <async/when_all.hpp>
 
-#include <stdx/ct_format.hpp>
-
-#include <boost/mp11/list.hpp>
 #include <catch2/catch_test_macros.hpp>
-#include <fmt/format.h>
 
 #include <concepts>
 #include <string>
@@ -26,15 +22,15 @@
 
 TEST_CASE("retry advertises what it sends", "[retry]") {
     [[maybe_unused]] auto s = async::just(42) | async::retry();
-    static_assert(
+    STATIC_REQUIRE(
         std::same_as<async::completion_signatures_of_t<decltype(s)>,
                      async::completion_signatures<async::set_value_t(int)>>);
 }
 
 TEST_CASE("retry advertises what it sends (nothing!)", "[retry]") {
     [[maybe_unused]] auto s = async::just_error(42) | async::retry();
-    static_assert(std::same_as<async::completion_signatures_of_t<decltype(s)>,
-                               async::completion_signatures<>>);
+    STATIC_REQUIRE(std::same_as<async::completion_signatures_of_t<decltype(s)>,
+                                async::completion_signatures<>>);
 }
 
 TEST_CASE("retry advertises sending stopped", "[retry]") {
@@ -45,7 +41,7 @@ TEST_CASE("retry advertises sending stopped", "[retry]") {
             [] { return async::just_stopped(); }) |
         async::retry();
     [[maybe_unused]] auto r = stoppable_receiver([] {});
-    static_assert(
+    STATIC_REQUIRE(
         std::same_as<async::completion_signatures_of_t<
                          decltype(s), async::env_of_t<decltype(r)>>,
                      async::completion_signatures<async::set_stopped_t()>>);
@@ -77,7 +73,7 @@ TEST_CASE("retry retries on error", "[retry]") {
 TEST_CASE("retry_until advertises what it sends", "[retry]") {
     [[maybe_unused]] auto s =
         async::just_error(42) | async::retry_until([](auto) { return true; });
-    static_assert(
+    STATIC_REQUIRE(
         std::same_as<async::completion_signatures_of_t<decltype(s)>,
                      async::completion_signatures<async::set_error_t(int)>>);
 }
@@ -115,7 +111,7 @@ TEST_CASE("retry may complete synchronously", "[retry]") {
     int var{};
     auto sub = async::just() | async::then([&] { ++var; });
     auto s = async::retry_until(sub, [&](auto i) { return i == 42; });
-    static_assert(async::synchronous<decltype(s)>);
+    STATIC_REQUIRE(async::synchronous<decltype(s)>);
 }
 
 TEST_CASE("retry may not complete synchronously", "[retry]") {
@@ -123,7 +119,7 @@ TEST_CASE("retry may not complete synchronously", "[retry]") {
     auto sub =
         async::thread_scheduler<>::schedule() | async::then([&] { ++var; });
     auto s = async::retry_until(sub, [&](auto i) { return i == 42; });
-    static_assert(not async::synchronous<decltype(s)>);
+    STATIC_REQUIRE(not async::synchronous<decltype(s)>);
 }
 
 TEST_CASE("retry op state may be synchronous", "[retry]") {
@@ -134,7 +130,7 @@ TEST_CASE("retry op state may be synchronous", "[retry]") {
                });
     auto s = async::retry_until(sub, [&](auto i) { return i == 42; });
     auto op = async::connect(s, receiver{[] {}});
-    static_assert(async::synchronous<decltype(op)>);
+    STATIC_REQUIRE(async::synchronous<decltype(op)>);
 }
 
 TEST_CASE("retry op state may not be synchronous", "[retry]") {
@@ -145,26 +141,11 @@ TEST_CASE("retry op state may not be synchronous", "[retry]") {
                });
     auto s = async::retry_until(sub, [&](auto i) { return i == 42; });
     auto op = async::connect(s, receiver{[] {}});
-    static_assert(not async::synchronous<decltype(op)>);
+    STATIC_REQUIRE(not async::synchronous<decltype(op)>);
 }
 
-namespace {
-std::vector<std::string> debug_events{};
-
-struct debug_handler {
-    template <stdx::ct_string C, stdx::ct_string S, typename Ctx>
-    constexpr auto signal(auto &&...) {
-        if constexpr (std::same_as<async::debug::tag_of<Ctx>, async::retry_t>) {
-            static_assert(not boost::mp11::mp_empty<
-                          async::debug::children_of<Ctx>>::value);
-            debug_events.push_back(
-                fmt::format("{} {} {}", C, async::debug::name_of<Ctx>, S));
-        }
-    }
-};
-} // namespace
-
-template <> inline auto async::injected_debug_handler<> = debug_handler{};
+template <>
+inline auto async::injected_debug_handler<> = debug_handler<async::retry_t>{};
 
 TEST_CASE("retry_until can be debugged", "[retry]") {
     using namespace std::string_literals;

--- a/test/start_on.cpp
+++ b/test/start_on.cpp
@@ -32,13 +32,13 @@ TEST_CASE("start_on error", "[start_on]") {
 TEST_CASE("start_on advertises what it sends", "[start_on]") {
     [[maybe_unused]] auto s =
         async::start_on(async::inline_scheduler{}, async::just(42));
-    static_assert(async::sender_of<decltype(s), async::set_value_t(int)>);
+    STATIC_REQUIRE(async::sender_of<decltype(s), async::set_value_t(int)>);
 }
 
 TEST_CASE("start_on advertises errors", "[start_on]") {
     [[maybe_unused]] auto s =
         async::start_on(async::inline_scheduler{}, async::just_error(42));
-    static_assert(async::sender_of<decltype(s), async::set_error_t(int)>);
+    STATIC_REQUIRE(async::sender_of<decltype(s), async::set_error_t(int)>);
 }
 
 TEST_CASE("move-only value", "[start_on]") {
@@ -46,7 +46,7 @@ TEST_CASE("move-only value", "[start_on]") {
 
     auto s =
         async::start_on(async::inline_scheduler{}, async::just(move_only{42}));
-    static_assert(async::singleshot_sender<decltype(s), universal_receiver>);
+    STATIC_REQUIRE(async::singleshot_sender<decltype(s), universal_receiver>);
     auto op = async::connect(std::move(s),
                              receiver{[&](auto mo) { value = mo.value; }});
     async::start(op);
@@ -57,7 +57,7 @@ TEST_CASE("singleshot sender first", "[start_on]") {
     int value{};
 
     auto s = async::start_on(singleshot_scheduler{}, async::just(42));
-    static_assert(async::singleshot_sender<decltype(s), universal_receiver>);
+    STATIC_REQUIRE(async::singleshot_sender<decltype(s), universal_receiver>);
     auto op =
         async::connect(std::move(s), receiver{[&](auto i) { value = i; }});
     async::start(op);
@@ -68,9 +68,9 @@ TEST_CASE("start_on advertises what it sends according to the receiver",
           "[start_on]") {
     [[maybe_unused]] auto s =
         async::start_on(async::inline_scheduler{}, async::when_all());
-    static_assert(not async::sender_of<decltype(s), async::set_stopped_t()>);
+    STATIC_REQUIRE(not async::sender_of<decltype(s), async::set_stopped_t()>);
 
     [[maybe_unused]] auto r = stoppable_receiver{[] {}};
-    static_assert(async::sender_of<decltype(s), async::set_stopped_t(),
-                                   async::env_of_t<decltype(r)>>);
+    STATIC_REQUIRE(async::sender_of<decltype(s), async::set_stopped_t(),
+                                    async::env_of_t<decltype(r)>>);
 }

--- a/test/stop_token.cpp
+++ b/test/stop_token.cpp
@@ -8,17 +8,17 @@
 #include <memory>
 
 TEST_CASE("concepts", "[stop_token]") {
-    static_assert(async::stoppable_token<async::inplace_stop_token>);
-    static_assert(async::stoppable_token<async::never_stop_token>);
-    static_assert(async::unstoppable_token<async::never_stop_token>);
-    static_assert(
+    STATIC_REQUIRE(async::stoppable_token<async::inplace_stop_token>);
+    STATIC_REQUIRE(async::stoppable_token<async::never_stop_token>);
+    STATIC_REQUIRE(async::unstoppable_token<async::never_stop_token>);
+    STATIC_REQUIRE(
         async::stoppable_token_for<async::inplace_stop_token, decltype([] {})>);
 }
 
 TEST_CASE("never_stop_token", "[stop_token]") {
     constexpr auto t = async::never_stop_token{};
-    static_assert(not t.stop_possible());
-    static_assert(not t.stop_requested());
+    STATIC_REQUIRE(not t.stop_possible());
+    STATIC_REQUIRE(not t.stop_requested());
 }
 
 TEST_CASE("request_stop returns true once", "[stop_token]") {

--- a/test/then.cpp
+++ b/test/then.cpp
@@ -1,4 +1,5 @@
 #include "detail/common.hpp"
+#include "detail/debug_handler.hpp"
 
 #include <async/concepts.hpp>
 #include <async/connect.hpp>
@@ -8,10 +9,7 @@
 #include <async/schedulers/inline_scheduler.hpp>
 #include <async/then.hpp>
 
-#include <stdx/ct_format.hpp>
-
 #include <catch2/catch_test_macros.hpp>
-#include <fmt/format.h>
 
 #include <concepts>
 #include <memory>
@@ -42,14 +40,14 @@ TEST_CASE("then propagates a value", "[then]") {
 TEST_CASE("then advertises what it sends", "[then]") {
     auto s = async::just();
     [[maybe_unused]] auto n = async::then(s, [] { return 42; });
-    static_assert(async::sender_of<decltype(n), async::set_value_t(int)>);
+    STATIC_REQUIRE(async::sender_of<decltype(n), async::set_value_t(int)>);
 }
 
 TEST_CASE("then can send a reference", "[then]") {
     int value{};
     auto s = async::just();
     [[maybe_unused]] auto n = async::then(s, [&]() -> int & { return value; });
-    static_assert(async::sender_of<decltype(n), async::set_value_t(int &)>);
+    STATIC_REQUIRE(async::sender_of<decltype(n), async::set_value_t(int &)>);
 }
 
 TEST_CASE("then is pipeable", "[then]") {
@@ -77,9 +75,9 @@ TEST_CASE("then can send nothing", "[then]") {
 
     auto s = async::just();
     auto n1 = async::then(s, [] {});
-    static_assert(async::sender_of<decltype(n1), async::set_value_t()>);
+    STATIC_REQUIRE(async::sender_of<decltype(n1), async::set_value_t()>);
     auto n2 = async::then(n1, [] {});
-    static_assert(async::sender_of<decltype(n2), async::set_value_t()>);
+    STATIC_REQUIRE(async::sender_of<decltype(n2), async::set_value_t()>);
     auto op = async::connect(n2, receiver{[&] { value = 42; }});
     async::start(op);
     CHECK(value == 42);
@@ -101,7 +99,7 @@ TEST_CASE("move-only lambda", "[then]") {
              async::then([mo = move_only{42}]() -> move_only<int> const && {
                  return std::move(mo);
              });
-    static_assert(async::singleshot_sender<decltype(n), universal_receiver>);
+    STATIC_REQUIRE(async::singleshot_sender<decltype(n), universal_receiver>);
     auto op = async::connect(std::move(n),
                              receiver{[&](auto &&mo) { value = mo.value; }});
     async::start(op);
@@ -112,7 +110,7 @@ TEST_CASE("single-shot sender", "[then]") {
     [[maybe_unused]] auto n = async::inline_scheduler<>::schedule<
                                   async::inline_scheduler<>::singleshot>() |
                               async::then([] {});
-    static_assert(async::singleshot_sender<decltype(n), universal_receiver>);
+    STATIC_REQUIRE(async::singleshot_sender<decltype(n), universal_receiver>);
 }
 
 TEST_CASE("then propagates error", "[then]") {
@@ -120,7 +118,7 @@ TEST_CASE("then propagates error", "[then]") {
     int value{};
 
     auto s = async::just_error(42) | async::then([&] { then_called = true; });
-    static_assert(
+    STATIC_REQUIRE(
         std::same_as<async::completion_signatures_of_t<decltype(s)>,
                      async::completion_signatures<async::set_error_t(int)>>);
     auto op = async::connect(s, error_receiver{[&](auto i) { value = i; }});
@@ -134,7 +132,7 @@ TEST_CASE("then propagates stopped", "[then]") {
     int value{};
 
     auto s = async::just_stopped() | async::then([&] { then_called = true; });
-    static_assert(
+    STATIC_REQUIRE(
         std::same_as<async::completion_signatures_of_t<decltype(s)>,
                      async::completion_signatures<async::set_stopped_t()>>);
     auto op = async::connect(s, stopped_receiver{[&] { value = 42; }});
@@ -155,7 +153,7 @@ TEST_CASE("then propagates forwarding queries to its child environment",
 TEST_CASE("then advertises what it sends (variadic)", "[then]") {
     auto s = async::just(true, false) |
              async::then([](auto) { return 42; }, [](auto) { return 17; });
-    static_assert(async::sender_of<decltype(s), async::set_value_t(int, int)>);
+    STATIC_REQUIRE(async::sender_of<decltype(s), async::set_value_t(int, int)>);
 }
 
 TEST_CASE("then (variadic)", "[then]") {
@@ -177,7 +175,7 @@ TEST_CASE("variadic then can have void-returning functions", "[then]") {
     int y{42};
     auto s = async::just(2, 3) |
              async::then([](auto i) { return i * 2; }, [](auto) {});
-    static_assert(async::sender_of<decltype(s), async::set_value_t(int)>);
+    STATIC_REQUIRE(async::sender_of<decltype(s), async::set_value_t(int)>);
     auto op = async::connect(s, receiver{[&](auto i) { x = i; }});
     async::start(op);
     CHECK(x == 4);
@@ -188,7 +186,7 @@ TEST_CASE("move-only value (from then) (variadic)", "[then]") {
     int x{};
     auto s = async::just(2, 3) |
              async::then([](auto i) { return move_only{i}; }, [](auto) {});
-    static_assert(
+    STATIC_REQUIRE(
         async::sender_of<decltype(s), async::set_value_t(move_only<int>)>);
     auto op = async::connect(s, receiver{[&](auto i) { x = i.value; }});
     async::start(op);
@@ -199,7 +197,7 @@ TEST_CASE("move-only value (to then) (variadic)", "[then]") {
     int x{};
     auto s = async::just(move_only{2}, move_only{3}) |
              async::then([](auto i) { return i.value; }, [](auto) {});
-    static_assert(async::sender_of<decltype(s), async::set_value_t(int)>);
+    STATIC_REQUIRE(async::sender_of<decltype(s), async::set_value_t(int)>);
     auto op = async::connect(std::move(s), receiver{[&](auto i) { x = i; }});
     async::start(op);
     CHECK(x == 2);
@@ -212,7 +210,7 @@ TEST_CASE("variadic then can take heteroadic functions", "[then]") {
     auto s = async::just(2, 3, 4) |
              async::then([](auto i, auto j) { return i + j; },
                          [](auto k) { return k; }, [] { return true; });
-    static_assert(
+    STATIC_REQUIRE(
         async::sender_of<decltype(s), async::set_value_t(int, int, bool)>);
     auto op = async::connect(s, receiver{[&](auto i, auto j, auto k) {
                                  x = i;
@@ -235,25 +233,8 @@ TEST_CASE("then can handle a reference", "[then]") {
     async::start(op);
 }
 
-namespace {
-std::vector<std::string> debug_events{};
-
-struct debug_handler {
-    template <stdx::ct_string C, stdx::ct_string S, typename Ctx>
-    constexpr auto signal(auto &&...) {
-        using namespace stdx::literals;
-        if constexpr (std::is_same_v<async::debug::tag_of<Ctx>,
-                                     async::then_t>) {
-            static_assert(not boost::mp11::mp_empty<
-                          async::debug::children_of<Ctx>>::value);
-            debug_events.push_back(
-                fmt::format("{} {} {}", C, async::debug::name_of<Ctx>, S));
-        }
-    }
-};
-} // namespace
-
-template <> inline auto async::injected_debug_handler<> = debug_handler{};
+template <>
+inline auto async::injected_debug_handler<> = debug_handler<async::then_t>{};
 
 TEST_CASE("then can be debugged with a string", "[then]") {
     using namespace std::string_literals;

--- a/test/timeout_after.cpp
+++ b/test/timeout_after.cpp
@@ -72,8 +72,8 @@ template <>
 TEST_CASE("timeout_after advertises what it sends", "[timeout_after]") {
     auto s = async::start_on(async::time_scheduler{1s}, async::just(42));
     auto to = async::timeout_after(s, 100ms, 1.0f);
-    static_assert(async::sender_of<decltype(to), async::set_value_t(int)>);
-    static_assert(async::sender_of<decltype(to), async::set_error_t(float)>);
+    STATIC_REQUIRE(async::sender_of<decltype(to), async::set_value_t(int)>);
+    STATIC_REQUIRE(async::sender_of<decltype(to), async::set_error_t(float)>);
 }
 
 TEST_CASE("timeout_after can complete successfully", "[timeout_after]") {
@@ -188,7 +188,7 @@ TEST_CASE("timeout_after can time out on custom channel", "[timeout_after]") {
     auto s = async::start_on(scheduler_factory(1s), async::just(42));
     auto to =
         async::timeout_after<alt_domain, async::set_value_t>(s, 100ms, 1.0f);
-    static_assert(
+    STATIC_REQUIRE(
         std::same_as<async::completion_signatures_of_t<decltype(to)>,
                      async::completion_signatures<async::set_value_t(float),
                                                   async::set_value_t(int)>>);

--- a/test/transform_error.cpp
+++ b/test/transform_error.cpp
@@ -1,4 +1,5 @@
 #include "detail/common.hpp"
+#include "detail/debug_handler.hpp"
 
 #include <async/concepts.hpp>
 #include <async/connect.hpp>
@@ -7,10 +8,7 @@
 #include <async/schedulers/inline_scheduler.hpp>
 #include <async/then.hpp>
 
-#include <stdx/ct_format.hpp>
-
 #include <catch2/catch_test_macros.hpp>
-#include <fmt/format.h>
 
 #include <concepts>
 #include <memory>
@@ -41,7 +39,7 @@ TEST_CASE("transform_error propagates a value", "[transform_error]") {
 TEST_CASE("transform_error advertises what it sends", "[transform_error]") {
     auto s = async::just_error(17);
     [[maybe_unused]] auto n = async::transform_error(s, [] { return 42; });
-    static_assert(async::sender_of<decltype(n), async::set_error_t(int)>);
+    STATIC_REQUIRE(async::sender_of<decltype(n), async::set_error_t(int)>);
 }
 
 TEST_CASE("transform_error can send a reference", "[transform_error]") {
@@ -49,7 +47,7 @@ TEST_CASE("transform_error can send a reference", "[transform_error]") {
     auto s = async::just_error(17);
     [[maybe_unused]] auto n =
         async::transform_error(s, [&]() -> int & { return value; });
-    static_assert(async::sender_of<decltype(n), async::set_error_t(int &)>);
+    STATIC_REQUIRE(async::sender_of<decltype(n), async::set_error_t(int &)>);
 }
 
 TEST_CASE("transform_error is pipeable", "[transform_error]") {
@@ -77,9 +75,9 @@ TEST_CASE("transform_error can send nothing", "[transform_error]") {
 
     auto s = async::just_error(17);
     auto n1 = async::transform_error(s, [] {});
-    static_assert(async::sender_of<decltype(n1), async::set_error_t()>);
+    STATIC_REQUIRE(async::sender_of<decltype(n1), async::set_error_t()>);
     auto n2 = async::transform_error(n1, [] {});
-    static_assert(async::sender_of<decltype(n2), async::set_error_t()>);
+    STATIC_REQUIRE(async::sender_of<decltype(n2), async::set_error_t()>);
     auto op = async::connect(n2, error_receiver{[&] { value = 42; }});
     async::start(op);
     CHECK(value == 42);
@@ -103,7 +101,7 @@ TEST_CASE("move-only lambda", "[transform_error]") {
                  [mo = move_only{42}]() -> move_only<int> const && {
                      return std::move(mo);
                  });
-    static_assert(async::singleshot_sender<decltype(n), universal_receiver>);
+    STATIC_REQUIRE(async::singleshot_sender<decltype(n), universal_receiver>);
     auto op = async::connect(
         std::move(n), error_receiver{[&](auto &&mo) { value = mo.value; }});
     async::start(op);
@@ -114,7 +112,7 @@ TEST_CASE("single-shot sender", "[transform_error]") {
     [[maybe_unused]] auto n = async::inline_scheduler<>::schedule<
                                   async::inline_scheduler<>::singleshot>() |
                               async::transform_error([] {});
-    static_assert(async::singleshot_sender<decltype(n), universal_receiver>);
+    STATIC_REQUIRE(async::singleshot_sender<decltype(n), universal_receiver>);
 }
 
 TEST_CASE("transform_error propagates value", "[transform_error]") {
@@ -123,7 +121,7 @@ TEST_CASE("transform_error propagates value", "[transform_error]") {
 
     auto s = async::just(42) |
              async::transform_error([&] { transform_error_called = true; });
-    static_assert(
+    STATIC_REQUIRE(
         std::same_as<async::completion_signatures_of_t<decltype(s)>,
                      async::completion_signatures<async::set_value_t(int)>>);
     auto op = async::connect(s, receiver{[&](auto i) { value = i; }});
@@ -138,7 +136,7 @@ TEST_CASE("transform_error propagates stopped", "[transform_error]") {
 
     auto s = async::just_stopped() |
              async::transform_error([&] { transform_error_called = true; });
-    static_assert(
+    STATIC_REQUIRE(
         std::same_as<async::completion_signatures_of_t<decltype(s)>,
                      async::completion_signatures<async::set_stopped_t()>>);
     auto op = async::connect(s, stopped_receiver{[&] { value = 42; }});
@@ -162,7 +160,7 @@ TEST_CASE("transform_error advertises what it sends (variadic)",
     auto s = async::just_error(true, false) |
              async::transform_error([](auto) { return 42; },
                                     [](auto) { return 17; });
-    static_assert(async::sender_of<decltype(s), async::set_error_t(int, int)>);
+    STATIC_REQUIRE(async::sender_of<decltype(s), async::set_error_t(int, int)>);
 }
 
 TEST_CASE("transform_error (variadic)", "[transform_error]") {
@@ -186,7 +184,7 @@ TEST_CASE("variadic transform_error can have void-returning functions",
     int y{42};
     auto s = async::just_error(2, 3) |
              async::transform_error([](auto i) { return i * 2; }, [](auto) {});
-    static_assert(async::sender_of<decltype(s), async::set_error_t(int)>);
+    STATIC_REQUIRE(async::sender_of<decltype(s), async::set_error_t(int)>);
     auto op = async::connect(s, error_receiver{[&](auto i) { x = i; }});
     async::start(op);
     CHECK(x == 4);
@@ -199,7 +197,7 @@ TEST_CASE("move-only value (from transform_error) (variadic)",
     auto s = async::just_error(2, 3) |
              async::transform_error([](auto i) { return move_only{i}; },
                                     [](auto) {});
-    static_assert(
+    STATIC_REQUIRE(
         async::sender_of<decltype(s), async::set_error_t(move_only<int>)>);
     auto op = async::connect(s, error_receiver{[&](auto i) { x = i.value; }});
     async::start(op);
@@ -212,7 +210,7 @@ TEST_CASE("move-only value (to transform_error) (variadic)",
     auto s =
         async::just_error(move_only{2}, move_only{3}) |
         async::transform_error([](auto i) { return i.value; }, [](auto) {});
-    static_assert(async::sender_of<decltype(s), async::set_error_t(int)>);
+    STATIC_REQUIRE(async::sender_of<decltype(s), async::set_error_t(int)>);
     auto op =
         async::connect(std::move(s), error_receiver{[&](auto i) { x = i; }});
     async::start(op);
@@ -228,7 +226,7 @@ TEST_CASE("variadic transform_error can take heteroadic functions",
         async::just_error(2, 3, 4) |
         async::transform_error([](auto i, auto j) { return i + j; },
                                [](auto k) { return k; }, [] { return true; });
-    static_assert(
+    STATIC_REQUIRE(
         async::sender_of<decltype(s), async::set_error_t(int, int, bool)>);
     auto op = async::connect(s, error_receiver{[&](auto i, auto j, auto k) {
                                  x = i;
@@ -252,25 +250,9 @@ TEST_CASE("transform_error can handle a reference", "[transform_error]") {
     async::start(op);
 }
 
-namespace {
-std::vector<std::string> debug_events{};
-
-struct debug_handler {
-    template <stdx::ct_string C, stdx::ct_string S, typename Ctx>
-    constexpr auto signal(auto &&...) {
-        using namespace stdx::literals;
-        if constexpr (std::is_same_v<async::debug::tag_of<Ctx>,
-                                     async::transform_error_t>) {
-            static_assert(not boost::mp11::mp_empty<
-                          async::debug::children_of<Ctx>>::value);
-            debug_events.push_back(
-                fmt::format("{} {} {}", C, async::debug::name_of<Ctx>, S));
-        }
-    }
-};
-} // namespace
-
-template <> inline auto async::injected_debug_handler<> = debug_handler{};
+template <>
+inline auto async::injected_debug_handler<> =
+    debug_handler<async::transform_error_t>{};
 
 TEST_CASE("transform_error can be debugged with a string",
           "[transform_error]") {

--- a/test/type_traits.cpp
+++ b/test/type_traits.cpp
@@ -13,8 +13,8 @@
 TEST_CASE("connect_result_t", "[type_traits]") {
     auto s = async::inline_scheduler{}.schedule();
     auto r = receiver{[] {}};
-    static_assert(async::operation_state<
-                  async::connect_result_t<decltype(s), decltype(r)>>);
+    STATIC_REQUIRE(async::operation_state<
+                   async::connect_result_t<decltype(s), decltype(r)>>);
 }
 
 namespace {
@@ -28,15 +28,15 @@ TEST_CASE("gather signatures", "[type_traits]") {
     using sigs = async::completion_signatures<async::set_value_t(int),
                                               async::set_error_t(float),
                                               async::set_stopped_t()>;
-    static_assert(
+    STATIC_REQUIRE(
         std::is_same_v<variant<tuple<int>>,
                        async::detail::gather_signatures<async::set_value_t,
                                                         sigs, tuple, variant>>);
-    static_assert(
+    STATIC_REQUIRE(
         std::is_same_v<variant<tuple<float>>,
                        async::detail::gather_signatures<async::set_error_t,
                                                         sigs, tuple, variant>>);
-    static_assert(
+    STATIC_REQUIRE(
         std::is_same_v<variant<tuple<>>,
                        async::detail::gather_signatures<async::set_stopped_t,
                                                         sigs, tuple, variant>>);
@@ -46,14 +46,14 @@ TEMPLATE_TEST_CASE("gather signatures (no signature for tag)", "[type_traits]",
                    async::set_value_t, async::set_error_t,
                    async::set_stopped_t) {
     using sigs = async::completion_signatures<>;
-    static_assert(
+    STATIC_REQUIRE(
         std::is_same_v<variant<>, async::detail::gather_signatures<
                                       TestType, sigs, tuple, variant>>);
 }
 
 TEST_CASE("gather signatures (unary template)", "[type_traits]") {
     using sigs = async::completion_signatures<async::set_value_t(int)>;
-    static_assert(
+    STATIC_REQUIRE(
         std::is_same_v<
             unary_variant<unary_tuple<int>>,
             async::detail::gather_signatures<async::set_value_t, sigs,
@@ -73,22 +73,22 @@ struct typed_sender2 {
 } // namespace
 
 TEST_CASE("completion signatures with exposed type", "[type_traits]") {
-    static_assert(
+    STATIC_REQUIRE(
         std::same_as<typename typed_sender1::completion_signatures,
                      async::completion_signatures_of_t<typed_sender1>>);
-    static_assert(
+    STATIC_REQUIRE(
         std::same_as<typename typed_sender2::completion_signatures,
                      async::completion_signatures_of_t<typed_sender2>>);
 }
 
 TEST_CASE("typed completion signatures by channel", "[type_traits]") {
-    static_assert(
+    STATIC_REQUIRE(
         std::same_as<async::completion_signatures<async::set_value_t(int)>,
                      async::value_signatures_of_t<typed_sender1>>);
-    static_assert(
+    STATIC_REQUIRE(
         std::same_as<async::completion_signatures<async::set_error_t(float)>,
                      async::error_signatures_of_t<typed_sender1>>);
-    static_assert(
+    STATIC_REQUIRE(
         std::same_as<async::completion_signatures<async::set_stopped_t()>,
                      async::stopped_signatures_of_t<typed_sender1>>);
 }
@@ -120,24 +120,24 @@ struct queryable_sender2 {
 } // namespace
 
 TEST_CASE("completion signatures with exposed query", "[type_traits]") {
-    static_assert(
+    STATIC_REQUIRE(
         std::same_as<async::completion_signatures_of_t<queryable_sender1>,
                      async::completion_signatures<async::set_value_t(int),
                                                   async::set_error_t(float),
                                                   async::set_stopped_t()>>);
-    static_assert(
+    STATIC_REQUIRE(
         std::same_as<async::completion_signatures_of_t<queryable_sender2>,
                      async::completion_signatures<>>);
 }
 
 TEST_CASE("queryable completion signatures by channel", "[type_traits]") {
-    static_assert(
+    STATIC_REQUIRE(
         std::same_as<async::completion_signatures<async::set_value_t(int)>,
                      async::value_signatures_of_t<queryable_sender1>>);
-    static_assert(
+    STATIC_REQUIRE(
         std::same_as<async::completion_signatures<async::set_error_t(float)>,
                      async::error_signatures_of_t<queryable_sender1>>);
-    static_assert(
+    STATIC_REQUIRE(
         std::same_as<async::completion_signatures<async::set_stopped_t()>,
                      async::stopped_signatures_of_t<queryable_sender1>>);
 }
@@ -160,78 +160,79 @@ struct queryable_sender3 {
 
 TEST_CASE("queryable completion signatures dependent on environment",
           "[type_traits]") {
-    static_assert(
+    STATIC_REQUIRE(
         std::same_as<async::completion_signatures_of_t<queryable_sender3,
                                                        dependent_env<int>>,
                      async::completion_signatures<async::set_value_t(int)>>);
 }
 
 TEST_CASE("types by channel (exposed types)", "[type_traits]") {
-    static_assert(
+    STATIC_REQUIRE(
         std::same_as<variant<tuple<int>>,
                      async::value_types_of_t<typed_sender1, async::empty_env,
                                              tuple, variant>>);
-    static_assert(
+    STATIC_REQUIRE(
         std::same_as<variant<tuple<float>>,
                      async::error_types_of_t<typed_sender1, async::empty_env,
                                              tuple, variant>>);
-    static_assert(
+    STATIC_REQUIRE(
         std::same_as<variant<tuple<>>,
                      async::stopped_types_of_t<typed_sender1, async::empty_env,
                                                tuple, variant>>);
-    static_assert(async::sends_stopped<typed_sender1>);
+    STATIC_REQUIRE(async::sends_stopped<typed_sender1>);
 
-    static_assert(
+    STATIC_REQUIRE(
         std::same_as<variant<>,
                      async::value_types_of_t<typed_sender2, async::empty_env,
                                              tuple, variant>>);
-    static_assert(
+    STATIC_REQUIRE(
         std::same_as<variant<>,
                      async::error_types_of_t<typed_sender2, async::empty_env,
                                              tuple, variant>>);
-    static_assert(
+    STATIC_REQUIRE(
         std::same_as<variant<>,
                      async::stopped_types_of_t<typed_sender2, async::empty_env,
                                                tuple, variant>>);
-    static_assert(not async::sends_stopped<typed_sender2>);
+    STATIC_REQUIRE(not async::sends_stopped<typed_sender2>);
 }
 
 TEST_CASE("types by channel (queries with empty env)", "[type_traits]") {
-    static_assert(
+    STATIC_REQUIRE(
         std::same_as<variant<tuple<int>>,
                      async::value_types_of_t<
                          queryable_sender1, async::empty_env, tuple, variant>>);
-    static_assert(
+    STATIC_REQUIRE(
         std::same_as<variant<tuple<float>>,
                      async::error_types_of_t<
                          queryable_sender1, async::empty_env, tuple, variant>>);
-    static_assert(
+    STATIC_REQUIRE(
         std::same_as<variant<tuple<>>,
                      async::stopped_types_of_t<
                          queryable_sender1, async::empty_env, tuple, variant>>);
-    static_assert(async::sends_stopped<queryable_sender1>);
+    STATIC_REQUIRE(async::sends_stopped<queryable_sender1>);
 
-    static_assert(
+    STATIC_REQUIRE(
         std::same_as<variant<>,
                      async::value_types_of_t<
                          queryable_sender2, async::empty_env, tuple, variant>>);
-    static_assert(
+    STATIC_REQUIRE(
         std::same_as<variant<>,
                      async::error_types_of_t<
                          queryable_sender2, async::empty_env, tuple, variant>>);
-    static_assert(
+    STATIC_REQUIRE(
         std::same_as<variant<>,
                      async::stopped_types_of_t<
                          queryable_sender2, async::empty_env, tuple, variant>>);
-    static_assert(not async::sends_stopped<queryable_sender2>);
+    STATIC_REQUIRE(not async::sends_stopped<queryable_sender2>);
 }
 
 TEST_CASE("types by channel (queries with dependent env)", "[type_traits]") {
-    static_assert(std::same_as<
-                  variant<tuple<int>>,
-                  async::value_types_of_t<queryable_sender3, dependent_env<int>,
-                                          tuple, variant>>);
-    static_assert(
+    STATIC_REQUIRE(
+        std::same_as<
+            variant<tuple<int>>,
+            async::value_types_of_t<queryable_sender3, dependent_env<int>,
+                                    tuple, variant>>);
+    STATIC_REQUIRE(
         std::same_as<
             variant<tuple<float>>,
             async::value_types_of_t<queryable_sender3, dependent_env<float>,
@@ -239,20 +240,20 @@ TEST_CASE("types by channel (queries with dependent env)", "[type_traits]") {
 }
 
 TEST_CASE("types by channel (non-variadic templates)", "[type_traits]") {
-    static_assert(
+    STATIC_REQUIRE(
         std::same_as<tuple<int>,
                      async::value_types_of_t<typed_sender1, async::empty_env,
                                              tuple, std::type_identity_t>>);
-    static_assert(
+    STATIC_REQUIRE(
         std::same_as<tuple<float>,
                      async::error_types_of_t<typed_sender1, async::empty_env,
                                              tuple, std::type_identity_t>>);
-    static_assert(
+    STATIC_REQUIRE(
         std::same_as<variant<unary_tuple<int>>,
                      async::value_types_of_t<typed_sender1, async::empty_env,
                                              unary_tuple, variant>>);
 
-    static_assert(
+    STATIC_REQUIRE(
         std::same_as<int, async::value_types_of_t<
                               typed_sender1, async::empty_env,
                               std::type_identity_t, std::type_identity_t>>);
@@ -268,9 +269,9 @@ concept single_sender = requires {
 } // namespace
 
 TEST_CASE("non-variadic templates in concept", "[type_traits]") {
-    static_assert(single_sender<typed_sender1, async::set_value_t>);
-    static_assert(single_sender<typed_sender1, async::set_error_t>);
-    static_assert(not single_sender<typed_sender2, async::set_value_t>);
+    STATIC_REQUIRE(single_sender<typed_sender1, async::set_value_t>);
+    STATIC_REQUIRE(single_sender<typed_sender1, async::set_error_t>);
+    STATIC_REQUIRE(not single_sender<typed_sender2, async::set_value_t>);
 }
 
 TEST_CASE("channel holder (values)", "[type_traits]") {
@@ -312,7 +313,7 @@ TEST_CASE("transform completion signatures (values)", "[type_traits]") {
         sigs, async::completion_signatures<>,
         set_lvalue<async::set_value_t>::template fn>;
 
-    static_assert(
+    STATIC_REQUIRE(
         std::is_same_v<
             async::completion_signatures<async::set_value_t(int &),
                                          async::set_value_t(float &, bool &)>,
@@ -326,10 +327,10 @@ TEST_CASE("transform completion signatures (errors)", "[type_traits]") {
         sigs, async::completion_signatures<>, async::detail::default_set_value,
         set_lvalue<async::set_error_t>::template fn>;
 
-    static_assert(std::is_same_v<
-                  async::completion_signatures<async::set_error_t(int &),
-                                               async::set_error_t(float &)>,
-                  transformed_sigs>);
+    STATIC_REQUIRE(std::is_same_v<
+                   async::completion_signatures<async::set_error_t(int &),
+                                                async::set_error_t(float &)>,
+                   transformed_sigs>);
 }
 
 TEST_CASE("transform completion signatures (stopped)", "[type_traits]") {
@@ -339,14 +340,14 @@ TEST_CASE("transform completion signatures (stopped)", "[type_traits]") {
             sigs, async::completion_signatures<>,
             async::detail::default_set_value, async::detail::default_set_error,
             async::completion_signatures<async::set_value_t()>>;
-        static_assert(
+        STATIC_REQUIRE(
             std::is_same_v<async::completion_signatures<async::set_value_t()>,
                            transformed_sigs>);
     }
     {
         using sigs = async::completion_signatures<>;
         using transformed_sigs = async::transform_completion_signatures<sigs>;
-        static_assert(
+        STATIC_REQUIRE(
             std::is_same_v<async::completion_signatures<>, transformed_sigs>);
     }
 }

--- a/test/upon_error.cpp
+++ b/test/upon_error.cpp
@@ -1,16 +1,13 @@
 #include "detail/common.hpp"
+#include "detail/debug_handler.hpp"
 
 #include <async/concepts.hpp>
 #include <async/connect.hpp>
-#include <async/debug.hpp>
 #include <async/just.hpp>
 #include <async/schedulers/inline_scheduler.hpp>
 #include <async/then.hpp>
 
-#include <stdx/ct_format.hpp>
-
 #include <catch2/catch_test_macros.hpp>
-#include <fmt/format.h>
 
 #include <concepts>
 #include <string>
@@ -31,7 +28,7 @@ TEST_CASE("upon_error advertises what it sends", "[upon_error]") {
     auto s = async::just_error(42);
     [[maybe_unused]] auto n =
         async::upon_error(s, [](auto i) { return i + 17; });
-    static_assert(async::sender_of<decltype(n), async::set_value_t(int)>);
+    STATIC_REQUIRE(async::sender_of<decltype(n), async::set_value_t(int)>);
 }
 
 TEST_CASE("upon_error is pipeable", "[upon_error]") {
@@ -49,7 +46,7 @@ TEST_CASE("upon_error can send nothing", "[upon_error]") {
 
     auto s = async::just_error(42);
     auto n = async::upon_error(s, [](auto) {});
-    static_assert(async::sender_of<decltype(n), async::set_value_t()>);
+    STATIC_REQUIRE(async::sender_of<decltype(n), async::set_value_t()>);
     auto op = async::connect(n, receiver{[&] { value = 42; }});
     async::start(op);
     CHECK(value == 42);
@@ -70,7 +67,7 @@ TEST_CASE("single-shot sender", "[upon_error]") {
     [[maybe_unused]] auto n = async::inline_scheduler<>::schedule<
                                   async::inline_scheduler<>::singleshot>() |
                               async::upon_error([] {});
-    static_assert(async::singleshot_sender<decltype(n), universal_receiver>);
+    STATIC_REQUIRE(async::singleshot_sender<decltype(n), universal_receiver>);
 }
 
 TEST_CASE("upon_error propagates success", "[upon_error]") {
@@ -79,7 +76,7 @@ TEST_CASE("upon_error propagates success", "[upon_error]") {
 
     auto s =
         async::just(42) | async::upon_error([&] { upon_error_called = true; });
-    static_assert(
+    STATIC_REQUIRE(
         std::same_as<async::completion_signatures_of_t<decltype(s)>,
                      async::completion_signatures<async::set_value_t(int)>>);
     auto op = async::connect(s, receiver{[&](auto i) { value = i; }});
@@ -94,7 +91,7 @@ TEST_CASE("upon_error propagates stopped", "[upon_error]") {
 
     auto s = async::just_stopped() |
              async::upon_error([&] { upon_error_called = true; });
-    static_assert(
+    STATIC_REQUIRE(
         std::same_as<async::completion_signatures_of_t<decltype(s)>,
                      async::completion_signatures<async::set_stopped_t()>>);
     auto op = async::connect(s, stopped_receiver{[&] { value = 42; }});
@@ -103,23 +100,9 @@ TEST_CASE("upon_error propagates stopped", "[upon_error]") {
     CHECK(not upon_error_called);
 }
 
-namespace {
-std::vector<std::string> debug_events{};
-
-struct debug_handler {
-    template <stdx::ct_string C, stdx::ct_string S, typename Ctx>
-    constexpr auto signal(auto &&...) {
-        using namespace stdx::literals;
-        if constexpr (std::is_same_v<async::debug::tag_of<Ctx>,
-                                     async::upon_error_t>) {
-            debug_events.push_back(
-                fmt::format("{} {} {}", C, async::debug::name_of<Ctx>, S));
-        }
-    }
-};
-} // namespace
-
-template <> inline auto async::injected_debug_handler<> = debug_handler{};
+template <>
+inline auto async::injected_debug_handler<> =
+    debug_handler<async::upon_error_t>{};
 
 TEST_CASE("upon_error can be debugged with a string", "[upon_error]") {
     using namespace std::string_literals;

--- a/test/upon_stopped.cpp
+++ b/test/upon_stopped.cpp
@@ -1,19 +1,17 @@
 #include "detail/common.hpp"
+#include "detail/debug_handler.hpp"
 
 #include <async/concepts.hpp>
 #include <async/connect.hpp>
-#include <async/debug.hpp>
 #include <async/just.hpp>
 #include <async/schedulers/inline_scheduler.hpp>
 #include <async/then.hpp>
 
-#include <stdx/ct_format.hpp>
-
 #include <catch2/catch_test_macros.hpp>
-#include <fmt/format.h>
 
 #include <concepts>
 #include <string>
+#include <type_traits>
 #include <vector>
 
 TEST_CASE("upon_stopped", "[upon_stopped]") {
@@ -29,7 +27,7 @@ TEST_CASE("upon_stopped", "[upon_stopped]") {
 TEST_CASE("upon_stopped advertises what it sends", "[upon_stopped]") {
     auto s = async::just_stopped();
     [[maybe_unused]] auto n = async::upon_stopped(s, [] { return 42; });
-    static_assert(async::sender_of<decltype(n), async::set_value_t(int)>);
+    STATIC_REQUIRE(async::sender_of<decltype(n), async::set_value_t(int)>);
 }
 
 TEST_CASE("upon_stopped is pipeable", "[upon_stopped]") {
@@ -46,7 +44,7 @@ TEST_CASE("single-shot sender", "[upon_stopped]") {
     [[maybe_unused]] auto n = async::inline_scheduler<>::schedule<
                                   async::inline_scheduler<>::singleshot>() |
                               async::upon_stopped([] {});
-    static_assert(async::singleshot_sender<decltype(n), universal_receiver>);
+    STATIC_REQUIRE(async::singleshot_sender<decltype(n), universal_receiver>);
 }
 
 TEST_CASE("upon_stopped propagates success", "[upon_stopped]") {
@@ -55,7 +53,7 @@ TEST_CASE("upon_stopped propagates success", "[upon_stopped]") {
 
     auto s = async::just(42) |
              async::upon_stopped([&] { upon_stopped_called = true; });
-    static_assert(
+    STATIC_REQUIRE(
         std::same_as<async::completion_signatures_of_t<decltype(s)>,
                      async::completion_signatures<async::set_value_t(int)>>);
     auto op = async::connect(s, receiver{[&](auto i) { value = i; }});
@@ -70,7 +68,7 @@ TEST_CASE("upon_stopped propagates errors", "[upon_stopped]") {
 
     auto s = async::just_error(42) |
              async::upon_stopped([&] { upon_stopped_called = true; });
-    static_assert(
+    STATIC_REQUIRE(
         std::same_as<async::completion_signatures_of_t<decltype(s)>,
                      async::completion_signatures<async::set_error_t(int)>>);
     auto op = async::connect(s, error_receiver{[&](auto i) { value = i; }});
@@ -79,23 +77,9 @@ TEST_CASE("upon_stopped propagates errors", "[upon_stopped]") {
     CHECK(not upon_stopped_called);
 }
 
-namespace {
-std::vector<std::string> debug_events{};
-
-struct debug_handler {
-    template <stdx::ct_string C, stdx::ct_string S, typename Ctx>
-    constexpr auto signal(auto &&...) {
-        using namespace stdx::literals;
-        if constexpr (std::is_same_v<async::debug::tag_of<Ctx>,
-                                     async::upon_stopped_t>) {
-            debug_events.push_back(
-                fmt::format("{} {} {}", C, async::debug::name_of<Ctx>, S));
-        }
-    }
-};
-} // namespace
-
-template <> inline auto async::injected_debug_handler<> = debug_handler{};
+template <>
+inline auto async::injected_debug_handler<> =
+    debug_handler<async::upon_stopped_t>{};
 
 TEST_CASE("upon_stopped can be debugged with a string", "[upon_stopped]") {
     using namespace std::string_literals;

--- a/test/variant_sender.cpp
+++ b/test/variant_sender.cpp
@@ -45,7 +45,7 @@ TEST_CASE("match with non-moveable type", "[variant_sender]") {
     auto const m = async::match(i == 1) >> [] { return non_moveable{}; };
     CHECK(m.test());
     [[maybe_unused]] auto nm = m.invoke();
-    static_assert(std::is_same_v<decltype(nm), non_moveable>);
+    STATIC_REQUIRE(std::is_same_v<decltype(nm), non_moveable>);
 }
 
 TEST_CASE("matcher returns correct variant", "[variant_sender]") {
@@ -68,7 +68,7 @@ TEST_CASE("matcher with non-moveable type", "[variant_sender]") {
                        async::otherwise >> [](auto) { return 3.14f; }};
     auto const v1 = m.run(0);
     REQUIRE(v1.index() == 0);
-    static_assert(
+    STATIC_REQUIRE(
         std::is_same_v<decltype(std::get<0>(v1)), non_moveable const &>);
 
     auto const v2 = m.run(1);
@@ -95,7 +95,7 @@ TEST_CASE("binary select with non-moveable type", "[variant_sender]") {
     auto const v1 = async::select(
         i == 0, [] { return non_moveable{}; }, [] { return 3.14f; });
     REQUIRE(v1.index() == 0);
-    static_assert(
+    STATIC_REQUIRE(
         std::is_same_v<decltype(std::get<0>(v1)), non_moveable const &>);
 
     auto const j = 1;
@@ -130,7 +130,7 @@ TEST_CASE("make_variant_sender (general choice)", "[variant_sender]") {
         async::otherwise >> [](auto, auto) { return async::just_error(17); }, 1,
         2);
 
-    static_assert(
+    STATIC_REQUIRE(
         std::is_same_v<async::completion_signatures_of_t<decltype(s)>,
                        async::completion_signatures<async::set_value_t(int),
                                                     async::set_error_t(int)>>);
@@ -146,7 +146,7 @@ TEST_CASE("make_optional_sender (unary choice)", "[variant_sender]") {
     auto const s =
         async::make_optional_sender(i == 0, [] { return async::just(42); });
 
-    static_assert(
+    STATIC_REQUIRE(
         std::is_same_v<async::completion_signatures_of_t<decltype(s)>,
                        async::completion_signatures<async::set_value_t(int),
                                                     async::set_value_t()>>);
@@ -168,7 +168,7 @@ TEST_CASE("make_variant_sender (simplified binary choice)",
         i == 0, [] { return async::just(42); },
         [] { return async::just_error(17); });
 
-    static_assert(
+    STATIC_REQUIRE(
         std::is_same_v<async::completion_signatures_of_t<decltype(s)>,
                        async::completion_signatures<async::set_value_t(int),
                                                     async::set_error_t(int)>>);
@@ -184,7 +184,7 @@ TEST_CASE("variant_sender may complete synchronously", "[variant_sender]") {
     [[maybe_unused]] auto const s = async::make_variant_sender(
         i == 0, [] { return async::just(42); },
         [] { return async::just_error(17); });
-    static_assert(async::synchronous<decltype(s)>);
+    STATIC_REQUIRE(async::synchronous<decltype(s)>);
 }
 
 TEST_CASE("variant_sender may not complete synchronously", "[variant_sender]") {
@@ -192,7 +192,7 @@ TEST_CASE("variant_sender may not complete synchronously", "[variant_sender]") {
     [[maybe_unused]] auto const s = async::make_variant_sender(
         i == 0, [] { return async::just(42); },
         [] { return async::thread_scheduler{}.schedule(); });
-    static_assert(not async::synchronous<decltype(s)>);
+    STATIC_REQUIRE(not async::synchronous<decltype(s)>);
 }
 
 TEST_CASE("variant_sender op state may be synchronous", "[variant_sender]") {
@@ -201,7 +201,7 @@ TEST_CASE("variant_sender op state may be synchronous", "[variant_sender]") {
         i == 0, [] { return async::just(42); },
         [] { return async::just_error(17); });
     [[maybe_unused]] auto op = async::connect(s, receiver{[] {}});
-    static_assert(async::synchronous<decltype(op)>);
+    STATIC_REQUIRE(async::synchronous<decltype(op)>);
 }
 
 TEST_CASE("variant_sender op state may not be synchronous",
@@ -211,5 +211,5 @@ TEST_CASE("variant_sender op state may not be synchronous",
         i == 0, [] { return async::just(42); },
         [] { return async::thread_scheduler{}.schedule(); });
     [[maybe_unused]] auto op = async::connect(s, receiver{[] {}});
-    static_assert(not async::synchronous<decltype(op)>);
+    STATIC_REQUIRE(not async::synchronous<decltype(op)>);
 }

--- a/test/when_any.cpp
+++ b/test/when_any.cpp
@@ -52,15 +52,15 @@ TEST_CASE("when_any advertises what it sends", "[when_any]") {
     auto s1 = async::just(42);
     auto s2 = async::just(17);
     [[maybe_unused]] auto w = async::when_any(s1, s2);
-    static_assert(async::sender_of<decltype(w), async::set_value_t(int)>);
-    static_assert(not async::sender_of<decltype(w), async::set_error_t()>);
+    STATIC_REQUIRE(async::sender_of<decltype(w), async::set_value_t(int)>);
+    STATIC_REQUIRE(not async::sender_of<decltype(w), async::set_error_t()>);
 }
 
 TEST_CASE("when_any advertises errors", "[when_any]") {
     auto s1 = async::just(42);
     auto s2 = async::just_error(17);
     [[maybe_unused]] auto w = async::when_any(s1, s2);
-    static_assert(async::sender_of<decltype(w), async::set_error_t(int)>);
+    STATIC_REQUIRE(async::sender_of<decltype(w), async::set_error_t(int)>);
 }
 
 TEST_CASE("complete with first success", "[when_any]") {
@@ -123,7 +123,7 @@ TEST_CASE("move-only value", "[when_any]") {
     int value{};
     auto s = async::just(move_only{42});
     auto w = async::when_any(std::move(s));
-    static_assert(async::singleshot_sender<decltype(w), universal_receiver>);
+    STATIC_REQUIRE(async::singleshot_sender<decltype(w), universal_receiver>);
     auto op = async::connect(
         std::move(w), receiver{[&](move_only<int> mo) { value = mo.value; }});
     async::start(op);
@@ -134,7 +134,7 @@ TEST_CASE("copy sender", "[when_any]") {
     int value{};
     auto const s = async::just(42);
     auto w = async::when_any(s);
-    static_assert(async::multishot_sender<decltype(w), universal_receiver>);
+    STATIC_REQUIRE(async::multishot_sender<decltype(w), universal_receiver>);
     auto op = async::connect(w, receiver{[&](auto i) { value = i; }});
     async::start(op);
     CHECK(value == 42);
@@ -144,7 +144,7 @@ TEST_CASE("move sender", "[when_any]") {
     int value{};
     auto s = async::just(42);
     auto w = async::when_any(s);
-    static_assert(async::multishot_sender<decltype(w), universal_receiver>);
+    STATIC_REQUIRE(async::multishot_sender<decltype(w), universal_receiver>);
     auto op =
         async::connect(std::move(w), receiver{[&](auto i) { value = i; }});
     async::start(op);
@@ -263,11 +263,11 @@ TEST_CASE("stop_when is adaptor-pipeable", "[when_any]") {
 
 TEST_CASE("when_any with zero args never completes", "[when_any]") {
     [[maybe_unused]] auto w = async::when_any();
-    static_assert(std::same_as<async::completion_signatures_of_t<decltype(w)>,
-                               async::completion_signatures<>>);
+    STATIC_REQUIRE(std::same_as<async::completion_signatures_of_t<decltype(w)>,
+                                async::completion_signatures<>>);
     auto r = receiver{[] {}};
     auto op = async::connect(w, r);
-    static_assert(
+    STATIC_REQUIRE(
         std::is_same_v<decltype(op),
                        async::_when_any::op_state<
                            "when_any", async::_when_any::first_noncancelled,
@@ -279,7 +279,7 @@ TEST_CASE("when_any with zero args can be stopped (before start)",
     int value{};
     [[maybe_unused]] auto w = async::when_any();
     auto r = stoppable_receiver{[&] { value = 42; }};
-    static_assert(
+    STATIC_REQUIRE(
         std::same_as<async::completion_signatures_of_t<
                          decltype(w), async::env_of_t<decltype(r)>>,
                      async::completion_signatures<async::set_stopped_t()>>);
@@ -295,7 +295,7 @@ TEST_CASE("when_any with zero args can be stopped (after start)",
     int value{};
     [[maybe_unused]] auto w = async::when_any();
     auto r = stoppable_receiver{[&] { value = 42; }};
-    static_assert(
+    STATIC_REQUIRE(
         std::same_as<async::completion_signatures_of_t<
                          decltype(w), async::env_of_t<decltype(r)>>,
                      async::completion_signatures<async::set_stopped_t()>>);
@@ -316,11 +316,11 @@ TEST_CASE("when_any nests", "[when_any]") {
 TEST_CASE("when_any with one arg is a no-op", "[when_all]") {
     auto s = async::just(42);
     [[maybe_unused]] auto w = async::when_any(s);
-    static_assert(std::same_as<decltype(s), decltype(w)>);
+    STATIC_REQUIRE(std::same_as<decltype(s), decltype(w)>);
 }
 
 TEST_CASE("nullary when_any has a stack allocator", "[when_any]") {
-    static_assert(
+    STATIC_REQUIRE(
         std::is_same_v<
             async::allocator_of_t<async::env_of_t<decltype(async::when_any())>>,
             async::stack_allocator>);
@@ -329,7 +329,7 @@ TEST_CASE("nullary when_any has a stack allocator", "[when_any]") {
 TEST_CASE("nullary when_any op_state is synchronous", "[when_any]") {
     [[maybe_unused]] auto op =
         async::connect(async::when_any(), receiver{[] {}});
-    static_assert(async::synchronous<decltype(op)>);
+    STATIC_REQUIRE(async::synchronous<decltype(op)>);
 }
 
 TEST_CASE("normal, (internally) stoppable op_state", "[when_any]") {
@@ -342,7 +342,7 @@ TEST_CASE("normal, (internally) stoppable op_state", "[when_any]") {
         []<stdx::ct_string Name, typename P, typename R, typename... Ss>(
             async::_when_any::op_state<Name, P, R, Ss...> const &) {};
 
-    static_assert(requires { test_op_state(op); });
+    STATIC_REQUIRE(requires { test_op_state(op); });
 }
 
 TEST_CASE("optimized op_state for unstoppable", "[when_any]") {
@@ -356,7 +356,7 @@ TEST_CASE("optimized op_state for unstoppable", "[when_any]") {
         []<stdx::ct_string Name, typename P, typename R, typename... Ss>(
             async::_when_any::nostop_op_state<Name, P, R, Ss...> const &) {};
 
-    static_assert(requires { test_op_state(op); });
+    STATIC_REQUIRE(requires { test_op_state(op); });
 }
 
 TEST_CASE("when_any receiver environment is well-formed for synchronous ops",


### PR DESCRIPTION
Problem:
- Using static_assert does not report the check in Catch2.

Solution:
- Use STATIC_REQUIRE so that the check is reported.