### PR TITLE
:white_check_mark: :bug: Fix thread safety for non-default reporters

### DIFF
--- a/test/allocator.cpp
+++ b/test/allocator.cpp
@@ -10,7 +10,9 @@
 
 #include <catch2/catch_test_macros.hpp>
 
+#include <atomic>
 #include <cstddef>
+#include <random>
 #include <thread>
 #include <type_traits>
 
@@ -68,22 +70,29 @@ TEST_CASE("static allocate fails when limit is reached", "[allocator]") {
 
 TEST_CASE("static allocator is thread-safe", "[allocator]") {
     auto alloc = async::static_allocator{};
+    std::atomic<int> val{};
+    std::atomic<int> successes{};
 
     auto const f = [&] {
         return alloc.construct<domain, S>(
             [&](auto &&s) {
-                CHECK(s.i == 42);
+                ++successes;
+                val += s.i;
                 alloc.destruct<domain>(&s);
             },
-            42);
+            17);
     };
     {
         auto t1 = std::thread{f};
         auto t2 = std::thread{f};
         t1.join();
         t2.join();
+        CHECK(successes > 0);
+        CHECK(val == 17 * successes);
     }
     CHECK(f());
+    CHECK(successes > 1);
+    CHECK(val == 17 * successes);
 }
 
 template <>

--- a/test/schedulers/time_scheduler.cpp
+++ b/test/schedulers/time_scheduler.cpp
@@ -15,13 +15,10 @@
 #include <catch2/catch_test_macros.hpp>
 #include <fmt/format.h>
 
-#include <atomic>
 #include <chrono>
 #include <concepts>
-#include <condition_variable>
 #include <functional>
 #include <mutex>
-#include <thread>
 #include <utility>
 #include <vector>
 

--- a/test/schedulers/trigger_scheduler.cpp
+++ b/test/schedulers/trigger_scheduler.cpp
@@ -319,10 +319,13 @@ TEST_CASE("thread safety for immediate execution", "[trigger_scheduler]") {
     std::atomic<bool> ready2{};
     int var1{};
     int var2{};
+    std::atomic<int> started{};
 
     auto start = [&](auto f) {
         async::sender auto sndr = async::start_on(s, async::just_result_of(f));
-        CHECK(async::start_detached(sndr));
+        if (async::start_detached(sndr)) {
+            ++started;
+        }
     };
 
     auto t1 = std::thread{[&] {
@@ -347,6 +350,7 @@ TEST_CASE("thread safety for immediate execution", "[trigger_scheduler]") {
 
     t1.join();
     t2.join();
+    CHECK(started == 3);
     CHECK(var1 == 18);
     CHECK(var2 == 42);
     CHECK(async::triggers<stdx::cts_t<"rqp_imm">>.empty());


### PR DESCRIPTION
Problem:
- Catch2 thread safety is very limited. Even when specifying `-DCATCH_CONFIG_THREAD_SAFE_ASSERTIONS`, many things are not thread-safe.
- Not all test reporters are thread-safe. (e.g. `JSON`)
- Those that are "more" thread-safe may still have interleaved output. (e.g. `tap`)
- Therefore calling `CHECK` is not thread-safe in general.

Solution:
- Serialize calls to `CHECK` on the main thread only.