### PR TITLE
:boom: Genericize `just`

### DIFF
--- a/docs/sender_factories.adoc
+++ b/docs/sender_factories.adoc
@@ -13,12 +13,14 @@ auto sndr = async::just(42, 17);
 // sndr produces (sends) the values 42 and 17
 ----
 
-`just` can be given a name that is used for debug events. By default, its name
-is `"just"`.
+By default, `just` sends on the value channel, but it can send on any channel.
+This is useful for generic code. It can also be given a name that is used for
+debug events. By default, its name is either `"just"`, `"just_error"` or
+`"just_stopped"` according to the channel selected.
 
 [source,cpp]
 ----
-auto sndr = async::just<"the answer">(42);
+auto sndr = async::just<set_value_t, "the answer">(42);
 ----
 
 [NOTE]
@@ -32,8 +34,7 @@ continuation monad.
 
 Found in the header: `async/just.hpp`
 
-`just_error` is like `just`, but instead of completing by calling `set_value` on
-a receiver, it will call `set_error`.
+`just_error` is `just<set_error_t>`.
 
 [source,cpp]
 ----
@@ -129,8 +130,7 @@ auto s = async::just() | async::then([] { return 42; });
 
 Found in the header: `async/just.hpp`
 
-`just_stopped` is like `just`, but instead of completing by calling `set_value` on
-a receiver, it will call `set_stopped`.
+`just_stopped` is `just<set_stopped_t>`.
 
 [source,cpp]
 ----
@@ -144,6 +144,26 @@ is `"just_stopped"`.
 [source,cpp]
 ----
 auto sndr = async::just_stopped<"cancel">();
+----
+
+=== `just_value`
+
+Found in the header: `async/just.hpp`
+
+`just_value` is `just<set_value_t>`.
+
+[source,cpp]
+----
+auto sndr = async::just_value(42);
+// sndr produces (sends) the value 42 on the value channel
+----
+
+`just_value` can be given a name that is used for debug events. By default, its name
+is `"just_value"`.
+
+[source,cpp]
+----
+auto sndr = async::just_value<"oops">(42);
 ----
 
 === `read_env`

--- a/docs/synopsis.adoc
+++ b/docs/synopsis.adoc
@@ -65,9 +65,10 @@
 * `into_variant` - a xref:sender_adaptors.adoc#_into_variant[sender adaptor] that collapses value completions into a variant
 
 ==== https://github.com/intel/cpp-baremetal-senders-and-receivers/blob/main/include/async/just.hpp[just.hpp]
-* `just` - a xref:sender_factories.adoc#_just[sender factory] that sends on the value channel
+* `just` - a xref:sender_factories.adoc#_just[sender factory] that sends on the selected channel (value by default)
 * `just_error` - a xref:sender_factories.adoc#_just_error[sender factory] that sends on the error channel
 * `just_stopped` - a xref:sender_factories.adoc#_just_stopped[sender factory] that sends on the stopped channel
+* `just_value` - a xref:sender_factories.adoc#_just[sender factory] that sends on the value channel
 
 ==== https://github.com/intel/cpp-baremetal-senders-and-receivers/blob/main/include/async/just_result_of.hpp[just_result_of.hpp]
 * `just_error_result_of` - a xref:sender_factories.adoc#_just_error_result_of[sender factory] that sends lazily computed values on the error channel
@@ -253,6 +254,7 @@ contains traits and metaprogramming constructs used by many senders.
 * xref:sender_factories.adoc#_just_error_result_of[`just_error_result_of`] - https://github.com/intel/cpp-baremetal-senders-and-receivers/blob/main/include/async/just_result_of.hpp[`#include <async/just_result_of.hpp>`]
 * xref:sender_factories.adoc#_just_result_of[`just_result_of`] - https://github.com/intel/cpp-baremetal-senders-and-receivers/blob/main/include/async/just_result_of.hpp[`#include <async/just_result_of.hpp>`]
 * xref:sender_factories.adoc#_just_stopped[`just_stopped`] - https://github.com/intel/cpp-baremetal-senders-and-receivers/blob/main/include/async/just.hpp[`#include <async/just.hpp>`]
+* xref:sender_factories.adoc#_just_value[`just_value`] - https://github.com/intel/cpp-baremetal-senders-and-receivers/blob/main/include/async/just.hpp[`#include <async/just.hpp>`]
 * xref:sender_adaptors.adoc#_let_error[`let_error`] - https://github.com/intel/cpp-baremetal-senders-and-receivers/blob/main/include/async/let_error.hpp[`#include <async/let_error.hpp>`]
 * xref:sender_adaptors.adoc#_let_stopped[`let_stopped`] - https://github.com/intel/cpp-baremetal-senders-and-receivers/blob/main/include/async/let_stopped.hpp[`#include <async/let_stopped.hpp>`]
 * xref:sender_adaptors.adoc#_let_value[`let_value`] - https://github.com/intel/cpp-baremetal-senders-and-receivers/blob/main/include/async/let_value.hpp[`#include <async/let_value.hpp>`]

--- a/include/async/just.hpp
+++ b/include/async/just.hpp
@@ -63,32 +63,49 @@ template <stdx::ct_string Name, typename Tag, typename... Vs> struct sender {
         return prop{completes_synchronously_t{}, std::true_type{}};
     }
 };
