### PR TITLE
:sparkles: Add `sync_stop_detached`

### DIFF
--- a/include/async/schedulers/runloop_scheduler.hpp
+++ b/include/async/schedulers/runloop_scheduler.hpp
@@ -34,7 +34,7 @@ namespace async {
 namespace detail {
 #if HAS_CONDITION_VARIABLE
 struct synchronizer_impl {
-    template <typename... Fs> auto notify(Fs &&...fs) {
+    template <typename... Fs> auto notify(Fs &&...fs) -> void {
         std::unique_lock const l{m};
         (std::forward<Fs>(fs)(), ...);
         if constexpr (sizeof...(Fs) == 0) {
@@ -43,7 +43,7 @@ struct synchronizer_impl {
         cv.notify_one();
     }
 
-    template <typename... Ps> auto wait(Ps &&...ps) {
+    template <typename... Ps> auto wait(Ps &&...ps) -> void {
         std::unique_lock l{m};
         cv.wait(l, [&] { return (ps() or ... or done); });
     }
@@ -54,11 +54,36 @@ struct synchronizer_impl {
 };
 
 template <typename Uniq> using runloop_synchronizer = synchronizer_impl;
-using simple_synchronizer = synchronizer_impl;
 
+struct simple_synchronizer {
+    auto notify() -> void {
+        std::unique_lock const l{m};
+        done = true;
+        cv.notify_one();
+    }
+
+    auto reset() -> void {
+        std::unique_lock const l{m};
+        done = false;
+    }
+
+    auto is_complete() -> bool {
+        std::unique_lock const l{m};
+        return done;
+    }
+
+    auto wait() -> void {
+        std::unique_lock l{m};
+        cv.wait(l, [&] -> bool { return done; });
+    }
+
+    std::mutex m;
+    std::condition_variable cv;
+    bool done{};
+};
 #else
 template <typename Uniq> struct runloop_synchronizer {
-    template <typename... Fs> auto notify(Fs &&...fs) {
+    template <typename... Fs> auto notify(Fs &&...fs) -> void {
         conc::call_in_critical_section<Uniq>([&] {
             (std::forward<Fs>(fs)(), ...);
             if constexpr (sizeof...(Fs) == 0) {
@@ -67,7 +92,7 @@ template <typename Uniq> struct runloop_synchronizer {
         });
     }
 
-    template <typename P> auto wait(P &&p) {
+    template <typename P> auto wait(P &&p) -> void {
         conc::call_in_critical_section<Uniq>([] {},
                                              [&] { return p() or done; });
     }
@@ -76,9 +101,11 @@ template <typename Uniq> struct runloop_synchronizer {
 };
 
 struct simple_synchronizer {
-    auto notify() { done = true; }
+    auto notify() -> void { done = true; }
+    auto reset() -> void { done = false; }
+    auto is_complete() -> bool { return done; }
 
-    auto wait() {
+    auto wait() -> void {
         while (!done) {
         }
     }

--- a/include/async/start_detached.hpp
+++ b/include/async/start_detached.hpp
@@ -5,6 +5,7 @@
 #include <async/connect.hpp>
 #include <async/debug.hpp>
 #include <async/env.hpp>
+#include <async/schedulers/runloop_scheduler.hpp>
 #include <async/stop_token.hpp>
 
 #include <stdx/concepts.hpp>
@@ -14,7 +15,6 @@
 #include <conc/concurrency.hpp>
 
 #include <concepts>
-#include <functional>
 #include <type_traits>
 #include <utility>
 
@@ -40,7 +40,62 @@ template <typename Ops> struct receiver {
     }
 };
 
+struct never_stop_handle {
+    [[nodiscard]] constexpr auto started() const -> bool { return started_; }
+    constexpr explicit operator bool() const { return started_; }
+
+    [[nodiscard]] consteval static auto stop_possible() -> bool {
+        return false;
+    }
+    [[nodiscard]] consteval static auto stop_requested() -> bool {
+        return false;
+    }
+    [[nodiscard]] consteval static auto request_stop() -> bool { return false; }
+    [[nodiscard]] consteval static auto is_complete() -> bool { return false; }
+    [[nodiscard]] consteval static auto sync_wait() -> bool { return false; }
+
+    bool started_{};
+};
+
 template <typename Uniq> inplace_stop_source *stop_source_for{};
+template <typename Uniq>
+auto synchronizer_for = async::detail::simple_synchronizer{};
+
+template <typename Uniq> struct stop_handle : never_stop_handle {
+    [[nodiscard]] constexpr static auto stop_possible() -> bool {
+        return conc::call_in_critical_section<Uniq>([&] -> bool {
+            auto s = stop_source_for<Uniq>;
+            return s != nullptr and s->stop_possible();
+        });
+    }
+
+    [[nodiscard]] constexpr static auto stop_requested() -> bool {
+        return conc::call_in_critical_section<Uniq>([&] -> bool {
+            auto s = stop_source_for<Uniq>;
+            return s != nullptr and s->stop_requested();
+        });
+    }
+
+    [[nodiscard]] constexpr static auto request_stop() -> bool {
+        return conc::call_in_critical_section<Uniq>([&] -> bool {
+            auto s = stop_source_for<Uniq>;
+            return s != nullptr and s->request_stop();
+        });
+    }
+
+    static auto notify() -> void {
+        conc::call_in_critical_section<Uniq>(
+            [&] -> void { stop_source_for<Uniq> = nullptr; });
+        synchronizer_for<Uniq>.notify();
+    }
+    [[nodiscard]] static auto is_complete() -> bool {
+        return synchronizer_for<Uniq>.is_complete();
+    }
+    [[nodiscard]] static auto sync_wait() -> bool {
+        synchronizer_for<Uniq>.wait();
+        return true;
+    }
+};
 
 template <typename Uniq, typename A, typename StopSource>
 constexpr auto use_single_stop_source =
@@ -89,7 +144,9 @@ struct op_state : op_state_base<StopSource, Env> {
 
     template <stdx::ct_string S> auto die() {
         debug_signal<S, debug::erased_context_for<op_state>>(this->e);
-        set_stop_source<Uniq, Alloc, StopSource>(nullptr);
+        if constexpr (use_single_stop_source<Uniq, Alloc, StopSource>) {
+            stop_handle<Uniq>{}.notify();
+        }
         Alloc::template destruct<Uniq>(this);
     }
 
@@ -102,7 +159,7 @@ struct op_state : op_state_base<StopSource, Env> {
 };
 
 template <typename Uniq, typename StopSource, sender S, typename Env>
-[[nodiscard]] auto start(S &&s, Env &&e) -> stdx::optional<StopSource *> {
+[[nodiscard]] auto start(S &&s, Env &&e) {
     using sndr_t = std::remove_cvref_t<S>;
     using custom_env_t = std::remove_cvref_t<Env>;
 
@@ -116,15 +173,19 @@ template <typename Uniq, typename StopSource, sender S, typename Env>
     using A = allocator_of_t<env<custom_env_t, env_of_t<sndr_t>, ops_env_t>>;
 
     using O = op_state<Uniq, sndr_t, A, StopSource, custom_env_t>;
-    stdx::optional<StopSource *> stop_src{};
-    A::template construct<Uniq, O>(
-        [&](O &ops) {
-            stop_src = std::addressof(ops.stop_src);
-            set_stop_source<Uniq, A>(std::addressof(ops.stop_src));
-            async::start(ops);
-        },
-        std::forward<S>(s), std::forward<Env>(e));
-    return stop_src;
+    if constexpr (use_single_stop_source<Uniq, A, StopSource>) {
+        return stop_handle<Uniq>{A::template construct<Uniq, O>(
+            [&](O &ops) {
+                set_stop_source<Uniq, A>(std::addressof(ops.stop_src));
+                synchronizer_for<Uniq>.reset();
+                async::start(ops);
+            },
+            std::forward<S>(s), std::forward<Env>(e))};
+    } else {
+        return never_stop_handle{A::template construct<Uniq, O>(
+            [&](O &ops) { async::start(ops); }, std::forward<S>(s),
+            std::forward<Env>(e))};
+    }
 }
 
 template <typename Uniq, typename StopSource, typename Env> struct pipeable {
@@ -219,14 +280,28 @@ template <stdx::ct_string Name, sender S, typename Env = empty_env>
 }
 
 template <typename Uniq> auto stop_detached() {
-    return conc::call_in_critical_section<Uniq>([] {
-        return _start_detached::stop_source_for<Uniq> != nullptr and
-               _start_detached::stop_source_for<Uniq>->request_stop();
-    });
+    return _start_detached::stop_handle<Uniq>{}.request_stop();
 }
 
 template <stdx::ct_string Name> auto stop_detached() {
     return stop_detached<stdx::cts_t<Name>>();
+}
+
+template <typename Uniq> auto sync_stop_detached() {
+    _start_detached::stop_handle<Uniq>{}.request_stop();
+    return _start_detached::stop_handle<Uniq>{}.sync_wait();
+}
+
+template <stdx::ct_string Name> auto sync_stop_detached() {
+    return sync_stop_detached<stdx::cts_t<Name>>();
+}
+
+template <typename Uniq> auto sync_wait_detached() {
+    return _start_detached::stop_handle<Uniq>{}.sync_wait();
+}
+
+template <stdx::ct_string Name> auto sync_wait_detached() {
+    return sync_wait_detached<stdx::cts_t<Name>>();
 }
 
 struct start_detached_t;

--- a/test/start_detached.cpp
+++ b/test/start_detached.cpp
@@ -18,6 +18,7 @@
 
 #include <cstddef>
 #include <string>
+#include <thread>
 #include <type_traits>
 #include <utility>
 #include <vector>
@@ -93,9 +94,9 @@ TEST_CASE("start_detached_stoppable can be cancelled", "[start_detached]") {
     auto s = S::schedule()                    //
              | async::then([&] { var = 42; }) //
              | async::upon_stopped([&] { var = 17; });
-    auto stop_src = async::start_detached_stoppable(s);
-    REQUIRE(stop_src.has_value());
-    stop_src.value()->request_stop();
+    auto stop_handle = async::start_detached_stoppable(s);
+    REQUIRE(stop_handle);
+    CHECK(stop_handle.request_stop());
     async::task_mgr::service_tasks<0>();
     CHECK(var == 17);
 }
@@ -107,12 +108,10 @@ TEST_CASE("start_detached_unstoppable has no cancellation",
     auto s = S::schedule()                    //
              | async::then([&] { var = 42; }) //
              | async::upon_stopped([&] { var = 17; });
-    auto stop_src = async::start_detached_unstoppable(s);
-    REQUIRE(stop_src.has_value());
-    STATIC_REQUIRE(
-        std::is_same_v<async::never_stop_source *,
-                       std::remove_cvref_t<decltype(stop_src.value())>>);
-    stop_src.value()->request_stop();
+    auto stop_handle = async::start_detached_unstoppable(s);
+    CHECK(stop_handle);
+    CHECK(not stop_handle.stop_possible());
+    CHECK(not stop_handle.request_stop());
     async::task_mgr::service_tasks<0>();
     CHECK(var == 42);
 }
@@ -239,8 +238,8 @@ template <>
 constexpr inline auto async::static_allocation_limit<alloc_domain> =
     std::size_t{2};
 
-TEST_CASE("stop_detached doesn't cancel the operation when the op state is "
-          "not a singleton",
+TEST_CASE("stop_detached doesn't cancel the operation when the op state is not "
+          "a singleton",
           "[start_detached]") {
     int var{};
     using S = async::fixed_priority_scheduler<0>;
@@ -330,7 +329,48 @@ TEST_CASE("stop_detached works with a string name", "[start_detached]") {
 
 TEST_CASE("start_detached is a synonym for start_detached_unstoppable",
           "[start_detached]") {
-    [[maybe_unused]] auto s = async::just();
-    STATIC_REQUIRE(std::same_as<decltype(async::start_detached(s)),
-                                stdx::optional<async::never_stop_source *>>);
+    auto s = async::just();
+    [[maybe_unused]] auto stop_handle = async::start_detached(s);
+    STATIC_CHECK(not stop_handle.stop_possible());
+}
+
+TEST_CASE("start_detached_stoppable can later be waited on using a handle",
+          "[start_detached]") {
+    int var{};
+    using S = async::fixed_priority_scheduler<0>;
+    auto s = S::schedule() | async::then([&] { var = 17; });
+    auto stop_handle = async::start_detached_stoppable(s);
+    REQUIRE(stop_handle);
+    REQUIRE(stop_handle.stop_possible());
+    CHECK(not stop_handle.is_complete());
+    bool sync_wait_success{};
+
+    auto t1 = std::thread{[&] { sync_wait_success = stop_handle.sync_wait(); }};
+    async::task_mgr::service_tasks<0>();
+    t1.join();
+
+    CHECK(stop_handle.is_complete());
+    CHECK(sync_wait_success);
+    CHECK(var == 17);
+}
+
+TEST_CASE("start_detached_stoppable can later be waited on using a name",
+          "[start_detached]") {
+    int var{};
+    using S = async::fixed_priority_scheduler<0>;
+    auto s = S::schedule() | async::then([&] { var = 17; });
+    auto stop_handle = async::start_detached_stoppable<"test">(s);
+    REQUIRE(stop_handle);
+    REQUIRE(stop_handle.stop_possible());
+    CHECK(not stop_handle.is_complete());
+    bool sync_wait_success{};
+
+    auto t1 = std::thread{
+        [&] { sync_wait_success = async::sync_wait_detached<"test">(); }};
+    async::task_mgr::service_tasks<0>();
+    t1.join();
+
+    CHECK(stop_handle.is_complete());
+    CHECK(sync_wait_success);
+    CHECK(var == 17);
 }


### PR DESCRIPTION
Problem:
- After `start_detached_stoppable`, the returned handle should allow you not only to `request_stop` but also to stop synchronously or `sync_wait` for completion.

Solution:
- Add `sync_stop_detached` and `sync_wait_detached`.