### PR TITLE
:bug: Fix `let_*` completion signatures, `when_all` reference handling

### DIFF
--- a/include/async/let.hpp
+++ b/include/async/let.hpp
@@ -221,9 +221,10 @@ struct sender {
 
     template <typename R>
     using is_multishot_leftover_sender = stdx::conditional_t<
-        boost::mp11::mp_empty<
-            boost::mp11::mp_second<raw_completions<env_of_t<R>>>>::value,
-        std::true_type, std::bool_constant<multishot_sender<S>>>;
+        boost::mp11::mp_empty<unchanged_completions<env_of_t<R>>>::value,
+        std::true_type,
+        std::bool_constant<multishot_sender<
+            S, async::detail::universal_receiver<env_of_t<R>>>>>;
 
     template <typename R> struct is_multishot_sender {
         template <typename T>
@@ -244,7 +245,8 @@ struct sender {
     }
 
     template <receiver_from<sender> R>
-        requires multishot_sender<S> and
+        requires multishot_sender<
+                     S, async::detail::universal_receiver<env_of_t<R>>> and
                  is_multishot_leftover_sender<R>::value and
                  boost::mp11::mp_all_of_q<dependent_senders<env_of_t<R>>,
                                           is_multishot_sender<R>>::value

--- a/include/async/when_all.hpp
+++ b/include/async/when_all.hpp
@@ -77,7 +77,7 @@ struct sub_op_storage<E, S> {
         boost::mp11::mp_transform<std::add_lvalue_reference_t, values_t>;
 
     template <typename... Args> auto store(Args &&...args) -> void {
-        v = stdx::make_tuple(std::forward<Args>(args)...);
+        v.emplace(values_t{std::forward<Args>(args)...});
     }
     auto load() -> ref_values_t {
         return v->apply([](auto &...args) { return ref_values_t{args...}; });

--- a/test/when_all.cpp
+++ b/test/when_all.cpp
@@ -115,6 +115,14 @@ TEST_CASE("basic operation sending void values", "[when_all]") {
     CHECK(value == 59);
 }
 
+TEST_CASE("basic operation sending reference values", "[when_all]") {
+    auto s1 = async::read_env(async::get_scheduler);
+    auto s2 = async::just();
+    auto w = async::when_all(s1, s2);
+    auto r = async::sync_wait_dynamic(w);
+    REQUIRE(r);
+}
+
 TEST_CASE("when_all with thread scheduler", "[when_all]") {
     std::uniform_int_distribution<> dis{5, 10};
     auto const d1 = std::chrono::milliseconds{dis(get_rng())};


### PR DESCRIPTION
Problem:
- When testing for a multishot sender, `let_*` erroneously tries to test the
  universal receiver against the upstream sender, without using the environment
  of the downstream receiver.
- When a sender sends a reference, `when_all` doesn't handle it properly.
- `read_env(get_scheduler)` is such a sender, sending a reference to the
  scheduler in the receiver's environment.

Solution:
- Endow the universal receiver used with `let_*` internals with the environment
  of the downstream receiver.
- Handle tuple of references properly in `when_all` sub op state storage.