### PR TITLE
:sparkles: Add `then_each`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -78,6 +78,7 @@ target_sources(
               include/async/stop_token.hpp
               include/async/sync_wait.hpp
               include/async/then.hpp
+              include/async/then_each.hpp
               include/async/timeout_after.hpp
               include/async/type_traits.hpp
               include/async/variant_sender.hpp

--- a/docs/sender_adaptors.adoc
+++ b/docs/sender_adaptors.adoc
@@ -555,6 +555,22 @@ auto t = async::then(s,
 // when run, this will call set_value(59, "no", 1.0f) on the downstream receiver
 ----
 
+=== `then_each`
+
+Found in the header: `async/then_each.hpp`
+
+`then_each` takes a sender and several functions, and returns a sender that will call
+each of the functions with the values that the sender sends.
+
+[source,cpp]
+----
+auto sndr = async::just(42);
+auto then_each_sndr = async::then_each(sndr,
+    [] (int i) { return std::to_string(i); },
+    [] (int i) { return i + 1; });
+// when run, then_each_sndr will produce values "42" and 43
+----
+
 === `timeout_after`
 
 Found in the header: `async/timeout_after.hpp`

--- a/docs/synopsis.adoc
+++ b/docs/synopsis.adoc
@@ -199,6 +199,9 @@ xref:schedulers.adoc#_time_scheduler[time_scheduler].
 * `upon error` - a xref:sender_adaptors.adoc#_upon_error[sender adaptor] that transforms what a sender sends on the error channel, and completes on the value channel
 * `upon stopped` - a xref:sender_adaptors.adoc#_upon_stopped[sender adaptor] that transforms what a sender sends on the stopped channel, and completes on the value channel
 
+==== https://github.com/intel/cpp-baremetal-senders-and-receivers/blob/main/include/async/then_each.hpp[then_each.hpp]
+* `then_each` - a xref:sender_adaptors.adoc#_then_each[sender adaptor] that transforms in multiple ways what a sender sends on the value channel
+
 ==== https://github.com/intel/cpp-baremetal-senders-and-receivers/blob/main/include/async/timeout_after.hpp[timeout_after.hpp]
 * `timeout_after` - a xref:sender_adaptors.adoc#_timeout_after[sender adaptor] that races a sender against a time limit
 
@@ -303,6 +306,7 @@ contains traits and metaprogramming constructs used by many senders.
 * `task_mgr::is_idle()` - https://github.com/intel/cpp-baremetal-senders-and-receivers/blob/main/include/async/schedulers/task_manager_interface.hpp[`#include <async/schedulers/task_manager_interface.hpp>`]
 * `task_mgr::service_tasks<P>()` - https://github.com/intel/cpp-baremetal-senders-and-receivers/blob/main/include/async/schedulers/task_manager_interface.hpp[`#include <async/schedulers/task_manager_interface.hpp>`]
 * xref:sender_adaptors.adoc#_then[`then`] - https://github.com/intel/cpp-baremetal-senders-and-receivers/blob/main/include/async/then.hpp[`#include <async/then.hpp>`]
+* xref:sender_adaptors.adoc#_then_each[`then_each`] - https://github.com/intel/cpp-baremetal-senders-and-receivers/blob/main/include/async/then_each.hpp[`#include <async/then_each.hpp>`]
 * xref:schedulers.adoc#_thread_scheduler[`thread_scheduler`] - https://github.com/intel/cpp-baremetal-senders-and-receivers/blob/main/include/async/schedulers/thread_scheduler.hpp[`#include <async/schedulers/thread_scheduler.hpp>`]
 * xref:schedulers.adoc#_time_scheduler[`time_scheduler`] - https://github.com/intel/cpp-baremetal-senders-and-receivers/blob/main/include/async/schedulers/time_scheduler.hpp[`#include <async/schedulers/time_scheduler.hpp>`]
 * xref:sender_adaptors.adoc#_timeout_after[`timeout_after`] - https://github.com/intel/cpp-baremetal-senders-and-receivers/blob/main/include/async/timeout_after.hpp[`#include <async/timeout_after.hpp>`]

--- a/include/async/then_each.hpp
+++ b/include/async/then_each.hpp
@@ -1,0 +1,166 @@
+#pragma once
+
+#include <async/completion_tags.hpp>
+#include <async/compose.hpp>
+#include <async/concepts.hpp>
+#include <async/connect.hpp>
+#include <async/debug.hpp>
+#include <async/env.hpp>
+#include <async/forwarding_query.hpp>
+#include <async/type_traits.hpp>
+
+#include <stdx/concepts.hpp>
+#include <stdx/ct_string.hpp>
+#include <stdx/tuple.hpp>
+#include <stdx/tuple_algorithms.hpp>
+#include <stdx/type_traits.hpp>
+#include <stdx/utility.hpp>
+
+#include <boost/mp11/algorithm.hpp>
+#include <boost/mp11/list.hpp>
+
+#include <concepts>
+#include <type_traits>
+#include <utility>
+
+template <typename...> struct undef;
+
+namespace async {
+namespace _then_each {
+
+namespace detail {
+struct void_t {};
+template <typename T>
+using nonvoid_result_t = std::bool_constant<not std::is_same_v<void_t, T>>;
+} // namespace detail
+
+template <stdx::ct_string Name, typename S, typename R, typename... Fs>
+struct receiver {
+    using is_receiver = void;
+    [[no_unique_address]] R r;
+    [[no_unique_address]] stdx::tuple<Fs...> fs;
+
+    [[nodiscard]] constexpr auto query(get_env_t) const
+        -> forwarding_env<env_of_t<R>> {
+        return forward_env_of(r);
+    }
+
+    template <typename... Args>
+    constexpr auto set_value(Args &&...args) && -> void {
+        std::move(fs).apply([&](auto &&...funcs) {
+            auto const invoke = [&]<typename F>(F &&f) -> decltype(auto) {
+                if constexpr (std::is_void_v<
+                                  std::invoke_result_t<F, Args...>>) {
+                    std::forward<F>(f)(args...);
+                    return detail::void_t{};
+                } else {
+                    return std::forward<F>(f)(args...);
+                }
+            };
+            auto results = stdx::tuple<decltype(invoke(FWD(funcs)))...>{
+                invoke(FWD(funcs))...};
+            auto filtered_results =
+                stdx::filter<detail::nonvoid_result_t>(std::move(results));
+
+            debug_signal<set_value_t::name,
+                         debug::erased_context_for<receiver>>(get_env(r));
+            std::move(filtered_results).apply([&]<typename... Ts>(Ts &&...ts) {
+                set_value_t{}(std::move(r), std::forward<Ts>(ts)...);
+            });
+        });
+    }
+    template <typename... Args>
+    constexpr auto set_error(Args &&...args) && -> void {
+        debug_signal<set_error_t::name, debug::erased_context_for<receiver>>(
+            get_env(r));
+        set_error_t{}(std::move(r), std::forward<Args>(args)...);
+    }
+    constexpr auto set_stopped() && -> void {
+        debug_signal<set_stopped_t::name, debug::erased_context_for<receiver>>(
+            get_env(r));
+        set_stopped_t{}(std::move(r));
+    }
+    using sender_t = S;
+};
+
+namespace detail {
+template <typename... As> using as_signature = set_value_t(As...);
+}
+
+template <stdx::ct_string Name, typename S, typename... Fs> struct sender {
+    template <async::receiver R>
+    [[nodiscard]] constexpr auto connect(R &&r) && {
+        check_connect<sender &&, R>();
+        return async::connect(std::move(s),
+                              receiver<Name, S, std::remove_cvref_t<R>, Fs...>{
+                                  std::forward<R>(r), std::move(fs)});
+    }
+
+    template <async::receiver R>
+        requires multishot_sender<
+                     S, async::detail::universal_receiver<env_of_t<R>>> and
+                 (... and std::copy_constructible<Fs>)
+    [[nodiscard]] constexpr auto connect(R &&r) const & {
+        check_connect<sender const &, R>();
+        return async::connect(s,
+                              receiver<Name, S, std::remove_cvref_t<R>, Fs...>{
+                                  std::forward<R>(r), fs});
+    }
+
+    template <typename... Ts>
+    using signature_over_fs = boost::mp11::mp_apply<
+        detail::as_signature,
+        boost::mp11::mp_remove_if<
+            completion_signatures<std::invoke_result_t<Fs, Ts...>...>,
+            std::is_void>>;
+
+    template <typename Env>
+    [[nodiscard]] constexpr static auto get_completion_signatures(Env const &) {
+        return transform_completion_signatures_of<
+            S, Env, completion_signatures<>, signature_over_fs>{};
+    }
+
+    using is_sender = void;
+
+    [[no_unique_address]] S s;
+    [[no_unique_address]] stdx::tuple<Fs...> fs;
+
+    [[nodiscard]] constexpr auto query(get_env_t) const {
+        return forward_env_of(s);
+    }
+};
+
+template <stdx::ct_string Name, typename... Fs> struct pipeable {
+    stdx::tuple<Fs...> fs;
+
+  private:
+    template <async::sender S, stdx::same_as_unqualified<pipeable> Self>
+    friend constexpr auto operator|(S &&s, Self &&self) -> async::sender auto {
+        return sender<Name, std::remove_cvref_t<S>, Fs...>{
+            std::forward<S>(s), std::forward<Self>(self).fs};
+    }
+};
+} // namespace _then_each
+
+template <stdx::ct_string Name = "then_each", stdx::callable... Fs>
+[[nodiscard]] constexpr auto then_each(Fs &&...fs) {
+    return compose(_then_each::pipeable<Name, std::remove_cvref_t<Fs>...>{
+        std::forward<Fs>(fs)...});
+}
+
+template <stdx::ct_string Name = "then_each", sender S, stdx::callable... Fs>
+[[nodiscard]] constexpr auto then_each(S &&s, Fs &&...fs) -> sender auto {
+    return std::forward<S>(s) | then_each<Name>(std::forward<Fs>(fs)...);
+}
+
+struct then_each_t;
+
+template <stdx::ct_string Name, typename... Ts>
+struct debug::context_for<_then_each::receiver<Name, Ts...>> {
+    using tag = then_each_t;
+    constexpr static auto name = Name;
+    using type = _then_each::receiver<Name, Ts...>;
+    using children = stdx::type_list<debug::erased_context_for<
+        connect_result_t<typename type::sender_t &&, type &&>>>;
+};
+} // namespace async

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -49,6 +49,7 @@ add_tests(
     start_on
     stop_token
     then
+    then_each
     timeout_after
     transform_error
     type_traits

--- a/test/then_each.cpp
+++ b/test/then_each.cpp
@@ -1,0 +1,207 @@
+#include "detail/common.hpp"
+#include "detail/debug_handler.hpp"
+
+#include <async/connect.hpp>
+#include <async/just.hpp>
+#include <async/schedulers/inline_scheduler.hpp>
+#include <async/then_each.hpp>
+
+#include <catch2/catch_test_macros.hpp>
+
+TEST_CASE("then_each", "[then_each]") {
+    int value{};
+
+    auto s = async::just();
+    auto n = async::then_each(s, [] { return 42; }, [] { return 17; });
+    auto op =
+        async::connect(n, receiver{[&](auto i, auto j) { value = i + j; }});
+    async::start(op);
+    CHECK(value == 59);
+}
+
+TEST_CASE("then_each propagates a value", "[then_each]") {
+    int value{};
+
+    auto s = async::just(42);
+    auto n = async::then_each(
+        s, [](auto i) { return i * 2; }, [](auto i) { return i + 1; });
+    auto op =
+        async::connect(n, receiver{[&](auto i, auto j) { value = i + j; }});
+    async::start(op);
+    CHECK(value == 127);
+}
+
+TEST_CASE("then_each advertises what it sends", "[then_each]") {
+    auto s = async::just();
+    [[maybe_unused]] auto n =
+        async::then_each(s, [] { return 42; }, [] { return 3.14f; });
+    STATIC_REQUIRE(
+        async::sender_of<decltype(n), async::set_value_t(int, float)>);
+}
+
+TEST_CASE("then_each can send a reference", "[then_each]") {
+    int value{};
+    auto s = async::just();
+    [[maybe_unused]] auto n = async::then_each(
+        s, [&]() -> int & { return value; }, [&]() -> int & { return value; });
+    STATIC_REQUIRE(
+        async::sender_of<decltype(n), async::set_value_t(int &, int &)>);
+}
+
+TEST_CASE("then_each is pipeable", "[then_each]") {
+    int value{};
+
+    auto n =
+        async::just() | async::then_each([] { return 42; }, [] { return 17; });
+    auto op =
+        async::connect(n, receiver{[&](auto i, auto j) { value = i + j; }});
+    async::start(op);
+    CHECK(value == 59);
+}
+
+TEST_CASE("then_each is adaptor-pipeable", "[then_each]") {
+    int value{};
+
+    auto n = async::then_each([] { return 42; }, [] { return 17; }) |
+             async::then_each([](int i, int j) { return i + j; },
+                              [](int i, int j) { return i - j; });
+    auto op = async::connect(async::just() | n,
+                             receiver{[&](auto i, auto j) { value = i + j; }});
+    async::start(op);
+    CHECK(value == 84);
+}
+
+TEST_CASE("then_each can send nothing", "[then_each]") {
+    int value{};
+
+    auto s = async::just();
+    auto n1 = async::then_each(s, [] {});
+    STATIC_REQUIRE(async::sender_of<decltype(n1), async::set_value_t()>);
+    auto n2 = async::then_each(n1, [] {}, [] {});
+    STATIC_REQUIRE(async::sender_of<decltype(n2), async::set_value_t()>);
+    auto op = async::connect(n2, receiver{[&] { value = 42; }});
+    async::start(op);
+    CHECK(value == 42);
+}
+
+TEST_CASE("then_each deals with void-returning functions", "[then_each]") {
+    int value{};
+
+    auto s = async::just(42) |
+             async::then_each([](auto i) { return i * 2; }, [](auto) {},
+                              [](auto i) { return i + 1; });
+    auto op =
+        async::connect(s, receiver{[&](auto i, auto j) { value = i + j; }});
+    async::start(op);
+    CHECK(value == 127);
+}
+
+TEST_CASE("move-only value", "[then_each]") {
+    int value{};
+
+    auto n = async::just() | async::then_each([] { return move_only{42}; });
+    auto op = async::connect(std::move(n),
+                             receiver{[&](auto mo) { value = mo.value; }});
+    async::start(op);
+    CHECK(value == 42);
+}
+
+TEST_CASE("move-only lambda", "[then_each]") {
+    int value{};
+    auto n =
+        async::just() |
+        async::then_each([mo = move_only{42}]() -> move_only<int> const && {
+            return std::move(mo);
+        });
+    STATIC_REQUIRE(async::singleshot_sender<decltype(n), universal_receiver>);
+    auto op = async::connect(std::move(n),
+                             receiver{[&](auto &&mo) { value = mo.value; }});
+    async::start(op);
+    CHECK(value == 42);
+}
+
+TEST_CASE("single-shot sender", "[then_each]") {
+    [[maybe_unused]] auto n = async::inline_scheduler<>::schedule<
+                                  async::inline_scheduler<>::singleshot>() |
+                              async::then_each([] {});
+    STATIC_REQUIRE(async::singleshot_sender<decltype(n), universal_receiver>);
+}
+
+TEST_CASE("then_each propagates error", "[then_each]") {
+    bool then_each_called{};
+    int value{};
+
+    auto s = async::just_error(42) |
+             async::then_each([&] { then_each_called = true; });
+    STATIC_REQUIRE(
+        std::same_as<async::completion_signatures_of_t<decltype(s)>,
+                     async::completion_signatures<async::set_error_t(int)>>);
+    auto op = async::connect(s, error_receiver{[&](auto i) { value = i; }});
+    async::start(op);
+    CHECK(value == 42);
+    CHECK(not then_each_called);
+}
+
+TEST_CASE("then_each propagates stopped", "[then_each]") {
+    bool then_each_called{};
+    int value{};
+
+    auto s = async::just_stopped() |
+             async::then_each([&] { then_each_called = true; });
+    STATIC_REQUIRE(
+        std::same_as<async::completion_signatures_of_t<decltype(s)>,
+                     async::completion_signatures<async::set_stopped_t()>>);
+    auto op = async::connect(s, stopped_receiver{[&] { value = 42; }});
+    async::start(op);
+    CHECK(value == 42);
+    CHECK(not then_each_called);
+}
+
+TEST_CASE("then_each propagates forwarding queries to its child environment",
+          "[then_each]") {
+    auto s = custom_sender{};
+    CHECK(get_fwd(async::get_env(s)) == 42);
+
+    auto t = async::then_each(s, [] {});
+    CHECK(get_fwd(async::get_env(t)) == 42);
+}
+
+TEST_CASE("then_each can handle a reference", "[then_each]") {
+    int value{};
+    auto s = async::just() | async::then_each([&]() -> int & { return value; });
+    auto op =
+        async::connect(s, receiver{[&](auto &i) {
+                           CHECK(std::addressof(value) == std::addressof(i));
+                       }});
+    async::start(op);
+}
+
+template <>
+inline auto async::injected_debug_handler<> =
+    debug_handler<async::then_each_t>{};
+
+TEST_CASE("then_each can be debugged with a string", "[then_each]") {
+    using namespace std::string_literals;
+    debug_events.clear();
+
+    auto s = async::just() | async::then_each([] {});
+    auto op = async::connect(
+        s, with_env{universal_receiver{},
+                    async::prop{async::get_debug_interface_t{},
+                                async::debug::named_interface<"op">{}}});
+    async::start(op);
+    CHECK(debug_events == std::vector{"op then_each set_value"s});
+}
+
+TEST_CASE("then_each can be named and debugged with a string", "[then_each]") {
+    using namespace std::string_literals;
+    debug_events.clear();
+
+    auto s = async::just() | async::then_each<"then_each_name">([] {});
+    auto op = async::connect(
+        s, with_env{universal_receiver{},
+                    async::prop{async::get_debug_interface_t{},
+                                async::debug::named_interface<"op">{}}});
+    async::start(op);
+    CHECK(debug_events == std::vector{"op then_each_name set_value"s});
+}


### PR DESCRIPTION
Problem:
- Sometimes you want to take a value sent and use it multiple ways. There are ways to do this with `let_value` or `when_all`, but they aren't obvious.

Solution:
- Add `then_each`, which takes what is sent, and passes it to each of a number of functions, sending all the results downstream.