### PR TITLE
:art: Retarget `sync_wait` to be `sync_wait_static`

### DIFF
--- a/docs/schedulers.adoc
+++ b/docs/schedulers.adoc
@@ -101,7 +101,7 @@ Found in the header: `async/schedulers/runloop_scheduler.hpp`
 
 The `runloop_scheduler` adds any work to a queue that is executed in order. It
 is used as a completion scheduler inside
-xref:sender_consumers.adoc#_sync_wait[`sync_wait`].
+xref:sender_consumers.adoc#_sync_wait_dynamic[`sync_wait_dynamic`].
 
 [source,cpp]
 ----
@@ -109,11 +109,11 @@ auto value = async::read_env(async::get_scheduler)
            | async::let_value([&](auto sched) {
                  return async::start_on(sched, async::just(42));
              })
-           | async::sync_wait();
+           | async::sync_wait_dynamic();
 ----
 
 This code uses xref:sender_factories.adoc#_read_env[`read_env`] to read the
-scheduler provided by `sync_wait`. That `runloop_scheduler` is then used to
+scheduler provided by `sync_wait_dynamic`. That `runloop_scheduler` is then used to
 schedule work.
 
 === `thread_scheduler`

--- a/docs/sender_consumers.adoc
+++ b/docs/sender_consumers.adoc
@@ -107,9 +107,14 @@ auto stop_requested = async::stop_detached<Name>(); // true if a stop was reques
 
 === `sync_wait`
 
+`sync_wait` is synonymous with
+xref:sender_consumers.adoc#_sync_wait_static[`sync_wait_static`].
+
+=== `sync_wait_dynamic`
+
 Found in the header: `async/sync_wait.hpp`
 
-`sync_wait` takes a sender and:
+`sync_wait_dynamic` takes a sender and:
 
 . connects and starts it
 . blocks waiting for it to complete
@@ -118,15 +123,33 @@ Found in the header: `async/sync_wait.hpp`
 [source,cpp]
 ----
 auto sndr = async::just(42);
-auto [i] = async::sync_wait(sndr).value();
+auto [i] = async::sync_wait_dynamic(sndr).value();
 // i is now 42
 ----
 
-As with `start_detached`, an extra xref:environments.adoc#_environments[environment] may be given to
-`sync_wait` in order to control sender behaviour:
+As with xref:sender_consumers.adoc#_start_detached[`start_detached`], an extra xref:environments.adoc#_environments[environment] may be given to
+`sync_wait_dynamic` in order to control sender behaviour:
 
 [source,cpp]
 ----
-auto result = async::sync_wait(
+auto result = async::sync_wait_dynamic(
     s, async::prop{async::get_custom_property_t{}, custom_property{}}));
 ----
+
+`sync_wait_dynamic` provides a xref:schedulers.adoc#_runloop_scheduler[`runloop_scheduler`] that can be read from the
+environment, so that a sender may append further work:
+[source,cpp]
+----
+auto s = async::get_scheduler()
+       | async::let_value([&](auto sched) {
+           return async::start_on(sched, async::just(42));
+       });
+auto result = s | async::sync_wait_dynamic();
+----
+
+=== `sync_wait_static`
+
+Found in the header: `async/sync_wait.hpp`
+
+`sync_wait_static` behaves like `sync_wait_dynamic`, except that it does not
+provide a xref:schedulers.adoc#_runloop_scheduler[`runloop_scheduler`], so further work cannot be appended.

--- a/docs/synopsis.adoc
+++ b/docs/synopsis.adoc
@@ -114,7 +114,7 @@ by `let_error.hpp`, `let_stopped.hpp`, and `let_value.hpp`
 * `requeue_policy::deferred` - the default policy used with `priority_task_manager::service_tasks()` and `triggers<"name">.run`
 
 ==== https://github.com/intel/cpp-baremetal-senders-and-receivers/blob/main/include/async/schedulers/runloop_scheduler.hpp[schedulers/runloop_scheduler.hpp]
