### PR TITLE
:art: Name trigger schedulers with a type rather than a value

### DIFF
--- a/include/async/schedulers/trigger_manager.hpp
+++ b/include/async/schedulers/trigger_manager.hpp
@@ -35,7 +35,7 @@ template <typename... Args> struct trigger_task {
     }
 };
 
-template <stdx::ct_string Name, typename... Args> struct trigger_manager {
+template <typename Name, typename... Args> struct trigger_manager {
     using task_t = trigger_task<Args...>;
 
   private:
@@ -83,13 +83,19 @@ template <stdx::ct_string Name, typename... Args> struct trigger_manager {
     [[nodiscard]] auto empty() const -> bool { return task_count == 0; }
 };
 
-template <stdx::ct_string Name, typename... Args>
+template <typename Name, typename... Args>
 inline auto triggers = trigger_manager<Name, Args...>{};
 
-template <stdx::ct_string Name, typename RQP = requeue_policy::deferred,
+template <typename Name, typename RQP = requeue_policy::deferred,
           typename... Args>
 auto run_triggers(Args &&...args) -> void {
     triggers<Name, std::remove_cvref_t<Args>...>.template run<RQP>(
         std::forward<Args>(args)...);
+}
+
+template <stdx::ct_string Name, typename RQP = requeue_policy::deferred,
+          typename... Args>
+auto run_triggers(Args &&...args) -> void {
+    run_triggers<stdx::cts_t<Name>, RQP>(std::forward<Args>(args)...);
 }
 } // namespace async

--- a/test/repeat.cpp
+++ b/test/repeat.cpp
@@ -293,5 +293,5 @@ TEST_CASE("repeat with a loop function", "[repeat]") {
 
     CHECK(var == 44);
     CHECK(sum == 34);
-    CHECK(async::triggers<"sched">.empty());
+    CHECK(async::triggers<stdx::cts_t<"sched">>.empty());
 }

--- a/test/schedulers/trigger_scheduler.cpp
+++ b/test/schedulers/trigger_scheduler.cpp
@@ -69,13 +69,13 @@ TEMPLATE_TEST_CASE("trigger_scheduler schedules tasks", "[trigger_scheduler]",
         async::start_on(s, async::just_result_of([&] { var = 42; }));
     auto op = async::connect(sndr, universal_receiver{});
 
-    async::triggers<name>.run();
+    async::triggers<stdx::cts_t<name>>.run();
     CHECK(var == 0);
 
     async::start(op);
-    async::triggers<name>.run();
+    async::triggers<stdx::cts_t<name>>.run();
     CHECK(var == 42);
-    CHECK(async::triggers<name>.empty());
+    CHECK(async::triggers<stdx::cts_t<name>>.empty());
 }
 
 TEMPLATE_TEST_CASE("trigger_scheduler can be triggered with arguments",
@@ -91,10 +91,10 @@ TEMPLATE_TEST_CASE("trigger_scheduler can be triggered with arguments",
     CHECK(var == 0);
 
     async::start(op);
-    CHECK(not async::triggers<name, int>.empty());
+    CHECK(not async::triggers<stdx::cts_t<name>, int>.empty());
     async::run_triggers<name>(42);
     CHECK(var == 42);
-    CHECK(async::triggers<name, int>.empty());
+    CHECK(async::triggers<stdx::cts_t<name>, int>.empty());
 }
 
 TEMPLATE_TEST_CASE("trigger_scheduler is cancellable before start",
@@ -110,7 +110,7 @@ TEMPLATE_TEST_CASE("trigger_scheduler is cancellable before start",
     r.request_stop();
     async::start(op);
     CHECK(var == 17);
-    CHECK(async::triggers<name>.empty());
+    CHECK(async::triggers<stdx::cts_t<name>>.empty());
 }
 
 TEMPLATE_TEST_CASE("trigger_scheduler is cancellable after start",
@@ -126,7 +126,7 @@ TEMPLATE_TEST_CASE("trigger_scheduler is cancellable after start",
     async::start(op);
     r.request_stop();
     CHECK(var == 17);
-    CHECK(async::triggers<name>.empty());
+    CHECK(async::triggers<stdx::cts_t<name>>.empty());
 }
 
 TEST_CASE("request and response", "[trigger_scheduler]") {
@@ -150,14 +150,14 @@ TEST_CASE("request and response", "[trigger_scheduler]") {
     CHECK(async::start_detached(s));
 
     CHECK(var == 0);
-    async::triggers<"client">.run();
+    async::run_triggers<"client">();
     CHECK(var == 1);
-    async::triggers<"server">.run();
+    async::run_triggers<"server">();
     CHECK(var == 2);
-    async::triggers<"client">.run();
+    async::run_triggers<"client">();
     CHECK(var == 86);
-    CHECK(async::triggers<"client">.empty());
-    CHECK(async::triggers<"server">.empty());
+    CHECK(async::triggers<stdx::cts_t<"client">>.empty());
+    CHECK(async::triggers<stdx::cts_t<"server">>.empty());
 }
 
 namespace {
@@ -191,7 +191,7 @@ TEST_CASE("trigger_scheduler can be debugged", "[trigger_scheduler]") {
 
     async::start(op);
     CHECK(debug_events == std::vector{"op sched start"s});
-    async::triggers<"sched">.run();
+    async::run_triggers<"sched">();
     CHECK(debug_events ==
           std::vector{"op sched start"s, "op sched set_value"s});
 }


### PR DESCRIPTION
Problem:
- A `trigger_scheduler` is a generic callback mechanism, so it's useful to be able to name them with compiler-generated types. At the moment they can only be used with a user-supplied `ct_string`.

Solution:
- Use a regular type parameter on the templates for `trigger_scheduler` and friends.
- The `ct_string` interface remains the same, delegating with a wrapper.

Note:
- It's possible for the compiler to generate a unique type (`decltype([]{})`). This type is even unique at link time. But it's not possible yet AFAIK for the compiler to generate such a unique NTTP.