### PR TITLE
:fire: Remove nullary forms of `get_scheduler` and `get_stop_token`

### DIFF
--- a/docs/schedulers.adoc
+++ b/docs/schedulers.adoc
@@ -105,14 +105,14 @@ xref:sender_consumers.adoc#_sync_wait[`sync_wait`].
 
 [source,cpp]
 ----
-auto value = async::get_scheduler()
+auto value = async::read_env(async::get_scheduler)
            | async::let_value([&](auto sched) {
                  return async::start_on(sched, async::just(42));
              })
            | async::sync_wait();
 ----
 
-This code uses xref:sender_factories.adoc#_read_env[`get_scheduler`] to read the
+This code uses xref:sender_factories.adoc#_read_env[`read_env`] to read the
 scheduler provided by `sync_wait`. That `runloop_scheduler` is then used to
 schedule work.
 

--- a/docs/sender_factories.adoc
+++ b/docs/sender_factories.adoc
@@ -150,32 +150,25 @@ auto sndr = async::just_stopped<"cancel">();
 
 Found in the header: `async/read_env.hpp`
 
-`read_env` takes a _tag_ and returns a sender that sends the value denoted by
-that tag, pulled from the environment of the receiver the sender is
+`read_env` takes a _query_ and returns a sender that sends the value denoted by
+that query, obtained from the environment of the receiver the sender is
 connected to.
 
 [source,cpp]
 ----
-auto s = async::read_env(async::get_stop_token_t{});
+auto s = async::read_env(async::get_stop_token);
 // when connected to a receiver, s will send the stop token from that receiver's environment
 ----
 
-`read_env` has some built-in aliases for well-known tags:
-[source,cpp]
-----
-auto s1 = async::get_stop_token(); // same as async::read_env(async::get_stop_token_t{});
-auto s2 = async::get_scheduler();  // same as async::read_env(async::get_scheduler_t{});
-----
-
-`read_env` (and its tag aliases) can be given a name that is used for debug
-events. By default, the name is the name exposed by the tag, or if there is no
+`read_env` can be given a name that is used for debug
+events. By default, the name is the name exposed by the query, or if there is no
 such name, `"read_env"`.
 
 [source,cpp]
 ----
-auto s1 = async::get_stop_token<"gst">(); // name = "gst"
-auto s2 = async::get_stop_token();        // name = "get_stop_token"
-auto s3 = async::read_env(unnamed_tag{}); // name = "read_env"
+auto s1 = async::read_env<"gst">(async::get_stop_token); // name = "gst"
+auto s2 = async::read_env(async::get_stop_token);        // name = "get_stop_token"
+auto s3 = async::read_env(unnamed_query{});              // name = "read_env"
 ----
 
 === `schedule`

--- a/docs/synopsis.adoc
+++ b/docs/synopsis.adoc
@@ -56,7 +56,7 @@ in pipe-composition syntax.
 * `get_completion_scheduler` - a query used to retrieve a completion_scheduler from a sender's attributes
 
 ==== https://github.com/intel/cpp-baremetal-senders-and-receivers/blob/main/include/async/get_scheduler.hpp[get_scheduler.hpp]
-* `get_scheduler` - a query used to retrieve a scheduler from a sender's attributes
+* `get_scheduler` - a query used to retrieve a scheduler from a receiver's environment, typically by using xref:sender_factories.adoc#_read_env[`read_env`]
 
 ==== https://github.com/intel/cpp-baremetal-senders-and-receivers/blob/main/include/async/incite_on.hpp[incite_on.hpp]
 * `incite_on` - a xref:sender_adaptors.adoc#_incite_on[sender adaptor] that incites execution on another scheduler
@@ -92,9 +92,7 @@ by `let_error.hpp`, `let_stopped.hpp`, and `let_value.hpp`
 * `periodic_until` - a xref:sender_adaptors.adoc#_periodic_until[sender adaptor] that repeats a sender until a condition becomes true, periodically without drift
 
 ==== https://github.com/intel/cpp-baremetal-senders-and-receivers/blob/main/include/async/read_env.hpp[read_env.hpp]