+
+template <channel_tag Tag> constexpr inline auto name = stdx::ct_string{""};
+
+template <>
+constexpr inline auto name<set_value_t> = stdx::ct_string{"just_value"};
+template <>
+constexpr inline auto name<set_error_t> = stdx::ct_string{"just_error"};
+template <>
+constexpr inline auto name<set_stopped_t> = stdx::ct_string{"just_stopped"};
 } // namespace _just
 
-template <stdx::ct_string Name = "just", typename... Vs>
+template <channel_tag Tag = set_value_t,
+          stdx::ct_string Name = _just::name<Tag>, typename... Vs>
 [[nodiscard]] constexpr auto just(Vs &&...vs) -> sender auto {
-    return _just::sender<Name, set_value_t, std::remove_cvref_t<Vs>...>{
+    static_assert(sizeof...(Vs) == 0 or not std::same_as<Tag, set_stopped_t>,
+                  "Can't send any values on the stopped channel");
+
+    return _just::sender<Name, Tag, std::remove_cvref_t<Vs>...>{
         {std::forward<Vs>(vs)...}};
 }
 
-template <stdx::ct_string Name = "just_error", typename... Vs>
+template <stdx::ct_string Name = _just::name<set_value_t>, typename... Vs>
+[[nodiscard]] constexpr auto just_value(Vs &&...vs) -> sender auto {
+    return just<set_value_t, Name>(std::forward<Vs>(vs)...);
+}
+
+template <stdx::ct_string Name = _just::name<set_error_t>, typename... Vs>
 [[nodiscard]] constexpr auto just_error(Vs &&...vs) -> sender auto {
-    return _just::sender<Name, set_error_t, std::remove_cvref_t<Vs>...>{
-        {std::forward<Vs>(vs)...}};
+    return just<set_error_t, Name>(std::forward<Vs>(vs)...);
 }
 
-template <stdx::ct_string Name = "just_stopped">
+template <stdx::ct_string Name = _just::name<set_stopped_t>>
 [[nodiscard]] constexpr auto just_stopped() -> sender auto {
-    return _just::sender<Name, set_stopped_t>{};
+    return just<set_stopped_t, Name>();
 }
 
-struct just_t;
+struct just_value_t;
 struct just_error_t;
 struct just_stopped_t;
 
 template <typename Tag>
 using just_tag_for =
-    stdx::conditional_t<std::same_as<Tag, set_value_t>, just_t,
+    stdx::conditional_t<std::same_as<Tag, set_value_t>, just_value_t,
                         stdx::conditional_t<std::same_as<Tag, set_error_t>,
                                             just_error_t, just_stopped_t>>;
 

--- a/include/async/variant_sender.hpp
+++ b/include/async/variant_sender.hpp
@@ -277,7 +277,7 @@ constexpr auto make_variant_sender(bool b, F1 &&f1, F2 &&f2) {
 
 template <stdx::callable F> constexpr auto make_optional_sender(bool b, F &&f) {
     return make_variant_sender(b, std::forward<F>(f),
-                               [] { return just<"opt-else">(); });
+                               [] { return just<set_value_t, "opt-else">(); });
 }
 
 struct variant_t;

--- a/test/just.cpp
+++ b/test/just.cpp
@@ -89,7 +89,7 @@ TEST_CASE("just op state is synchronous", "[just]") {
 
 template <>
 inline auto async::injected_debug_handler<> =
-    debug_handler<async::just_t, true>{};
+    debug_handler<async::just_value_t, true>{};
 
 TEST_CASE("just can be debugged with a string", "[just]") {
     using namespace std::string_literals;
@@ -100,13 +100,14 @@ TEST_CASE("just can be debugged with a string", "[just]") {
                     async::prop{async::get_debug_interface_t{},
                                 async::debug::named_interface<"op">{}}});
     async::start(op);
-    CHECK(debug_events == std::vector{"op just start"s, "op just set_value"s});
+    CHECK(debug_events ==
+          std::vector{"op just_value start"s, "op just_value set_value"s});
 }
 
 TEST_CASE("just can be named and debugged with a string", "[just]") {
     using namespace std::string_literals;
     debug_events.clear();
-    auto s = async::just<"just_name">();
+    auto s = async::just_value<"just_name">();
     auto op = async::connect(
         s, with_env{universal_receiver{},
                     async::prop{async::get_debug_interface_t{},
@@ -114,4 +115,13 @@ TEST_CASE("just can be named and debugged with a string", "[just]") {
     async::start(op);
     CHECK(debug_events ==
           std::vector{"op just_name start"s, "op just_name set_value"s});
+}
+
+TEST_CASE("just<> is equivalent to just_value", "[just]") {
+    int value{};
+    auto s = async::just_value(42);
+    auto r = receiver{[&](auto i) { value = i; }};
+    auto op = async::connect(s, r);
+    async::start(op);
+    CHECK(value == 42);
 }


### PR DESCRIPTION
Problem:
- In generic code, it's useful to parameterize the completion channel for `just` without having to write `if constexpr` or constrained overloads.

Solution:
- Allow `just` to take a channel template argument.
- Expose `just_value`.

Note:
- Most uses of `just` remain unchanged. Uses of `just` that set the name will need to change -- either to `just_value` or to `just<set_value_t, "name">`.
