### PR TITLE
:construction_worker: Add clang-21 to CI

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -13,7 +13,7 @@ env:
   DEBIAN_FRONTEND: noninteractive
   CMAKE_GENERATOR: Ninja
   DEFAULT_CXX_STANDARD: 20
-  DEFAULT_LLVM_VERSION: 20
+  DEFAULT_LLVM_VERSION: 21
   DEFAULT_GCC_VERSION: 14
 
 concurrency:
@@ -27,7 +27,7 @@ jobs:
       fail-fast: false
       matrix:
         compiler: [clang, gcc]
-        version: [12, 13, 14, 16, 17, 18, 19, 20]
+        version: [12, 13, 14, 16, 17, 18, 19, 20, 21]
         cxx_standard: [20]
         stdlib: [libstdc++, libc++]
         build_type: [Debug]
@@ -36,6 +36,15 @@ jobs:
             cc: "clang"
             cxx: "clang++"
             cxx_flags: "-stdlib=libstdc++"
+          - version: 21
+            compiler: clang
+            install: wget https://apt.llvm.org/llvm.sh && chmod +x llvm.sh && sudo ./llvm.sh 21
+            toolchain_root: "/usr/lib/llvm-21"
+          - version: 21
+            compiler: clang
+            stdlib: libc++
+            install: wget https://apt.llvm.org/llvm.sh && chmod +x llvm.sh && sudo ./llvm.sh 21 && sudo apt install -y libc++-21-dev libc++abi-21-dev
+            cxx_flags: "-stdlib=libc++"
           - version: 20
             compiler: clang
             install: wget https://apt.llvm.org/llvm.sh && chmod +x llvm.sh && sudo ./llvm.sh 20
@@ -101,6 +110,8 @@ jobs:
             cxx: "g++-12"
             cxx_flags: ""
         exclude:
+          - compiler: gcc
+            version: 21
           - compiler: gcc
             version: 20
           - compiler: gcc

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ concurrent execution.
 
 C++20 is required. The following compilers are supported:
  
-- clang 14 through 19
+- clang 14 through 21
 - gcc 12 through 14
 
 See the [full documentation](https://intel.github.io/cpp-baremetal-senders-and-receivers/).


### PR DESCRIPTION
Problem:
- Clang 21 has been released and is not yet used by CI. Solution:
- Add clang-21 to CI.