-* `get_scheduler` - a sender factory equivalent to `read_env(get_scheduler_t{})`
-* `get_stop_token` - a sender factory equivalent to `read_env(get_stop_token_t{})`
-* `read_env` - a xref:sender_factories.adoc#_read_env[sender factory] that sends values obtained from a receiver's environment
+* `read_env` - a xref:sender_factories.adoc#_read_env[sender factory] that sends values obtained from a receiver's environment using a query
 
 ==== https://github.com/intel/cpp-baremetal-senders-and-receivers/blob/main/include/async/repeat.hpp[repeat.hpp]
 * `repeat` - a xref:sender_adaptors.adoc#_repeat[sender adaptor] that repeats a sender indefinitely
@@ -183,6 +181,7 @@ xref:schedulers.adoc#_time_scheduler[time_scheduler].
 * `static_allocator` - an xref:attributes.adoc#_allocator[`allocator`] that allocates using static storage
 
 ==== https://github.com/intel/cpp-baremetal-senders-and-receivers/blob/main/include/async/stop_token.hpp[stop_token.hpp]
+* `get_stop_token` - a query used to retrieve a https://en.cppreference.com/w/cpp/thread/stop_token[stop_token] from a receiver's environment, typically by using xref:sender_factories.adoc#_read_env[`read_env`]
 * `inplace_stop_source` - a https://en.cppreference.com/w/cpp/thread/stop_source[stop source] that can be used to control cancellation
 * `inplace_stop_token` - a https://en.cppreference.com/w/cpp/thread/stop_token[stop token] corresponding to `inplace_stop_source`
 * `stop_token_of_t` - the type returned by `get_stop_token`
@@ -230,8 +229,8 @@ contains traits and metaprogramming constructs used by many senders.
 * `get_completion_scheduler` - https://github.com/intel/cpp-baremetal-senders-and-receivers/blob/main/include/async/get_completion_scheduler.hpp[`#include <async/get_completion_scheduler.hpp>`]
 * xref:debug.adoc#_naming_senders_and_operations[`get_debug_interface`] - https://github.com/intel/cpp-baremetal-senders-and-receivers/blob/main/include/async/debug.hpp[`#include <async/debug.hpp>`]
 * xref:environments.adoc#_environments[`get_env`] - https://github.com/intel/cpp-baremetal-senders-and-receivers/blob/main/include/async/env.hpp[`#include <async/env.hpp>`]
-* `get_scheduler` - https://github.com/intel/cpp-baremetal-senders-and-receivers/blob/main/include/async/read_env.hpp[`#include <async/read_env.hpp>`]
-* `get_stop_token` - https://github.com/intel/cpp-baremetal-senders-and-receivers/blob/main/include/async/read_env.hpp[`#include <async/read_env.hpp>`]
+* `get_scheduler` - https://github.com/intel/cpp-baremetal-senders-and-receivers/blob/main/include/async/get_scheduler.hpp[`#include <async/get_scheduler.hpp>`]
+* `get_stop_token` - https://github.com/intel/cpp-baremetal-senders-and-receivers/blob/main/include/async/stop_token.hpp[`#include <async/stop_token.hpp>`]
 * xref:sender_adaptors.adoc#_incite_on[`incite_on`] - https://github.com/intel/cpp-baremetal-senders-and-receivers/blob/main/include/async/incite_on.hpp[`#include <async/incite_on.hpp>`]
 * xref:debug.adoc#_handling_a_debug_signal[`injected_debug_handler<>`] - https://github.com/intel/cpp-baremetal-senders-and-receivers/blob/main/include/async/debug.hpp[`#include <async/debug.hpp>`]
 * `injected_task_manager<>` - https://github.com/intel/cpp-baremetal-senders-and-receivers/blob/main/include/async/schedulers/task_manager_interface.hpp[`#include <async/schedulers/task_manager_interface.hpp>`]