-* `runloop_scheduler` - a xref:schedulers.adoc#_runloop_scheduler[scheduler] that allows further work to be added during execution, and is used by xref:sender_consumers.adoc#_sync_wait[`sync_wait`]
+* `runloop_scheduler` - a xref:schedulers.adoc#_runloop_scheduler[scheduler] that allows further work to be added during execution, and is used by xref:sender_consumers.adoc#_sync_wait_dynamic[`sync_wait_dynamic`]
 
 ==== https://github.com/intel/cpp-baremetal-senders-and-receivers/blob/main/include/async/schedulers/task.hpp[schedulers/task.hpp]
 An internal header that contains no public-facing identifiers. `task.hpp`
@@ -189,6 +189,8 @@ xref:schedulers.adoc#_time_scheduler[time_scheduler].
 
 ==== https://github.com/intel/cpp-baremetal-senders-and-receivers/blob/main/include/async/sync_wait.hpp[sync_wait.hpp]
 * `sync_wait` - a xref:sender_consumers.adoc#_sync_wait[sender consumer] that starts a sender and waits for it to complete
+* `sync_wait_dynamic` - a xref:sender_consumers.adoc#_sync_wait[sender consumer] that starts a sender and waits for it to complete, allowing further work to be appended
+* `sync_wait_static` - a xref:sender_consumers.adoc#_sync_wait[sender consumer] that starts a sender and waits for it to complete
 
 ==== https://github.com/intel/cpp-baremetal-senders-and-receivers/blob/main/include/async/then.hpp[then.hpp]
 * `then` - a xref:sender_adaptors.adoc#_then[sender adaptor] that transforms what a sender sends on the value channel
@@ -293,6 +295,8 @@ contains traits and metaprogramming constructs used by many senders.
 * `stop_token_of_t` - https://github.com/intel/cpp-baremetal-senders-and-receivers/blob/main/include/async/schedulers/stop_token.hpp[`#include <async/stop_token.hpp>`]
 * xref:sender_adaptors.adoc#_when_any[`stop_when`] - https://github.com/intel/cpp-baremetal-senders-and-receivers/blob/main/include/async/schedulers/when_any.hpp[`#include <async/when_any.hpp>`]
 * xref:sender_consumers.adoc#_sync_wait[`sync_wait`] - https://github.com/intel/cpp-baremetal-senders-and-receivers/blob/main/include/async/schedulers/sync_wait.hpp[`#include <async/sync_wait.hpp>`]
+* xref:sender_consumers.adoc#_sync_wait_dynamic[`sync_wait_dynamic`] - https://github.com/intel/cpp-baremetal-senders-and-receivers/blob/main/include/async/schedulers/sync_wait.hpp[`#include <async/sync_wait.hpp>`]
+* xref:sender_consumers.adoc#_sync_wait_static[`sync_wait_static`] - https://github.com/intel/cpp-baremetal-senders-and-receivers/blob/main/include/async/schedulers/sync_wait.hpp[`#include <async/sync_wait.hpp>`]
 * `task_mgr::is_idle()` - https://github.com/intel/cpp-baremetal-senders-and-receivers/blob/main/include/async/schedulers/task_manager_interface.hpp[`#include <async/schedulers/task_manager_interface.hpp>`]
 * `task_mgr::service_tasks<P>()` - https://github.com/intel/cpp-baremetal-senders-and-receivers/blob/main/include/async/schedulers/task_manager_interface.hpp[`#include <async/schedulers/task_manager_interface.hpp>`]
 * xref:sender_adaptors.adoc#_then[`then`] - https://github.com/intel/cpp-baremetal-senders-and-receivers/blob/main/include/async/schedulers/then.hpp[`#include <async/then.hpp>`]

