### PR TITLE
:art: Allow repeat to be stopped when the wrapped sender can't

### DIFF
--- a/test/repeat.cpp
+++ b/test/repeat.cpp
@@ -134,6 +134,21 @@ TEST_CASE("repeat can be cancelled", "[repeat]") {
     CHECK(var == 44);
 }
 
+TEST_CASE("repeat can be cancelled even for a sender that cannot", "[repeat]") {
+    int var{};
+    stoppable_receiver r{[&] { var += 42; }};
+
+    auto sub = async::just_result_of([&] {
+        if (++var == 2) {
+            r.request_stop();
+        }
+    });
+    auto s = sub | async::repeat();
+    auto op = async::connect(s, r);
+    async::start(op);
+    CHECK(var == 44);
+}
+
 TEST_CASE("repeat may complete synchronously", "[repeat]") {
     int var{};
     auto sub = async::just() | async::then([&] { ++var; });


### PR DESCRIPTION
Problem:
- When `repeat` wraps a sender that does not respond to cancellation requests, it is possible that `repeat` is not stoppable. This is confusing and bug-prone.

Solution:
- When the wrapped sender does not respond to cancellation requests, repeat will check for cancellation each time it repeats.

Note:
- For a synchronously completing sender, this also prevents an infinite loop that exhibits undefined behaviour (pre-C++26).