### PR TITLE
:art: Extend `read_env` to be variadic

### DIFF
--- a/include/async/read_env.hpp
+++ b/include/async/read_env.hpp
@@ -9,7 +9,9 @@
 #include <async/type_traits.hpp>
 
 #include <stdx/concepts.hpp>
+#include <stdx/ct_conversions.hpp>
 #include <stdx/ct_string.hpp>
+#include <stdx/tuple.hpp>
 
 #include <concepts>
 #include <type_traits>
@@ -18,28 +20,42 @@
 namespace async {
 namespace _read_env {
 namespace detail {
-template <stdx::ct_string Name, typename Tag> constexpr auto get_name() {
+template <stdx::ct_string Name, typename... Tags> constexpr auto get_name() {
     if constexpr (not Name.empty()) {
         return Name;
-    } else if constexpr (requires {
-                             []<auto N>(stdx::ct_string<N>) {}(Tag::name);
-                         }) {
-        return Tag::name;
     } else {
-        return stdx::ct_string{"read_env"};
+        auto const f = []<typename Tag>() {
+            if constexpr (requires {
+                              []<auto N>(stdx::ct_string<N>) {}(Tag::name);
+                          }) {
+                return Tag::name;
+            } else {
+                constexpr auto s = stdx::type_as_string<Tag>();
+                return stdx::ct_string<s.size() + 1>{s};
+            }
+        };
+        using namespace stdx::literals;
+        if constexpr (sizeof...(Tags) == 1) {
+            return f.template operator()<Tags...>();
+        } else {
+            return "read_env<"_cts +
+                   stdx::tuple{f.template operator()<Tags>()...}.join(
+                       ""_cts,
+                       [](auto lhs, auto rhs) { return lhs + ","_cts + rhs; }) +
+                   ">"_cts;
+        }
     }
 }
 } // namespace detail
 
-template <stdx::ct_string Name, typename R, typename Tag> struct op_state {
+template <stdx::ct_string Name, typename R, typename... Tags> struct op_state {
     [[no_unique_address]] R receiver;
 
     constexpr auto start() & -> void {
-        debug_signal<"start", debug::erased_context_for<op_state>>(
-            get_env(receiver));
-        debug_signal<"set_value", debug::erased_context_for<op_state>>(
-            get_env(receiver));
-        set_value(std::move(receiver), Tag{}(get_env(receiver)));
+        auto e = get_env(receiver);
+        debug_signal<"start", debug::erased_context_for<op_state>>(e);
+        debug_signal<"set_value", debug::erased_context_for<op_state>>(e);
+        set_value(std::move(receiver), Tags{}(e)...);
     }
 
     [[nodiscard]] constexpr static auto query(get_env_t) noexcept {
@@ -47,13 +63,13 @@ template <stdx::ct_string Name, typename R, typename Tag> struct op_state {
     }
 };
 
-template <stdx::ct_string Name, typename Tag> struct sender {
+template <stdx::ct_string Name, typename... Tags> struct sender {
     using is_sender = void;
 
     template <typename Env>
     [[nodiscard]] constexpr static auto get_completion_signatures(Env const &)
-        -> completion_signatures<
-            set_value_t(decltype(std::declval<Tag>()(std::declval<Env>())))> {
+        -> completion_signatures<set_value_t(
+            decltype(std::declval<Tags>()(std::declval<Env>()))...)> {
         return {};
     }
 
@@ -63,26 +79,27 @@ template <stdx::ct_string Name, typename Tag> struct sender {
 
     template <receiver R>
     [[nodiscard]] constexpr static auto connect(R &&r)
-        -> op_state<detail::get_name<Name, Tag>(), std::remove_cvref_t<R>,
-                    Tag> {
+        -> op_state<detail::get_name<Name, Tags...>(), std::remove_cvref_t<R>,
+                    Tags...> {
         check_connect<sender, R>();
         return {std::forward<R>(r)};
     }
 };
 } // namespace _read_env
 
-template <stdx::ct_string Name = "", typename Tag>
-[[nodiscard]] constexpr auto read_env(Tag) -> sender auto {
-    return _read_env::sender<Name, Tag>{};
+template <stdx::ct_string Name = "", typename... Tags>
+    requires(sizeof...(Tags) > 0)
+[[nodiscard]] constexpr auto read_env(Tags...) -> sender auto {
+    return _read_env::sender<Name, Tags...>{};
 }
 
-template <typename> struct read_env_t;
+template <typename...> struct read_env_t;
 
-template <stdx::ct_string Name, typename R, typename Tag>
-struct debug::context_for<_read_env::op_state<Name, R, Tag>> {
-    using tag = read_env_t<Tag>;
+template <stdx::ct_string Name, typename R, typename... Tags>
+struct debug::context_for<_read_env::op_state<Name, R, Tags...>> {
+    using tag = read_env_t<Tags...>;
     constexpr static auto name = Name;
     using children = stdx::type_list<>;
-    using type = _read_env::op_state<Name, R, Tag>;
+    using type = _read_env::op_state<Name, R, Tags...>;
 };
 } // namespace async

--- a/test/detail/common.hpp
+++ b/test/detail/common.hpp
@@ -141,6 +141,8 @@ struct none {
 };
 
 constexpr inline struct get_fwd_t : async::forwarding_query_t {
+    constexpr static auto name = stdx::ct_string{"get_fwd"};
+
     template <typename T>
     constexpr auto operator()(T &&t) const
         noexcept(noexcept(std::forward<T>(t).query(std::declval<get_fwd_t>())))
@@ -152,6 +154,8 @@ constexpr inline struct get_fwd_t : async::forwarding_query_t {
 } get_fwd{};
 
 constexpr inline struct get_nofwd_t {
+    constexpr static auto name = stdx::ct_string{"get_nofwd"};
+
     template <typename T>
     constexpr auto operator()(T &&t) const noexcept(
         noexcept(std::forward<T>(t).query(std::declval<get_nofwd_t>())))


### PR DESCRIPTION
Problem:
- Sometimes it's useful to read more than one thing from an environment and pass it downstream.

Solution:
- Make `read_env` variadic.