### PR TITLE
:bug: Fix calculation of `let_*` completion signatures

### DIFF
--- a/include/async/let.hpp
+++ b/include/async/let.hpp
@@ -223,7 +223,7 @@ struct sender {
     using is_multishot_leftover_sender = stdx::conditional_t<
         boost::mp11::mp_empty<
             boost::mp11::mp_second<raw_completions<env_of_t<R>>>>::value,
-        std::true_type, std::bool_constant<multishot_sender<S, R>>>;
+        std::true_type, std::bool_constant<multishot_sender<S>>>;
 
     template <typename R> struct is_multishot_sender {
         template <typename T>


### PR DESCRIPTION
Problem:
- When testing for a multishot sender, `let_*` erroneously tries to test the downstream receiver against the upstream sender. This provokes errors when the downstream receiver can't handle what the upstream sender sends -- because it doesn't need to, when the dependent sender(s) sends something else.

Solution:
- Remove the receiver argument to the offending `multishot_sender<>` call. The `universal_receiver` will take care of it correctly.