### PR TITLE
:sparkles: Add `then_error`

### DIFF
--- a/docs/sender_adaptors.adoc
+++ b/docs/sender_adaptors.adoc
@@ -571,6 +571,19 @@ auto then_each_sndr = async::then_each(sndr,
 // when run, then_each_sndr will produce values "42" and 43
 ----
 
+=== `then_error`
+
+Found in the header: `async/then.hpp`
+
+`then_error` works just like `then`, but it completes on the error channel.
+
+[source,cpp]
+----
+auto sndr = async::just(42);
+auto then_error_sndr = async::then_error(sndr, [] (int i) { return std::to_string(i); });
+// when run, then_error_sndr will call set_error with the string "42"
+----
+
 === `timeout_after`
 
 Found in the header: `async/timeout_after.hpp`

--- a/docs/synopsis.adoc
+++ b/docs/synopsis.adoc
@@ -195,6 +195,7 @@ xref:schedulers.adoc#_time_scheduler[time_scheduler].
 
 ==== https://github.com/intel/cpp-baremetal-senders-and-receivers/blob/main/include/async/then.hpp[then.hpp]
 * `then` - a xref:sender_adaptors.adoc#_then[sender adaptor] that transforms what a sender sends on the value channel
+* `then_error` - a xref:sender_adaptors.adoc#_then_error[sender adaptor] that transforms what a sender sends on the value channel, and completes on the error channel
 * `transform error` - a xref:sender_adaptors.adoc#_transform_error[sender adaptor] that transforms what a sender sends on the error channel
 * `upon error` - a xref:sender_adaptors.adoc#_upon_error[sender adaptor] that transforms what a sender sends on the error channel, and completes on the value channel
 * `upon stopped` - a xref:sender_adaptors.adoc#_upon_stopped[sender adaptor] that transforms what a sender sends on the stopped channel, and completes on the value channel
@@ -307,6 +308,7 @@ contains traits and metaprogramming constructs used by many senders.
 * `task_mgr::service_tasks<P>()` - https://github.com/intel/cpp-baremetal-senders-and-receivers/blob/main/include/async/schedulers/task_manager_interface.hpp[`#include <async/schedulers/task_manager_interface.hpp>`]
 * xref:sender_adaptors.adoc#_then[`then`] - https://github.com/intel/cpp-baremetal-senders-and-receivers/blob/main/include/async/then.hpp[`#include <async/then.hpp>`]
 * xref:sender_adaptors.adoc#_then_each[`then_each`] - https://github.com/intel/cpp-baremetal-senders-and-receivers/blob/main/include/async/then_each.hpp[`#include <async/then_each.hpp>`]
+* xref:sender_adaptors.adoc#_then_error[`then_error`] - https://github.com/intel/cpp-baremetal-senders-and-receivers/blob/main/include/async/then.hpp[`#include <async/then.hpp>`]
 * xref:schedulers.adoc#_thread_scheduler[`thread_scheduler`] - https://github.com/intel/cpp-baremetal-senders-and-receivers/blob/main/include/async/schedulers/thread_scheduler.hpp[`#include <async/schedulers/thread_scheduler.hpp>`]
 * xref:schedulers.adoc#_time_scheduler[`time_scheduler`] - https://github.com/intel/cpp-baremetal-senders-and-receivers/blob/main/include/async/schedulers/time_scheduler.hpp[`#include <async/schedulers/time_scheduler.hpp>`]
 * xref:sender_adaptors.adoc#_timeout_after[`timeout_after`] - https://github.com/intel/cpp-baremetal-senders-and-receivers/blob/main/include/async/timeout_after.hpp[`#include <async/timeout_after.hpp>`]

--- a/include/async/then.hpp
+++ b/include/async/then.hpp
@@ -307,6 +307,18 @@ template <stdx::ct_string Name = "upon_stopped", sender S, stdx::callable F>
     return std::forward<S>(s) | upon_stopped<Name>(std::forward<F>(f));
 }
 
