### PR TITLE
:sparkles: Add `cancel_triggers`

### DIFF
--- a/include/async/schedulers/trigger_manager.hpp
+++ b/include/async/schedulers/trigger_manager.hpp
@@ -23,6 +23,7 @@ template <typename... Args> struct trigger_task {
     trigger_task *next{};
 
     virtual auto run(Args const &...) -> void = 0;
+    virtual auto cancel() -> void = 0;
 
     constexpr trigger_task() = default;
     constexpr trigger_task(trigger_task &&) = delete;
@@ -34,26 +35,42 @@ template <typename... Args> struct trigger_task {
     }
 };
 
+namespace detail {
+struct runner {
+    template <typename... Args>
+    static auto complete(auto task, Args &&...args) -> void {
+        task->run(std::forward<Args>(args)...);
+    }
+};
+
+struct canceller {
+    template <typename... Args>
+    static auto complete(auto task, Args &&...) -> void {
+        task->cancel();
+    }
+};
+} // namespace detail
+
 namespace run_policy {
 struct one {
-    template <typename, typename M, typename... Args>
+    template <typename, typename Completer, typename M, typename... Args>
     static auto run(auto &&tasks, auto &count, Args &&...args) {
         using RQP = requeue_policy::immediate;
         decltype(auto) q = RQP::template get_queue<0, M>(tasks);
         if (auto task = RQP::template pop<M>(q); task) {
-            task->run(std::forward<Args>(args)...);
+            Completer::complete(task, std::forward<Args>(args)...);
             --count;
         }
     }
 };
 
 struct all {
-    template <typename RQP, typename M, typename... Args>
+    template <typename RQP, typename Completer, typename M, typename... Args>
     static auto run(auto &&tasks, auto &count, Args &&...args) {
         decltype(auto) q = RQP::template get_queue<0, M>(tasks);
         for (auto task = RQP::template pop<M>(q); task;
              task = RQP::template pop<M>(q)) {
-            task->run(args...);
+            Completer::complete(task, args...);
             --count;
         }
     }
@@ -92,11 +109,12 @@ template <typename Name, typename... Args> struct trigger_manager {
     }
 
     template <typename RQP = requeue_policy::deferred,
-              typename RunPolicy = run_policy::all, typename... As>
+              typename RunPolicy = run_policy::all,
+              typename Completer = detail::runner, typename... As>
     auto run(As &&...args) -> void {
         static_assert((... and std::same_as<Args, std::remove_cvref_t<As>>));
-        RunPolicy::template run<RQP, mutex>(tasks, task_count,
-                                            std::forward<As>(args)...);
+        RunPolicy::template run<RQP, Completer, mutex>(
+            tasks, task_count, std::forward<As>(args)...);
     }
 
     [[nodiscard]] auto empty() const -> bool { return task_count == 0; }
@@ -117,6 +135,15 @@ template <stdx::ct_string Name, typename RQP = requeue_policy::deferred,
 auto run_triggers(Args &&...args) -> void {
     run_triggers<stdx::cts_t<Name>, RQP, RunPolicy>(
         std::forward<Args>(args)...);
+}
+
+template <typename Name, typename... Args> auto cancel_triggers() -> void {
+    triggers<Name, Args...>.template run<requeue_policy::deferred, run_policy::all, detail::canceller>();
+}
+
+template <stdx::ct_string Name, typename... Args>
+auto cancel_triggers() -> void {
+    cancel_triggers<stdx::cts_t<Name>, Args...>();
 }
 
 template <typename Name, typename RQP = requeue_policy::deferred,

--- a/include/async/schedulers/trigger_scheduler.hpp
+++ b/include/async/schedulers/trigger_scheduler.hpp
@@ -81,6 +81,11 @@ struct op_state final : op_state_base<Rcvr, op_state<Name, Rcvr, Args...>>,
         set_value(std::move(rcvr), args...);
     }
 
+    auto cancel() -> void final {
+        this->clear_stop_cb();
+        complete_stopped();
+    }
+
     constexpr auto start() & -> void {
         debug_signal<"start", debug::erased_context_for<op_state>>(
             get_env(rcvr));
@@ -110,24 +115,13 @@ template <typename S, typename Name, typename... Args> class scheduler {
     struct sender {
         using is_sender = void;
 
+        using completion_signatures =
+            async::completion_signatures<set_value_t(Args const &...),
+                                         set_stopped_t()>;
+
         [[nodiscard]] constexpr auto query(get_env_t) const noexcept {
-            return prop{get_completion_scheduler_t<set_value_t>{}, S{}};
-        }
-
-        template <typename Env>
-        [[nodiscard]] constexpr static auto
-        get_completion_signatures(Env const &) noexcept
-            -> completion_signatures<set_value_t(Args const &...),
-                                     set_stopped_t()> {
-            return {};
-        }
-
-        template <typename Env>
-            requires unstoppable_token<stop_token_of_t<Env>>
-        [[nodiscard]] constexpr static auto
-        get_completion_signatures(Env const &) noexcept
-            -> completion_signatures<set_value_t(Args const &...)> {
-            return {};
+            return env{prop{get_completion_scheduler_t<set_value_t>{}, S{}},
+                       prop{get_completion_scheduler_t<set_stopped_t>{}, S{}}};
         }
 
         template <receiver R>

--- a/test/schedulers/trigger_scheduler.cpp
+++ b/test/schedulers/trigger_scheduler.cpp
@@ -34,20 +34,22 @@ constexpr auto type_string =
 } // namespace
 
 TEST_CASE("trigger_scheduler fulfils concept", "[trigger_scheduler]") {
-    static_assert(async::scheduler<async::trigger_scheduler<"name">>);
+    STATIC_CHECK(async::scheduler<async::trigger_scheduler<"name">>);
 }
 
 TEMPLATE_TEST_CASE("trigger_scheduler sender advertises nothing",
                    "[trigger_scheduler]", decltype([] {})) {
-    static_assert(async::sender_of<decltype(async::trigger_scheduler<
-                                            type_string<TestType>>::schedule()),
-                                   async::set_value_t()>);
+    using expected_t = async::completion_signatures<async::set_value_t(),
+                                                    async::set_stopped_t()>;
+    using actual_t = async::completion_signatures_of_t<
+        decltype(async::trigger_scheduler<type_string<TestType>>::schedule())>;
+    STATIC_CHECK(std::same_as<actual_t, expected_t>);
 }
 
 TEMPLATE_TEST_CASE(
     "trigger_scheduler sender advertises args that will be used to trigger it",
     "[trigger_scheduler]", decltype([] {})) {
-    static_assert(
+    STATIC_CHECK(
         async::sender_of<decltype(async::trigger_scheduler<
                                   type_string<TestType>, int>::schedule()),
                          async::set_value_t(int const &)>);
@@ -60,7 +62,7 @@ TEMPLATE_TEST_CASE(
     auto s = S::schedule();
     auto cs =
         async::get_completion_scheduler<async::set_value_t>(async::get_env(s));
-    static_assert(std::same_as<decltype(cs), S>);
+    STATIC_CHECK(std::same_as<decltype(cs), S>);
 }
 
 TEMPLATE_TEST_CASE("trigger_scheduler schedules tasks", "[trigger_scheduler]",
@@ -132,6 +134,22 @@ TEMPLATE_TEST_CASE("trigger_scheduler is cancellable after start",
     CHECK(async::triggers<stdx::cts_t<name>>.empty());
 }
 
+TEMPLATE_TEST_CASE("trigger_scheduler is cancellable by cancel_triggers",
+                   "[trigger_scheduler]", decltype([] {})) {
+    constexpr auto name = type_string<TestType>;
+    auto s = async::trigger_scheduler<name>{};
+    int var{};
+    async::sender auto sndr =
+        async::start_on(s, async::just_result_of([&] { var = 42; }));
+    auto r = stopped_receiver{[&] { var = 17; }};
+    auto op = async::connect(sndr, r);
+
+    async::start(op);
+    async::cancel_triggers<name>();
+    CHECK(var == 17);
+    CHECK(async::triggers<stdx::cts_t<name>>.empty());
+}
+
 TEST_CASE("request and response", "[trigger_scheduler]") {
     int var{};
 
@@ -173,9 +191,9 @@ struct debug_handler {
     auto signal(auto &&...) {
         if constexpr (std::is_same_v<async::debug::tag_of<Ctx>,
                                      async::trigger_scheduler_sender_t>) {
-            static_assert(
-                boost::mp11::mp_empty<async::debug::children_of<Ctx>>::value);
             std::lock_guard lock{m};
+            STATIC_CHECK(
+                boost::mp11::mp_empty<async::debug::children_of<Ctx>>::value);
             debug_events.push_back(
                 fmt::format("{} {} {}", C, async::debug::name_of<Ctx>, S));
         }


### PR DESCRIPTION
Problem:
- There is not an easy way to cancel all triggers for a given stimulus.

Solution:
- Add `cancel_triggers`.

Note:
- The trigger scheduler can now always complete with `set_stopped` regardless of the `stop_token` in the connected receiver.