### PR TITLE
:fire: Replace old compiler macros

### DIFF
--- a/include/async/concepts.hpp
+++ b/include/async/concepts.hpp
@@ -8,7 +8,6 @@
 #include <async/stop_token.hpp>
 #include <async/type_traits.hpp>
 
-#include <stdx/compiler.hpp>
 #include <stdx/concepts.hpp>
 #include <stdx/function_traits.hpp>
 #include <stdx/type_traits.hpp>
@@ -169,7 +168,7 @@ concept scheduler = queryable<S> and
                     } and std::equality_comparable<std::remove_cvref_t<S>> and
                     std::copy_constructible<std::remove_cvref_t<S>>;
 
-template <typename S, typename R> CONSTEVAL auto check_connect() -> void {
+template <typename S, typename R> consteval auto check_connect() -> void {
     if constexpr (not receiver_from<R, S>) {
         static_assert(
             stdx::always_false_v<S, R,

--- a/include/async/when_any.hpp
+++ b/include/async/when_any.hpp
@@ -10,7 +10,6 @@
 #include <async/type_traits.hpp>
 
 #include <stdx/atomic.hpp>
-#include <stdx/compiler.hpp>
 #include <stdx/concepts.hpp>
 #include <stdx/ct_string.hpp>
 #include <stdx/functional.hpp>
@@ -419,7 +418,7 @@ template <stdx::ct_string Name, typename StopPolicy, typename... Sndrs>
 struct sender : Sndrs... {
     using is_sender = void;
 
-    template <typename Env> CONSTEVAL static auto check_completeable() -> void {
+    template <typename Env> consteval static auto check_completeable() -> void {
         static_assert(
             not boost::mp11::mp_any<std::is_same<
                 completion_signatures<>,


### PR DESCRIPTION
Problem:
- `consteval` and `constinit` have full support in our supported compilers, but we're still using `CONSTEVAL` and `CONSTINIT`.

Solution:
- Remove uses of `CONSTEVAL` and `CONSTINIT`.