### PR TITLE
:bug: Fix `into_variant` duplicate completions

### DIFF
--- a/include/async/into_variant.hpp
+++ b/include/async/into_variant.hpp
@@ -56,7 +56,8 @@ template <typename... Ts>
 using decayed_tuple = stdx::tuple<std::decay_t<Ts>...>;
 
 template <typename S, typename Env, template <typename...> typename V>
-using variant_t = value_types_of_t<S, Env, decayed_tuple, V>;
+using variant_t =
+    boost::mp11::mp_unique<value_types_of_t<S, Env, decayed_tuple, V>>;
 } // namespace detail
 
 template <stdx::ct_string Name, typename S, template <typename...> typename V>


### PR DESCRIPTION
Problem:
- Senders handled by `into_variant` may completed with types that are the same when decayed. This results in a variant with duplicate types, which cannot be constructed unambiguously.

Solution:
- Uniquify the variant completion type.

Note:
- It's not possible in general to tell _which_ upstream sender completed if multiple senders complete with the same type. i.e. we cannot distinguish the position of the active variant member. If that is important, strong types (or a similar technique) should be used.