### PR TITLE
:books: :bug: Fix broken link to `get_scheduler`

### DIFF
--- a/docs/schedulers.adoc
+++ b/docs/schedulers.adoc
@@ -112,7 +112,7 @@ auto value = async::get_scheduler()
            | async::sync_wait();
 ----
 
-This code uses xref:sender_factories.adoc#_read[`get_scheduler`] to read the
+This code uses xref:sender_factories.adoc#_read_env[`get_scheduler`] to read the
 scheduler provided by `sync_wait`. That `runloop_scheduler` is then used to
 schedule work.
 


### PR DESCRIPTION
Problem:
- The link to `get_scheduler` in the `runloop_scheduler` section is broken. It was broken a while ago by the rename of `read` to `read_env`.

Solution:
- Fix the link.