### PR TITLE
:bug: :white_check_mark: Don't destroy `stop_source` in `receiver` de…

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,8 +15,8 @@ else()
     cpmaddpackage("gh:intel/cicd-repo-infrastructure#3e2bef0")
 endif()
 
-add_versioned_package("gh:intel/cpp-baremetal-concurrency#0ddce52")
-add_versioned_package("gh:intel/cpp-std-extensions#19369a5")
+add_versioned_package("gh:intel/cpp-baremetal-concurrency#9d6573a")
+add_versioned_package("gh:intel/cpp-std-extensions#efc6045")
 add_versioned_package("gh:boostorg/mp11#boost-1.83.0")
 
 add_library(async INTERFACE)

--- a/test/detail/common.hpp
+++ b/test/detail/common.hpp
@@ -84,7 +84,6 @@ template <typename F> struct stoppable_receiver {
     explicit stoppable_receiver(F &&fn) : f{std::move(fn)} {
         stop_source<stoppable_receiver>.emplace();
     }
-    ~stoppable_receiver() { stop_source<stoppable_receiver>.reset(); }
 
     auto request_stop() { stop_source<stoppable_receiver>->request_stop(); }
 


### PR DESCRIPTION
…structor

Problem:
- Receivers are cheap to copy and may be copy-constructed/destroyed; `stoppable_receiver` ensures the non-movable `stop_source` is constructed but should not destroy it on destruction.

Solution:
- Don't destroy the `stop_source` when the `stoppable_receiver` is destroyed.