--- a/include/async/get_scheduler.hpp
+++ b/include/async/get_scheduler.hpp
@@ -8,7 +8,7 @@
 #include <utility>
 
 namespace async {
-struct get_scheduler_t : forwarding_query_t {
+constexpr inline struct get_scheduler_t : forwarding_query_t {
     constexpr static auto name = stdx::ct_string{"get_scheduler"};
 
     template <typename T>
@@ -17,9 +17,5 @@ struct get_scheduler_t : forwarding_query_t {
         -> decltype(std::forward<T>(t).query(*this)) {
         return std::forward<T>(t).query(*this);
     }
-};
-
-template <typename E> auto get_scheduler(E &&e) {
-    return get_scheduler_t{}(std::forward<E>(e));
-}
+} get_scheduler{};
 } // namespace async

--- a/include/async/read_env.hpp
+++ b/include/async/read_env.hpp
@@ -6,8 +6,6 @@
 #include <async/connect.hpp>
 #include <async/debug.hpp>
 #include <async/env.hpp>
-#include <async/get_scheduler.hpp>
-#include <async/stop_token.hpp>
 #include <async/type_traits.hpp>
 
 #include <stdx/concepts.hpp>
@@ -76,15 +74,6 @@ template <stdx::ct_string Name, typename Tag> struct sender {
 template <stdx::ct_string Name = "", typename Tag>
 [[nodiscard]] constexpr auto read_env(Tag) -> sender auto {
     return _read_env::sender<Name, Tag>{};
-}
-
-template <stdx::ct_string Name = "">
-[[nodiscard]] constexpr auto get_stop_token() -> sender auto {
-    return read_env<Name>(get_stop_token_t{});
-}
-template <stdx::ct_string Name = "">
-[[nodiscard]] constexpr auto get_scheduler() -> sender auto {
-    return read_env<Name>(get_scheduler_t{});
 }
 
 template <typename> struct read_env_t;

--- a/include/async/stop_token.hpp
+++ b/include/async/stop_token.hpp
@@ -205,7 +205,7 @@ template <typename F> struct inplace_stop_callback : stop_callback_base {
     F callback;
 };
 
-struct get_stop_token_t : forwarding_query_t {
+constexpr inline struct get_stop_token_t : forwarding_query_t {
     constexpr static auto name = stdx::ct_string{"get_stop_token"};
 
     template <typename T>
@@ -217,12 +217,7 @@ struct get_stop_token_t : forwarding_query_t {
     }
 
     constexpr auto operator()(auto &&) const -> never_stop_token { return {}; }
-};
-
-template <typename E>
-auto get_stop_token(E &&e) -> decltype(get_stop_token_t{}(std::forward<E>(e))) {
-    return get_stop_token_t{}(std::forward<E>(e));
-}
+} get_stop_token;
 
 template <typename T>
 using stop_token_of_t =

--- a/test/completes_synchronously.cpp
+++ b/test/completes_synchronously.cpp
@@ -5,6 +5,7 @@
 #include <async/read_env.hpp>
 #include <async/schedulers/inline_scheduler.hpp>
 #include <async/schedulers/thread_scheduler.hpp>
+#include <async/stop_token.hpp>
 #include <async/then.hpp>
 
 #include <catch2/catch_test_macros.hpp>
@@ -26,7 +27,7 @@ TEST_CASE("just_result_of completes synchronously",
 }
 
 TEST_CASE("read_env completes synchronously", "[completes_synchronously]") {
-    constexpr auto s = async::get_stop_token();
+    constexpr auto s = async::read_env(async::get_stop_token);
     STATIC_REQUIRE(async::completes_synchronously(async::get_env(s)));
 }
 

--- a/test/fail/read_env_connect.cpp
+++ b/test/fail/read_env_connect.cpp
@@ -1,6 +1,7 @@
 #include <async/concepts.hpp>
 #include <async/connect.hpp>
 #include <async/read_env.hpp>
+#include <async/stop_token.hpp>
 
 // EXPECT: Can't connect sender and receiver
 
@@ -11,5 +12,5 @@ static_assert(async::receiver<fail_receiver>);
 
 auto main() -> int {
     [[maybe_unused]] auto op =
-        async::connect(async::get_stop_token(), fail_receiver{});
+        async::connect(async::read_env(async::get_stop_token), fail_receiver{});
 }

--- a/test/freestanding_sync_wait.cpp
+++ b/test/freestanding_sync_wait.cpp
@@ -2,6 +2,7 @@
 #include "detail/debug_handler.hpp"
 
 #include <async/concepts.hpp>
+#include <async/get_scheduler.hpp>
 #include <async/just.hpp>
 #include <async/let_value.hpp>
 #include <async/read_env.hpp>
@@ -55,7 +56,8 @@ TEST_CASE("sync_wait stopped completion", "[freestanding_sync_wait]") {
 
 TEST_CASE("sync_wait with read (inline scheduler)",
           "[freestanding_sync_wait]") {
-    auto s = async::get_scheduler() | async::let_value([&](auto sched) {
+    auto s = async::read_env(async::get_scheduler) |
+             async::let_value([&](auto sched) {
                  return async::start_on(sched, async::just(42));
              });
 
@@ -66,7 +68,8 @@ TEST_CASE("sync_wait with read (inline scheduler)",
 }
 
 TEST_CASE("sync_wait with read (thread scheduler", "[freestanding_sync_wait]") {
-    auto s = async::get_scheduler() | async::let_value([&](auto sched) {
+    auto s = async::read_env(async::get_scheduler) |
+             async::let_value([&](auto sched) {
                  return async::start_on(sched, async::just(42));
              });
 

--- a/test/hosted_sync_wait.cpp
+++ b/test/hosted_sync_wait.cpp
@@ -2,6 +2,7 @@
 #include "detail/debug_handler.hpp"
 
 #include <async/concepts.hpp>
+#include <async/get_scheduler.hpp>
 #include <async/just.hpp>
 #include <async/let_value.hpp>
 #include <async/read_env.hpp>
@@ -52,7 +53,8 @@ TEST_CASE("sync_wait stopped completion", "[hosted_sync_wait]") {
 }
 
 TEST_CASE("sync_wait with read (inline scheduler)", "[hosted_sync_wait]") {
-    auto s = async::get_scheduler() | async::let_value([&](auto sched) {
+    auto s = async::read_env(async::get_scheduler) |
+             async::let_value([&](auto sched) {
                  return async::start_on(sched, async::just(42));
              });
 
@@ -63,7 +65,8 @@ TEST_CASE("sync_wait with read (inline scheduler)", "[hosted_sync_wait]") {
 }
 
 TEST_CASE("sync_wait with read (thread scheduler)", "[hosted_sync_wait]") {
-    auto s = async::get_scheduler() | async::let_value([&](auto sched) {
+    auto s = async::read_env(async::get_scheduler) |
+             async::let_value([&](auto sched) {
                  return async::start_on(sched, async::just(42));
              });
 

--- a/test/when_all.cpp
+++ b/test/when_all.cpp
@@ -8,6 +8,7 @@
 #include <async/let_value.hpp>
 #include <async/read_env.hpp>
 #include <async/schedulers/thread_scheduler.hpp>
+#include <async/stop_token.hpp>
 #include <async/sync_wait.hpp>
 #include <async/then.hpp>
 #include <async/variant_sender.hpp>
@@ -328,7 +329,8 @@ TEST_CASE("when_all receiver environment is well-formed for synchronous ops",
           "[when_all]") {
     int value{};
     auto op = async::connect(
-        async::when_all(async::get_stop_token(), async::just(42)),
+        async::when_all(async::read_env(async::get_stop_token),
+                        async::just(42)),
         receiver{[&](auto st, int x) {
             STATIC_REQUIRE(
                 std::is_same_v<decltype(st), async::never_stop_token>);

--- a/test/when_any.cpp
+++ b/test/when_any.cpp
@@ -363,7 +363,8 @@ TEST_CASE("when_any receiver environment is well-formed for synchronous ops",
           "[when_any]") {
     int value{};
     auto op = async::connect(
-        async::when_any(async::get_stop_token(), async::just(42)),
+        async::when_any(async::read_env(async::get_stop_token),
+                        async::just(42)),
         receiver{[&](auto st) {
             CHECK(std::is_same_v<decltype(st), async::never_stop_token>);
             value = 42;


### PR DESCRIPTION
Problem:
- `get_stop_token()` and `get_scheduler()` are variations on `read_env` that are actually sender factories. They do not return (respectively) a stop token and a scheduler, and their names clash with the actual queries that do. They were removed from P2300R10, perhaps because they are confusing.

Solution:
- Remove them.