### PR TITLE
:bug: Fix CICD version for non-top-level build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,7 +12,7 @@ include(cmake/get_cpm.cmake)
 if(PROJECT_IS_TOP_LEVEL)
     cpmaddpackage("gh:intel/cicd-repo-infrastructure#dev")
 else()
-    cpmaddpackage("gh:intel/cicd-repo-infrastructure#3e2bef0")
+    cpmaddpackage("gh:intel/cicd-repo-infrastructure#6021593")
 endif()
 
 add_versioned_package(URI "gh:boostorg/mp11#boost-1.83.0" TARGET boost_mp11)


### PR DESCRIPTION
Problem:
- When using this project as a dependency, the CICD repo version is out of date.

Solution:
- Update to latest.