+template <stdx::ct_string Name = "then_error", stdx::callable... Fs>
+[[nodiscard]] constexpr auto then_error(Fs &&...fs) {
+    return compose(
+        _then::pipeable<Name, set_value_t, set_error_t,
+                        std::remove_cvref_t<Fs>...>{std::forward<Fs>(fs)...});
+}
+
+template <stdx::ct_string Name = "then_error", sender S, stdx::callable... Fs>
+[[nodiscard]] constexpr auto then_error(S &&s, Fs &&...fs) -> sender auto {
+    return std::forward<S>(s) | then_error<Name>(std::forward<Fs>(fs)...);
+}
+
 template <stdx::ct_string Name = "transform_error", stdx::callable... Fs>
 [[nodiscard]] constexpr auto transform_error(Fs &&...fs) {
     return compose(
@@ -324,6 +336,7 @@ struct then_t;
 struct upon_error_t;
 struct upon_stopped_t;
 
+struct then_error_t;
 struct transform_error_t;
 
 namespace _then {
@@ -340,6 +353,9 @@ template <> struct debug_tag<set_stopped_t, set_value_t> {
     using type = upon_stopped_t;
 };
 
+template <> struct debug_tag<set_value_t, set_error_t> {
+    using type = then_error_t;
+};
 template <> struct debug_tag<set_error_t, set_error_t> {
     using type = transform_error_t;
 };

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -50,6 +50,7 @@ add_tests(
     stop_token
     then
     then_each
+    then_error
     timeout_after
     transform_error
     type_traits

--- a/test/then_error.cpp
+++ b/test/then_error.cpp
@@ -1,0 +1,275 @@
+#include "detail/common.hpp"
+#include "detail/debug_handler.hpp"
+
+#include <async/concepts.hpp>
+#include <async/connect.hpp>
+#include <async/env.hpp>
+#include <async/just.hpp>
+#include <async/just_result_of.hpp>
+#include <async/schedulers/inline_scheduler.hpp>
+#include <async/then.hpp>
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <concepts>
+#include <memory>
+#include <string>
+#include <utility>
+#include <vector>
+
+TEST_CASE("then_error", "[then_error]") {
+    int value{};
+
+    auto s = async::just();
+    auto n = async::then_error(s, [] { return 42; });
+    auto op = async::connect(n, error_receiver{[&](auto i) { value = i; }});
+    async::start(op);
+    CHECK(value == 42);
+}
+
+TEST_CASE("then_error propagates a value", "[then_error]") {
+    int value{};
+
+    auto s = async::just(42);
+    auto n = async::then_error(s, [](auto i) { return i * 2; });
+    auto op = async::connect(n, error_receiver{[&](auto i) { value = i; }});
+    async::start(op);
+    CHECK(value == 84);
+}
+
+TEST_CASE("then_error advertises what it sends", "[then_error]") {
+    auto s = async::just();
+    [[maybe_unused]] auto n = async::then_error(s, [] { return 42; });
+    STATIC_REQUIRE(async::sender_of<decltype(n), async::set_error_t(int)>);
+}
+
+TEST_CASE("then_error can send a reference", "[then_error]") {
+    int value{};
+    auto s = async::just();
+    [[maybe_unused]] auto n =
+        async::then_error(s, [&]() -> int & { return value; });
+    STATIC_REQUIRE(async::sender_of<decltype(n), async::set_error_t(int &)>);
+}
+
+TEST_CASE("then_error is pipeable", "[then_error]") {
+    int value{};
+
+    auto n = async::just() | async::then_error([] { return 42; });
+    auto op = async::connect(n, error_receiver{[&](auto i) { value = i; }});
+    async::start(op);
+    CHECK(value == 42);
+}
+
+TEST_CASE("then_error is adaptor-pipeable", "[then_error]") {
+    int value{};
+
+    auto n = async::then_error([] { return 42; }) |
+             async::transform_error([](int i) { return i * 2; });
+    auto op = async::connect(async::just() | n,
+                             error_receiver{[&](auto i) { value = i; }});
+    async::start(op);
+    CHECK(value == 84);
+}
+
+TEST_CASE("then_error can send nothing", "[then_error]") {
+    int value{};
+
+    auto s = async::just();
+    auto n1 = async::then_error(s, [] {});
+    STATIC_REQUIRE(async::sender_of<decltype(n1), async::set_error_t()>);
+    auto n2 = async::then_error(n1, [] {});
+    STATIC_REQUIRE(async::sender_of<decltype(n2), async::set_error_t()>);
+    auto op = async::connect(n2, error_receiver{[&] { value = 42; }});
+    async::start(op);
+    CHECK(value == 42);
+}
+
+TEST_CASE("move-only value", "[then_error]") {
+    int value{};
+
+    auto n = async::just() | async::then_error([] { return move_only{42}; });
+    auto op = async::connect(
+        std::move(n), error_receiver{[&](auto mo) { value = mo.value; }});
+    async::start(op);
+    CHECK(value == 42);
+}
+
+TEST_CASE("move-only lambda", "[then_error]") {
+    int value{};
+    auto n =
+        async::just() |
+        async::then_error([mo = move_only{42}]() -> move_only<int> const && {
+            return std::move(mo);
+        });
+    STATIC_REQUIRE(async::singleshot_sender<decltype(n), universal_receiver>);
+    auto op = async::connect(
+        std::move(n), error_receiver{[&](auto &&mo) { value = mo.value; }});
+    async::start(op);
+    CHECK(value == 42);
+}
+
+TEST_CASE("single-shot sender", "[then_error]") {
+    [[maybe_unused]] auto n = async::inline_scheduler<>::schedule<
+                                  async::inline_scheduler<>::singleshot>() |
+                              async::then_error([] {});
+    STATIC_REQUIRE(async::singleshot_sender<decltype(n), universal_receiver>);
+}
+
+TEST_CASE("then_error propagates error", "[then]") {
+    bool then_error_called{};
+    int value{};
+
+    auto s = async::just_error(42) |
+             async::then_error([&] { then_error_called = true; });
+    STATIC_REQUIRE(
+        std::same_as<async::completion_signatures_of_t<decltype(s)>,
+                     async::completion_signatures<async::set_error_t(int)>>);
+    auto op = async::connect(s, error_receiver{[&](auto i) { value = i; }});
+    async::start(op);
+    CHECK(value == 42);
+    CHECK(not then_error_called);
+}
+
+TEST_CASE("then_error propagates stopped", "[then_error]") {
+    bool then_error_called{};
+    int value{};
+
+    auto s = async::just_stopped() |
+             async::then_error([&] { then_error_called = true; });
+    STATIC_REQUIRE(
+        std::same_as<async::completion_signatures_of_t<decltype(s)>,
+                     async::completion_signatures<async::set_stopped_t()>>);
+    auto op = async::connect(s, stopped_receiver{[&] { value = 42; }});
+    async::start(op);
+    CHECK(value == 42);
+    CHECK(not then_error_called);
+}
+
+TEST_CASE("then_error propagates forwarding queries to its child environment ",
+          "[then_error]") {
+    auto s = custom_sender{};
+    CHECK(get_fwd(async::get_env(s)) == 42);
+
+    auto t = async::then_error(s, [] {});
+    CHECK(get_fwd(async::get_env(t)) == 42);
+}
+
+TEST_CASE("then_error advertises what it sends (variadic)", "[then_error]") {
+    auto s =
+        async::just(true, false) |
+        async::then_error([](auto) { return 42; }, [](auto) { return 17; });
+    STATIC_REQUIRE(async::sender_of<decltype(s), async::set_error_t(int, int)>);
+}
+
+TEST_CASE("then_error (variadic)", "[then_error]") {
+    int x{};
+    int y{};
+    auto s =
+        async::just(2, 3) | async::then_error([](auto i) { return i * 2; },
+                                              [](auto i) { return i * 3; });
+    auto op = async::connect(s, error_receiver{[&](auto i, auto j) {
+                                 x = i;
+                                 y = j;
+                             }});
+    async::start(op);
+    CHECK(x == 4);
+    CHECK(y == 9);
+}
+
+TEST_CASE("variadic then_error can have void-returning functions",
+          "[then_error]") {
+    int x{};
+    int y{42};
+    auto s = async::just(2, 3) |
+             async::then_error([](auto i) { return i * 2; }, [](auto) {});
+    STATIC_REQUIRE(async::sender_of<decltype(s), async::set_error_t(int)>);
+    auto op = async::connect(s, error_receiver{[&](auto i) { x = i; }});
+    async::start(op);
+    CHECK(x == 4);
+    CHECK(y == 42);
+}
+
+TEST_CASE("move-only value (from then_error) (variadic)", "[then_error]") {
+    int x{};
+    auto s =
+        async::just(2, 3) |
+        async::then_error([](auto i) { return move_only{i}; }, [](auto) {});
+    STATIC_REQUIRE(
+        async::sender_of<decltype(s), async::set_error_t(move_only<int>)>);
+    auto op = async::connect(s, error_receiver{[&](auto i) { x = i.value; }});
+    async::start(op);
+    CHECK(x == 2);
+}
+
+TEST_CASE("move-only value (to then_error) (variadic)", "[then_error]") {
+    int x{};
+    auto s = async::just(move_only{2}, move_only{3}) |
+             async::then_error([](auto i) { return i.value; }, [](auto) {});
+    STATIC_REQUIRE(async::sender_of<decltype(s), async::set_error_t(int)>);
+    auto op =
+        async::connect(std::move(s), error_receiver{[&](auto i) { x = i; }});
+    async::start(op);
+    CHECK(x == 2);
+}
+
+TEST_CASE("variadic then_error can take heteroadic functions", "[then_error]") {
+    int x{};
+    int y{42};
+    bool z{};
+    auto s = async::just(2, 3, 4) |
+             async::then_error([](auto i, auto j) { return i + j; },
+                               [](auto k) { return k; }, [] { return true; });
+    STATIC_REQUIRE(
+        async::sender_of<decltype(s), async::set_error_t(int, int, bool)>);
+    auto op = async::connect(s, error_receiver{[&](auto i, auto j, auto k) {
+                                 x = i;
+                                 y = j;
+                                 z = k;
+                             }});
+    async::start(op);
+    CHECK(x == 5);
+    CHECK(y == 4);
+    CHECK(z);
+}
+
+TEST_CASE("then_error can handle a reference", "[then_error]") {
+    int value{};
+    auto s =
+        async::just() | async::then_error([&]() -> int & { return value; });
+    auto op =
+        async::connect(s, error_receiver{[&](auto &i) {
+                           CHECK(std::addressof(value) == std::addressof(i));
+                       }});
+    async::start(op);
+}
+
+template <>
+inline auto async::injected_debug_handler<> =
+    debug_handler<async::then_error_t>{};
+
+TEST_CASE("then_error can be debugged with a string", "[then_error]") {
+    using namespace std::string_literals;
+    debug_events.clear();
+
+    auto s = async::just() | async::then_error([] {});
+    auto op = async::connect(
+        s, with_env{universal_receiver{},
+                    async::prop{async::get_debug_interface_t{},
+                                async::debug::named_interface<"op">{}}});
+    async::start(op);
+    CHECK(debug_events == std::vector{"op then_error set_error"s});
+}
+
+TEST_CASE("then_error can be named and debugged with a string",
+          "[then_error]") {
+    using namespace std::string_literals;
+    debug_events.clear();
+
+    auto s = async::just() | async::then_error<"then_error_name">([] {});
+    auto op = async::connect(
+        s, with_env{universal_receiver{},
+                    async::prop{async::get_debug_interface_t{},
+                                async::debug::named_interface<"op">{}}});
+    async::start(op);
+    CHECK(debug_events == std::vector{"op then_error_name set_error"s});
+}


### PR DESCRIPTION
Problem:
- There is no easy way to transform something on the value channel into an error. `upon_error` goes the other way; from the error channel to the value channel.

Solution:
- Add `then_error`.