### PR TITLE
:safety_vest: Compile-time errors for `sync_wait` and `when_all` viol…

### DIFF
--- a/test/fail/CMakeLists.txt
+++ b/test/fail/CMakeLists.txt
@@ -15,8 +15,12 @@ add_compile_fail_test("repeat_compose.cpp" LIBRARIES async pthread)
 add_compile_fail_test("retry_compose.cpp" LIBRARIES async pthread)
 add_compile_fail_test("sequence_connect.cpp" LIBRARIES async pthread)
 add_compile_fail_test("split_connect.cpp" LIBRARIES async pthread)
+add_compile_fail_test("sync_wait_multiple_completions.cpp" LIBRARIES async
+                      pthread)
 add_compile_fail_test("then_connect.cpp" LIBRARIES async pthread)
 add_compile_fail_test("timeout_after_error.cpp" LIBRARIES async pthread)
 add_compile_fail_test("timeout_after_stopped.cpp" LIBRARIES async pthread)
+add_compile_fail_test("when_all_multiple_completions.cpp" LIBRARIES async
+                      pthread)
 add_compile_fail_test("when_any_uncompleteable.cpp" LIBRARIES async pthread)
 add_compile_fail_test("when_any_unstoppable.cpp" LIBRARIES async pthread)

--- a/test/fail/sync_wait_multiple_completions.cpp
+++ b/test/fail/sync_wait_multiple_completions.cpp
@@ -1,0 +1,13 @@
+#include <async/just.hpp>
+#include <async/sync_wait.hpp>
+#include <async/variant_sender.hpp>
+
+// clang-format off
+// EXPECT: sync_wait requires a single set_value completion: consider using into_variant
+// clang-format on
+
+auto main(int argc, char **) -> int {
+    [[maybe_unused]] auto r =
+        async::make_optional_sender(argc == 0, [] { return async::just(42); }) |
+        async::sync_wait();
+}

--- a/test/fail/when_all_multiple_completions.cpp
+++ b/test/fail/when_all_multiple_completions.cpp
@@ -1,0 +1,20 @@
+#include <async/just.hpp>
+#include <async/sync_wait.hpp>
+#include <async/variant_sender.hpp>
+#include <async/when_all.hpp>
+
+// clang-format off
+// EXPECT: when_all requires each sender to complete with at most one set_value completion
+// clang-format on
+
+template <typename...> struct undef;
+
+auto main(int argc, char **) -> int {
+    [[maybe_unused]] auto s1 = async::make_variant_sender(
+        argc == 0, [] { return async::just(42); },
+        [] { return async::just(3.14f); });
+    [[maybe_unused]] auto s2 = async::just(42);
+
+    [[maybe_unused]] auto r = async::when_all(s1, s2) | async::sync_wait();
+    undef<decltype(r)> q{};
+}


### PR DESCRIPTION
…ations

Problem:
- `sync_wait` requires the sender to complete with a single `set_value` completion, but the message when this isn't the case is obscure.
- `when_all` has a similar requirement of its senders, but gives no error at all when the precondition is violated.

Solution:
- Add compile-time checks for `sync_wait` and `when_all` to provide better help messages.