### PR TITLE
:construction_worker: Protect against boost_mp11 coming from boost

### DIFF
--- a/.github/workflows/usage_test.yml
+++ b/.github/workflows/usage_test.yml
@@ -12,7 +12,7 @@ on:
 env:
   DEBIAN_FRONTEND: noninteractive
   CMAKE_GENERATOR: Ninja
-  USER_CMAKE_VERSION: 3.25
+  USER_CMAKE_VERSION: 3.27
 
 jobs:
   usage_test:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,9 +15,9 @@ else()
     cpmaddpackage("gh:intel/cicd-repo-infrastructure#3e2bef0")
 endif()
 
+add_versioned_package(URI "gh:boostorg/mp11#boost-1.83.0" TARGET boost_mp11)
 add_versioned_package("gh:intel/cpp-baremetal-concurrency#63230eb")
 add_versioned_package("gh:intel/cpp-std-extensions#2b7917f")
-add_versioned_package("gh:boostorg/mp11#boost-1.83.0")
 
 if(NOT DEFINED CMAKE_CXX_STANDARD)
     set(CMAKE_CXX_STANDARD 23)

--- a/usage_test/CMakeLists.txt
+++ b/usage_test/CMakeLists.txt
@@ -7,7 +7,10 @@ message(STATUS "Actual cmake version: ${CMAKE_VERSION}")
 project(conc_usage)
 
 include(${CMAKE_CURRENT_LIST_DIR}/../cmake/get_cpm.cmake)
-cpmaddpackage(NAME async SOURCE_DIR "${CMAKE_CURRENT_LIST_DIR}/.." GIT_TAG HEAD)
+cpmaddpackage("gh:intel/cicd-repo-infrastructure#dev")
+
+add_versioned_package(NAME async SOURCE_DIR "${CMAKE_CURRENT_LIST_DIR}/.."
+                      GIT_TAG HEAD)
 
 add_executable(app main.cpp)
 target_link_libraries(app PRIVATE async)


### PR DESCRIPTION
Problem:
- When `boost` is already fetched as a dependency and the `boost_mp11` target exists, fetching `boost_mp11` fails.

Solution:
- Allow `boost_mp11` target to exist.