### PR TITLE
:bug: Fix multishot constraints on several adaptors

### DIFF
--- a/include/async/incite_on.hpp
+++ b/include/async/incite_on.hpp
@@ -130,8 +130,9 @@ template <typename Sched, typename S> struct sender {
     }
 
     template <async::receiver R>
-        requires multishot_sender<S> and std::copy_constructible<S> and
-                 std::copy_constructible<Sched>
+        requires multishot_sender<
+                     S, async::detail::universal_receiver<env_of_t<R>>> and
+                 std::copy_constructible<S> and std::copy_constructible<Sched>
     [[nodiscard]] constexpr auto
     connect(R &&r) const & -> op_state<Sched, std::remove_cvref_t<R>, S> {
         check_connect<sender, R>();

--- a/include/async/into_variant.hpp
+++ b/include/async/into_variant.hpp
@@ -74,7 +74,8 @@ struct sender {
     }
 
     template <async::receiver R>
-        requires multishot_sender<S>
+        requires multishot_sender<
+            S, async::detail::universal_receiver<env_of_t<R>>>
     [[nodiscard]] constexpr auto connect(R &&r) const & {
         check_connect<sender const &, R>();
         using env_t = env_of_t<std::remove_cvref_t<R>>;

--- a/include/async/sequence.hpp
+++ b/include/async/sequence.hpp
@@ -125,8 +125,9 @@ template <stdx::ct_string Name, typename S, std::invocable F> struct sender {
     }
 
     template <async::receiver R>
-        requires multishot_sender<S> and std::copy_constructible<S> and
-                 std::copy_constructible<F>
+        requires multishot_sender<
+                     S, async::detail::universal_receiver<env_of_t<R>>> and
+                 std::copy_constructible<S> and std::copy_constructible<F>
     [[nodiscard]] constexpr auto
     connect(R &&r) const & -> op_state<Name, S, F, std::remove_cvref_t<R>> {
         check_connect<sender, R>();

--- a/include/async/then.hpp
+++ b/include/async/then.hpp
@@ -207,7 +207,9 @@ struct sender {
     }
 
     template <async::receiver R>
-        requires multishot_sender<S> and (... and std::copy_constructible<Fs>)
+        requires multishot_sender<
+                     S, async::detail::universal_receiver<env_of_t<R>>> and
+                 (... and std::copy_constructible<Fs>)
     [[nodiscard]] constexpr auto connect(R &&r) const & {
         check_connect<sender const &, R>();
         return async::connect(


### PR DESCRIPTION
Problem:
- When constraining `connect` for a multishot sender, several adaptors fail to properly use the environment of the downstream receiver.

Solution:
- Constrain those `connect` calls with the universal receiver with the correct environment.