--- a/include/async/sync_wait.hpp
+++ b/include/async/sync_wait.hpp
@@ -22,30 +22,74 @@
 namespace async {
 namespace _sync_wait {
 
-template <typename V, typename RL, typename Env> struct receiver {
+template <typename V, typename Env> struct receiver {
     using is_receiver = void;
 
     // NOLINTBEGIN(cppcoreguidelines-avoid-const-or-ref-data-members)
     V &values;
-    RL &loop;
     [[no_unique_address]] Env env;
     // NOLINTEND(cppcoreguidelines-avoid-const-or-ref-data-members)
 
     [[nodiscard]] constexpr auto query(get_env_t) const noexcept { return env; }
 
+    constexpr auto signal_start() const {
+        debug_signal<"start", debug::erased_context_for<receiver>>(env);
+    }
+
     template <typename... Args>
     constexpr auto set_value(Args &&...args) const && -> void {
         debug_signal<"set_value", debug::erased_context_for<receiver>>(env);
         values.emplace(stdx::make_tuple(std::forward<Args>(args)...));
-        loop.finish();
     }
     constexpr auto set_error(auto &&...) const && -> void {
         debug_signal<"set_error", debug::erased_context_for<receiver>>(env);
-        loop.finish();
     }
     constexpr auto set_stopped() const && -> void {
         debug_signal<"set_stopped", debug::erased_context_for<receiver>>(env);
+    }
+};
+
+template <typename V, typename Env, typename RL>
+struct dynamic_receiver : receiver<V, Env> {
+    // NOLINTBEGIN(cppcoreguidelines-avoid-const-or-ref-data-members)
+    RL &loop;
+    // NOLINTEND(cppcoreguidelines-avoid-const-or-ref-data-members)
+
+    template <typename... Args>
+    constexpr auto set_value(Args &&...args) const && -> void {
+        static_cast<receiver<V, Env> const &&>(*this).set_value(
+            std::forward<Args>(args)...);
         loop.finish();
+    }
+    constexpr auto set_error(auto &&...) const && -> void {
+        static_cast<receiver<V, Env> const &&>(*this).set_error();
+        loop.finish();
+    }
+    constexpr auto set_stopped() const && -> void {
+        static_cast<receiver<V, Env> const &&>(*this).set_stopped();
+        loop.finish();
+    }
+};
+
+template <typename V, typename Env, typename Uniq>
+struct static_receiver : receiver<V, Env> {
+    // NOLINTBEGIN(cppcoreguidelines-avoid-const-or-ref-data-members)
+    async::detail::synchronizer<Uniq, 0> &sync;
+    // NOLINTEND(cppcoreguidelines-avoid-const-or-ref-data-members)
+
+    template <typename... Args>
+    constexpr auto set_value(Args &&...args) const && -> void {
+        static_cast<receiver<V, Env> const &&>(*this).set_value(
+            std::forward<Args>(args)...);
+        sync.notify();
+    }
+    constexpr auto set_error(auto &&...) const && -> void {
+        static_cast<receiver<V, Env> const &&>(*this).set_error();
+        sync.notify();
+    }
+    constexpr auto set_stopped() const && -> void {
+        static_cast<receiver<V, Env> const &&>(*this).set_stopped();
+        sync.notify();
     }
 };
 
@@ -57,37 +101,119 @@ template <typename E, sender_in<E> S>
 using sync_wait_type = value_types_of_t<S, E, decayed_tuple, std::optional>;
 } // namespace detail
 
-template <typename Uniq, sender S, typename Env> auto wait(S &&s, Env &&e) {
-    run_loop<Uniq> rl{};
-    auto sched = rl.get_scheduler();
-    auto new_env = env{prop{get_scheduler_t{}, sched}, std::forward<Env>(e)};
+struct dynamic_t;
+struct static_t;
 
-    using E = decltype(new_env);
-    using V = detail::sync_wait_type<E, S>;
-    V values{};
-    auto r = receiver<V, decltype(rl), E>{values, rl, std::move(new_env)};
-
-    auto op_state = connect(std::forward<S>(s), r);
-    debug_signal<"start", debug::erased_context_for<decltype(r)>>(r.env);
-    start(op_state);
-    rl.run();
-    return values;
-}
-
-template <typename Uniq, typename Env> struct pipeable {
+template <typename Env> struct pipeable_base {
     [[no_unique_address]] Env e;
+};
 
-  private:
+template <typename Uniq, typename Env, typename Flavor> class pipeable;
+
+template <typename Uniq, typename Env>
+class pipeable<Uniq, Env, static_t> : public pipeable_base<Env> {
+    template <sender S> static auto wait(S &&s, Env const &e) {
+        static_assert(sender_in<S, Env>,
+                      "Sender given to sync_wait_static cannot run with that "
+                      "environment: did you mean to use sync_wait_dynamic?");
+        async::detail::synchronizer<Uniq, 0> sync{};
+        using V = detail::sync_wait_type<Env, S>;
+        V values{};
+        auto r = static_receiver<V, Env, Uniq>{values, e, sync};
+
+        auto op_state = connect(std::forward<S>(s), r);
+        r.signal_start();
+        start(op_state);
+        sync.wait();
+        return values;
+    }
+
     template <async::sender S, stdx::same_as_unqualified<pipeable> Self>
     [[nodiscard]] friend auto operator|(S &&s, Self &&self) {
-        return wait<Uniq>(std::forward<S>(s), std::forward<Self>(self).e);
+        return wait(std::forward<S>(s), std::forward<Self>(self).e);
+    }
+};
+
+template <typename Uniq, typename Env>
+class pipeable<Uniq, Env, dynamic_t> : public pipeable_base<Env> {
+    template <sender S> static auto wait(S &&s, Env const &e) {
+        run_loop<Uniq> rl{};
+        auto sched = rl.get_scheduler();
+        auto new_env = env{prop{get_scheduler_t{}, sched}, e};
+        using E = decltype(new_env);
+        using V = detail::sync_wait_type<E, S>;
+        V values{};
+        auto r = dynamic_receiver<V, E, decltype(rl)>{values,
+                                                      std::move(new_env), rl};
+
+        auto op_state = connect(std::forward<S>(s), r);
+        r.signal_start();
+        start(op_state);
+        rl.run();
+        return values;
+    }
+
+    template <async::sender S, stdx::same_as_unqualified<pipeable> Self>
+    [[nodiscard]] friend auto operator|(S &&s, Self &&self) {
+        return wait(std::forward<S>(s), std::forward<Self>(self).e);
     }
 };
 } // namespace _sync_wait
 
 template <typename Uniq = decltype([] {}), typename Env = empty_env>
     requires(not sender<Env>)
-[[nodiscard]] auto sync_wait(Env &&e = {}) -> _sync_wait::pipeable<Uniq, Env> {
+[[nodiscard]] auto sync_wait_dynamic(Env &&e = {})
+    -> _sync_wait::pipeable<Uniq, Env, _sync_wait::dynamic_t> {
+    return {std::forward<Env>(e)};
+}
+
+template <stdx::ct_string Name, typename Env = empty_env>
+    requires(not sender<Env>)
+[[nodiscard]] auto sync_wait_dynamic(Env &&e = {}) {
+    return sync_wait_dynamic<stdx::cts_t<Name>>(
+        env{prop{get_debug_interface_t{}, debug::named_interface<Name>{}},
+            std::forward<Env>(e)});
+}
+
+template <typename Uniq = decltype([] {}), sender S, typename Env = empty_env>
+[[nodiscard]] auto sync_wait_dynamic(S &&s, Env &&e = {}) {
+    return std::forward<S>(s) | sync_wait_dynamic<Uniq>(std::forward<Env>(e));
+}
+
+template <stdx::ct_string Name, sender S, typename Env = empty_env>
+[[nodiscard]] auto sync_wait_dynamic(S &&s, Env &&e = {}) {
+    return std::forward<S>(s) | sync_wait_dynamic<Name>(std::forward<Env>(e));
+}
+
+template <typename Uniq = decltype([] {}), typename Env = empty_env>
+    requires(not sender<Env>)
+[[nodiscard]] auto sync_wait_static(Env &&e = {})
+    -> _sync_wait::pipeable<Uniq, Env, _sync_wait::static_t> {
+    return {std::forward<Env>(e)};
+}
+
+template <stdx::ct_string Name, typename Env = empty_env>
+    requires(not sender<Env>)
+[[nodiscard]] auto sync_wait_static(Env &&e = {}) {
+    return sync_wait_static<stdx::cts_t<Name>>(
+        env{prop{get_debug_interface_t{}, debug::named_interface<Name>{}},
+            std::forward<Env>(e)});
+}
+
+template <typename Uniq = decltype([] {}), sender S, typename Env = empty_env>
+[[nodiscard]] auto sync_wait_static(S &&s, Env &&e = {}) {
+    return std::forward<S>(s) | sync_wait_static<Uniq>(std::forward<Env>(e));
+}
+
+template <stdx::ct_string Name, sender S, typename Env = empty_env>
+[[nodiscard]] auto sync_wait_static(S &&s, Env &&e = {}) {
+    return std::forward<S>(s) | sync_wait_static<Name>(std::forward<Env>(e));
+}
+
+template <typename Uniq = decltype([] {}), typename Env = empty_env>
+    requires(not sender<Env>)
+[[nodiscard]] auto sync_wait(Env &&e = {})
+    -> _sync_wait::pipeable<Uniq, Env, _sync_wait::static_t> {
     return {std::forward<Env>(e)};
 }
 

--- a/test/fail/CMakeLists.txt
+++ b/test/fail/CMakeLists.txt
@@ -10,6 +10,7 @@ add_compile_fail_test("just_error_result_of_connect.cpp" LIBRARIES async
 add_compile_fail_test("just_result_of_connect.cpp" LIBRARIES async pthread)
 add_compile_fail_test("just_stopped_connect.cpp" LIBRARIES async pthread)
 add_compile_fail_test("read_env_connect.cpp" LIBRARIES async pthread)
+add_compile_fail_test("read_env_sync_wait.cpp" LIBRARIES async pthread)
 add_compile_fail_test("repeat_compose.cpp" LIBRARIES async pthread)
 add_compile_fail_test("retry_compose.cpp" LIBRARIES async pthread)
 add_compile_fail_test("sequence_connect.cpp" LIBRARIES async pthread)

--- a/test/fail/read_env_sync_wait.cpp
+++ b/test/fail/read_env_sync_wait.cpp
@@ -1,0 +1,16 @@
+#include <async/get_scheduler.hpp>
+#include <async/just.hpp>
+#include <async/let_value.hpp>
+#include <async/read_env.hpp>
+#include <async/start_on.hpp>
+#include <async/sync_wait.hpp>
+
+// EXPECT: did you mean to use sync_wait_dynamic
+
+auto main() -> int {
+    auto s = async::read_env(async::get_scheduler) |
+             async::let_value([&](auto sched) {
+                 return async::start_on(sched, async::just(42));
+             });
+    auto value = s | async::sync_wait();
+}

--- a/test/freestanding_sync_wait.cpp
+++ b/test/freestanding_sync_wait.cpp
@@ -54,7 +54,7 @@ TEST_CASE("sync_wait stopped completion", "[freestanding_sync_wait]") {
     CHECK(not value.has_value());
 }
 
-TEST_CASE("sync_wait with read (inline scheduler)",
+TEST_CASE("sync_wait_dynamic with read (inline scheduler)",
           "[freestanding_sync_wait]") {
     auto s = async::read_env(async::get_scheduler) |
              async::let_value([&](auto sched) {
@@ -62,29 +62,32 @@ TEST_CASE("sync_wait with read (inline scheduler)",
              });
 
     auto value = async::inline_scheduler<>::schedule() |
-                 async::sequence([&] { return s; }) | async::sync_wait();
+                 async::sequence([&] { return s; }) |
+                 async::sync_wait_dynamic();
     REQUIRE(value.has_value());
     CHECK(get<0>(*value) == 42);
 }
 
-TEST_CASE("sync_wait with read (thread scheduler", "[freestanding_sync_wait]") {
+TEST_CASE("sync_wait_dynamic with read (thread scheduler)",
+          "[freestanding_sync_wait]") {
     auto s = async::read_env(async::get_scheduler) |
              async::let_value([&](auto sched) {
                  return async::start_on(sched, async::just(42));
              });
 
     auto value = async::thread_scheduler<>::schedule() |
-                 async::sequence([&] { return s; }) | async::sync_wait();
+                 async::sequence([&] { return s; }) |
+                 async::sync_wait_dynamic();
     REQUIRE(value.has_value());
     CHECK(get<0>(*value) == 42);
 }
 
-TEST_CASE("sync_wait can use a custom environment",
+TEST_CASE("sync_wait_dynamic can use a custom environment",
           "[freestanding_sync_wait]") {
     int var{};
     auto s =
         async::read_env(get_fwd_t{}) | async::then([&](int i) { var = i; });
-    CHECK(async::sync_wait(s, async::prop{get_fwd_t{}, 42}));
+    CHECK(async::sync_wait_dynamic(s, async::prop{get_fwd_t{}, 42}));
     CHECK(var == 42);
 }
 

--- a/test/hosted_sync_wait.cpp
+++ b/test/hosted_sync_wait.cpp
@@ -52,35 +52,40 @@ TEST_CASE("sync_wait stopped completion", "[hosted_sync_wait]") {
     CHECK(not value.has_value());
 }
 
-TEST_CASE("sync_wait with read (inline scheduler)", "[hosted_sync_wait]") {
+TEST_CASE("sync_wait_dynamic with read (inline scheduler)",
+          "[hosted_sync_wait]") {
     auto s = async::read_env(async::get_scheduler) |
              async::let_value([&](auto sched) {
                  return async::start_on(sched, async::just(42));
              });
 
     auto value = async::inline_scheduler<>::schedule() |
-                 async::sequence([&] { return s; }) | async::sync_wait();
+                 async::sequence([&] { return s; }) |
+                 async::sync_wait_dynamic();
     REQUIRE(value.has_value());
     CHECK(get<0>(*value) == 42);
 }
 
-TEST_CASE("sync_wait with read (thread scheduler)", "[hosted_sync_wait]") {
+TEST_CASE("sync_wait_dynamic with read (thread scheduler)",
+          "[hosted_sync_wait]") {
     auto s = async::read_env(async::get_scheduler) |
              async::let_value([&](auto sched) {
                  return async::start_on(sched, async::just(42));
              });
 
     auto value = async::thread_scheduler<>::schedule() |
-                 async::sequence([&] { return s; }) | async::sync_wait();
+                 async::sequence([&] { return s; }) |
+                 async::sync_wait_dynamic();
     REQUIRE(value.has_value());
     CHECK(get<0>(*value) == 42);
 }
 
-TEST_CASE("sync_wait can use a custom environment", "[hosted_sync_wait]") {
+TEST_CASE("sync_wait_dynamic can use a custom environment",
+          "[hosted_sync_wait]") {
     int var{};
     auto s =
         async::read_env(get_fwd_t{}) | async::then([&](int i) { var = i; });
-    CHECK(async::sync_wait(s, async::prop{get_fwd_t{}, 42}));
+    CHECK(async::sync_wait_dynamic(s, async::prop{get_fwd_t{}, 42}));
     CHECK(var == 42);
 }
 

--- a/test/read_env.cpp
+++ b/test/read_env.cpp
@@ -50,13 +50,13 @@ TEST_CASE("read_env sends a value", "[read_env]") {
     CHECK(value == 43);
 }
 
-TEST_CASE("read_env with sync_wait", "[read_env]") {
+TEST_CASE("read_env with sync_wait_dynamic", "[read_env]") {
     auto s = async::read_env(async::get_scheduler) |
              async::let_value([&](auto sched) {
                  return async::start_on(sched, async::just(42));
              });
 
-    auto value = s | async::sync_wait();
+    auto value = s | async::sync_wait_dynamic();
     REQUIRE(value.has_value());
     CHECK(get<0>(*value) == 42);
 }


### PR DESCRIPTION
Problem:
- `sync_wait` uses a `runloop_scheduler` to deal with any extra work that is attached during running. However, many times no such work is necessary. So `sync_wait` does a bit of work for nothing.

Solution:
- Rename `sync_wait` to `sync_wait_dynamic`.
- Introduce `sync_wait_static` to run a sender without providing a scheduler for further work. If a scheduler is required, it should be explicit - don't pay for what you don't use.
- `sync_wait` is now a synonym for `sync_wait_static`.