### PR TITLE
:sparkles: Add `observe`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,7 +17,7 @@ endif()
 
 add_versioned_package(URI "gh:boostorg/mp11#boost-1.83.0" TARGET boost_mp11)
 add_versioned_package("gh:intel/cpp-baremetal-concurrency#63230eb")
-add_versioned_package("gh:intel/cpp-std-extensions#2b7917f")
+add_versioned_package("gh:intel/cpp-std-extensions#ddaaa70")
 
 if(NOT DEFINED CMAKE_CXX_STANDARD)
     set(CMAKE_CXX_STANDARD 23)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,6 +44,7 @@ target_sources(
               include/async/connect.hpp
               include/async/continue_on.hpp
               include/async/debug.hpp
+              include/async/debug_context.hpp
               include/async/detail/freestanding.hpp
               include/async/env.hpp
               include/async/forwarding_query.hpp
@@ -56,6 +57,8 @@ target_sources(
               include/async/let.hpp
               include/async/let_stopped.hpp
               include/async/let_value.hpp
+              include/async/observe.hpp
+              include/async/periodic.hpp
               include/async/read_env.hpp
               include/async/repeat.hpp
               include/async/retry.hpp
@@ -90,6 +93,10 @@ target_sources(
               include/async/when_any.hpp)
 
 if(PROJECT_IS_TOP_LEVEL)
+    set_target_properties(async PROPERTIES VERIFY_INTERFACE_HEADER_SETS true)
+    add_dependencies(${INFRA_TARGET_NAMESPACE}quality
+                     async_verify_interface_header_sets)
+
     include(CTest)
     add_docs(docs)
     add_subdirectory(test)

--- a/docs/sender_adaptors.adoc
+++ b/docs/sender_adaptors.adoc
@@ -206,6 +206,54 @@ auto let_sndr = async::let_value(
 This works: using the helper function `make_variant_sender`, `let_value` can
 successfully make a runtime choice about which sender to proceed with.
 
+=== `observe`
+
+Found in the header: `async/observe.hpp`
+
+`observe` takes a sender and a function, and returns a sender that will call the
+function with the values that the sender sends. Unlike `then`, the sender
+produced by `observe` will not send the values produced by the function: it will
+pass through the values from upstream.
+
+`observe`​'s primary use is to see what was sent (on any channel) without changing it.
+
+[source,cpp]
+----
+auto sndr = async::just(42);
+auto observe_sndr = async::observe(sndr, [] (int i) { LOG("{} was sent", i); });
+// when run, observe_sndr will produce the int 42
+----
+
+By default, `observe` handles any channel: its function will be called (as is
+possible) whether the upstream sender completes on the value, error, or stopped
+channel. But it's possible to constrain which channel(s) are handled:
+
+[source,cpp]
+----
+auto s = ...
+       | async::observe<async::set_value | async::set_error>(
+           [] (auto value) { LOG("{} was sent", value); })
+       | ...;
+----
+
+It's also possible to observe the completion channel:
+
+[source,cpp]
+----
+auto s = ...
+       | async::observe([] <async::channel_tag C> (auto value) {
+                            LOG("{} was sent on channel {}", value, C::name);
+                       })
+       | ...;
+----
+
+where `async::channel_tag` is a concept matching one of `set_value_t`, `set_error_t`, or `set_stopped_t`.
+
+NOTE: Functions passed to `observe` work the same way as functions passed to
+xref:sender_adaptors.adoc#_then[`then`]: they use
+https://intel.github.io/cpp-std-extensions/#_call_by_need_hpp[`call_by_need`].
+
+
 === `periodic`
 
 Found in the header: `async/periodic.hpp`

--- a/docs/synopsis.adoc
+++ b/docs/synopsis.adoc
@@ -87,6 +87,9 @@ by `let_error.hpp`, `let_stopped.hpp`, and `let_value.hpp`
 ==== https://github.com/intel/cpp-baremetal-senders-and-receivers/blob/main/include/async/let_value.hpp[let_value.hpp]
 * `let_value` - a xref:sender_adaptors.adoc#_let_value[sender adaptor] that can make runtime decisions on the value channel
 
+==== https://github.com/intel/cpp-baremetal-senders-and-receivers/blob/main/include/async/observe.hpp[observe.hpp]
+* `observe` - a xref:sender_adaptors.adoc#_observe[sender adaptor] that can observe values without changing them
+
 ==== https://github.com/intel/cpp-baremetal-senders-and-receivers/blob/main/include/async/periodic.hpp[periodic.hpp]
 * `periodic` - a xref:sender_adaptors.adoc#_periodic[sender adaptor] that repeats a sender indefinitely, periodically without drift
 * `periodic_n` - a xref:sender_adaptors.adoc#_periodic_n[sender adaptor] that repeats a sender a set number of times, periodically without drift
@@ -260,6 +263,7 @@ contains traits and metaprogramming constructs used by many senders.
 * xref:sender_adaptors.adoc#_let_value[`let_value`] - https://github.com/intel/cpp-baremetal-senders-and-receivers/blob/main/include/async/let_value.hpp[`#include <async/let_value.hpp>`]
 * xref:variant_senders.adoc#_variant_senders[`make_variant_sender`] - https://github.com/intel/cpp-baremetal-senders-and-receivers/blob/main/include/async/variant_sender.hpp[`#include <async/variant_sender.hpp>`]
 * `multishot_sender<S>` - https://github.com/intel/cpp-baremetal-senders-and-receivers/blob/main/include/async/concepts.hpp[`#include <async/concepts.hpp>`]
+* xref:sender_adaptors.adoc#_observe[`observe`] - https://github.com/intel/cpp-baremetal-senders-and-receivers/blob/main/include/async/observe.hpp[`#include <async/observe.hpp>`]
 * `operation_state<O>` - https://github.com/intel/cpp-baremetal-senders-and-receivers/blob/main/include/async/concepts.hpp[`#include <async/concepts.hpp>`]
 * `priority_t` - https://github.com/intel/cpp-baremetal-senders-and-receivers/blob/main/include/async/schedulers/task_manager_interface.hpp[`#include <async/schedulers/task_manager_interface.hpp>`]
 * `priority_task_manager<HAL, NumPriorities>` - https://github.com/intel/cpp-baremetal-senders-and-receivers/blob/main/include/async/schedulers/task_manager.hpp[`#include <async/schedulers/task_manager.hpp>`]

--- a/include/async/completion_tags.hpp
+++ b/include/async/completion_tags.hpp
@@ -1,7 +1,11 @@
 #pragma once
 
 #include <stdx/ct_string.hpp>
+#include <stdx/type_traits.hpp>
 
+#include <boost/mp11/algorithm.hpp>
+
+#include <concepts>
 #include <type_traits>
 #include <utility>
 
@@ -44,4 +48,34 @@ constexpr inline struct set_stopped_t {
         return std::forward<R>(r).set_stopped();
     }
 } set_stopped{};
+
+template <typename T>
+concept channel_tag =
+    std::same_as<set_value_t, T> or std::same_as<set_error_t, T> or
+    std::same_as<set_stopped_t, T>;
+
+template <channel_tag T, channel_tag U>
+[[nodiscard]] consteval auto operator|(T, U)
+    -> boost::mp11::mp_unique<stdx::type_list<T, U>> {
+    return {};
+}
+
+template <channel_tag T, channel_tag... Us>
+[[nodiscard]] consteval auto operator|(T, stdx::type_list<Us...>)
+    -> boost::mp11::mp_unique<stdx::type_list<T, Us...>> {
+    return {};
+}
+
+template <channel_tag T, channel_tag... Us>
+[[nodiscard]] consteval auto operator|(stdx::type_list<Us...>, T)
+    -> boost::mp11::mp_unique<stdx::type_list<T, Us...>> {
+    return {};
+}
+
+template <channel_tag... Ts, channel_tag... Us>
+[[nodiscard]] consteval auto operator|(stdx::type_list<Ts...>,
+                                       stdx::type_list<Us...>)
+    -> boost::mp11::mp_unique<stdx::type_list<Ts..., Us...>> {
+    return {};
+}
 } // namespace async

--- a/include/async/concepts.hpp
+++ b/include/async/concepts.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <async/completion_tags.hpp>
 #include <async/connect.hpp>
 #include <async/env.hpp>
 #include <async/get_completion_scheduler.hpp>
@@ -16,15 +17,6 @@
 #include <type_traits>
 
 namespace async {
-struct set_value_t;
-struct set_error_t;
-struct set_stopped_t;
-
-template <typename T>
-concept channel_tag =
-    std::same_as<set_value_t, T> or std::same_as<set_error_t, T> or
-    std::same_as<set_stopped_t, T>;
-
 template <typename T>
 concept queryable = std::destructible<T>;
 

--- a/include/async/observe.hpp
+++ b/include/async/observe.hpp
@@ -1,0 +1,155 @@
+#pragma once
+
+#include <async/completion_tags.hpp>
+#include <async/compose.hpp>
+#include <async/concepts.hpp>
+#include <async/debug.hpp>
+#include <async/debug_context.hpp>
+#include <async/env.hpp>
+
+#include <stdx/call_by_need.hpp>
+#include <stdx/concepts.hpp>
+#include <stdx/ct_string.hpp>
+#include <stdx/tuple.hpp>
+#include <stdx/type_traits.hpp>
+
+#include <boost/mp11/algorithm.hpp>
+
+#include <type_traits>
+#include <utility>
+
+namespace async {
+namespace _observe {
+template <channel_tag T> struct caller_t {
+    template <typename F, typename... Args>
+    constexpr static auto invoke(F &&f, Args &&...args)
+        -> decltype(std::forward<F>(f)(std::forward<Args>(args)...)) {
+        return std::forward<F>(f)(std::forward<Args>(args)...);
+    }
+
+    template <typename F, typename... Args>
+        requires true
+    constexpr static auto invoke(F &&f, Args &&...args)
+        -> decltype(std::forward<F>(f).template operator()<T>(
+            std::forward<Args>(args)...)) {
+        return std::forward<F>(f).template operator()<T>(
+            std::forward<Args>(args)...);
+    }
+};
+
+template <stdx::ct_string Name, typename HandleTags, typename S, typename R,
+          typename... Fs>
+struct receiver {
+    using is_receiver = void;
+    [[no_unique_address]] R r;
+    [[no_unique_address]] stdx::tuple<Fs...> fs;
+
+    [[nodiscard]] constexpr auto query(get_env_t) const
+        -> forwarding_env<env_of_t<R>> {
+        return forward_env_of(r);
+    }
+
+    template <typename... Args>
+    constexpr auto set_value(Args &&...args) && -> void {
+        handle<set_value_t>(std::forward<Args>(args)...);
+    }
+    template <typename... Args>
+    constexpr auto set_error(Args &&...args) && -> void {
+        handle<set_error_t>(std::forward<Args>(args)...);
+    }
+    constexpr auto set_stopped() && -> void { handle<set_stopped_t>(); }
+
+    using sender_t = S;
+
+  private:
+    template <channel_tag T, typename... Args>
+    auto handle(Args &&...args) -> void {
+        if constexpr (boost::mp11::mp_contains<HandleTags, T>::value) {
+            stdx::call_by_need<caller_t<T>>(
+                std::move(fs), stdx::tuple<Args const &...>{args...});
+        }
+        debug_signal<T::name, debug::erased_context_for<receiver>>(get_env(r));
+        T{}(std::move(r), std::forward<Args>(args)...);
+    }
+};
+
+template <stdx::ct_string Name, typename HandleTags, typename S, typename... Fs>
+struct sender {
+    template <async::receiver R>
+    [[nodiscard]] constexpr auto connect(R &&r) && {
+        check_connect<sender &&, R>();
+        return async::connect(
+            std::move(s),
+            receiver<Name, HandleTags, S, std::remove_cvref_t<R>, Fs...>{
+                std::forward<R>(r), std::move(fs)});
+    }
+
+    template <async::receiver R>
+        requires multishot_sender<
+                     S, async::detail::universal_receiver<env_of_t<R>>> and
+                 (... and std::copy_constructible<Fs>)
+    [[nodiscard]] constexpr auto connect(R &&r) const & {
+        check_connect<sender const &, R>();
+        return async::connect(
+            s, receiver<Name, HandleTags, S, std::remove_cvref_t<R>, Fs...>{
+                   std::forward<R>(r), fs});
+    }
+
+    template <typename Env>
+    [[nodiscard]] constexpr static auto get_completion_signatures(Env const &)
+        -> completion_signatures_of_t<S, Env> {
+        return {};
+    }
+
+    using is_sender = void;
+
+    [[no_unique_address]] S s;
+    [[no_unique_address]] stdx::tuple<Fs...> fs;
+
+    [[nodiscard]] constexpr auto query(get_env_t) const {
+        return forward_env_of(s);
+    }
+};
+
+template <stdx::ct_string Name, typename HandleTags, typename... Fs>
+struct pipeable {
+    [[no_unique_address]] stdx::tuple<Fs...> fs;
+
+  private:
+    template <async::sender S, stdx::same_as_unqualified<pipeable> Self>
+    friend constexpr auto operator|(S &&s, Self &&self) -> async::sender auto {
+        return sender<Name, HandleTags, std::remove_cvref_t<S>, Fs...>{
+            std::forward<S>(s), std::forward<Self>(self).fs};
+    }
+};
+} // namespace _observe
+
+template <
+    auto Channels = stdx::type_list<set_value_t, set_error_t, set_stopped_t>{},
+    stdx::ct_string Name = "observe", stdx::callable... Fs>
+[[nodiscard]] constexpr auto observe(Fs &&...fs) {
+    return compose(
+        _observe::pipeable<Name, std::remove_cvref_t<decltype(Channels)>,
+                           std::remove_cvref_t<Fs>...>{
+            std::forward<Fs>(fs)...});
+}
+
+template <
+    auto Channels = stdx::type_list<set_value_t, set_error_t, set_stopped_t>{},
+    stdx::ct_string Name = "observe", sender S, stdx::callable... Fs>
+[[nodiscard]] constexpr auto observe(S &&s, Fs &&...fs) -> sender auto {
+    return std::forward<S>(s) |
+           observe<Channels, Name>(std::forward<Fs>(fs)...);
+}
+
+struct observe_t;
+
+template <stdx::ct_string Name, typename HandleTags, typename... Ts>
+struct debug::context_for<_observe::receiver<Name, HandleTags, Ts...>> {
+    using tag = observe_t;
+    constexpr static auto name = Name;
+    using type = _observe::receiver<Name, HandleTags, Ts...>;
+    using children = stdx::type_list<debug::erased_context_for<
+        connect_result_t<typename type::sender_t &&, type &&>>>;
+};
+} // namespace async

--- a/include/async/then.hpp
+++ b/include/async/then.hpp
@@ -229,31 +229,6 @@ template <
            multithen<Channels, Name>(std::forward<Fs>(fs)...);
 }
 
-template <channel_tag T, channel_tag U>
-[[nodiscard]] consteval auto operator|(T, U)
-    -> boost::mp11::mp_unique<stdx::type_list<T, U>> {
-    return {};
-}
-
-template <channel_tag T, channel_tag... Us>
-[[nodiscard]] consteval auto operator|(T, stdx::type_list<Us...>)
-    -> boost::mp11::mp_unique<stdx::type_list<T, Us...>> {
-    return {};
-}
-
-template <channel_tag T, channel_tag... Us>
-[[nodiscard]] consteval auto operator|(stdx::type_list<Us...>, T)
-    -> boost::mp11::mp_unique<stdx::type_list<T, Us...>> {
-    return {};
-}
-
-template <channel_tag... Ts, channel_tag... Us>
-[[nodiscard]] consteval auto operator|(stdx::type_list<Ts...>,
-                                       stdx::type_list<Us...>)
-    -> boost::mp11::mp_unique<stdx::type_list<Ts..., Us...>> {
-    return {};
-}
-
 struct then_t;
 struct upon_error_t;
 struct upon_stopped_t;

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -39,6 +39,7 @@ add_tests(
     let_multichannel
     let_stopped
     let_value
+    observe
     periodic
     read_env
     repeat

--- a/test/observe.cpp
+++ b/test/observe.cpp
@@ -1,0 +1,179 @@
+#include "detail/common.hpp"
+
+#include <async/connect.hpp>
+#include <async/just.hpp>
+#include <async/observe.hpp>
+#include <async/start.hpp>
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <concepts>
+
+TEST_CASE("observe", "[observe]") {
+    int observed_value{};
+    int value{};
+
+    auto j = async::just(42);
+    auto s = async::observe(j, [&](auto const &i) { observed_value = i; });
+    auto r = receiver{[&](auto i) { value = i; }};
+    auto op = async::connect(s, r);
+    async::start(op);
+
+    CHECK(observed_value == 42);
+    CHECK(value == 42);
+}
+
+TEST_CASE("observer advertises what upstream sends", "[observe]") {
+    auto s = async::just(42);
+    [[maybe_unused]] auto n = async::observe(s, [] {});
+    STATIC_REQUIRE(async::sender_of<decltype(n), async::set_value_t(int)>);
+}
+
+TEST_CASE("observe is pipeable", "[observe]") {
+    int value{};
+
+    auto n = async::just(42) | async::observe([] {});
+    auto op = async::connect(n, receiver{[&](auto i) { value = i; }});
+    async::start(op);
+
+    CHECK(value == 42);
+}
+
+TEST_CASE("observe is adaptor-pipeable", "[observe]") {
+    int observed_value{};
+    int value{};
+
+    auto n = async::observe([&] { observed_value = 42; }) |
+             async::observe([&](int i) { observed_value += i; });
+    auto op = async::connect(async::just(42) | n,
+                             receiver{[&](auto i) { value = i; }});
+    async::start(op);
+
+    CHECK(observed_value == 84);
+    CHECK(value == 42);
+}
+
+TEST_CASE("observe receives const ref values", "[observe]") {
+    int value{};
+
+    auto s = async::just(42) | async::observe([&]<typename T>(T &&) {
+                 CHECK(std::same_as<T, int const &>);
+             });
+    auto r = receiver{[&](auto i) { value = i; }};
+    auto op = async::connect(s, r);
+    async::start(op);
+
+    CHECK(value == 42);
+}
+
+TEST_CASE("observe can observe only what it wants", "[observe]") {
+    int observed_value{};
+    float value{};
+
+    auto n =
+        async::just(42, 3.14f) |
+        async::observe([&](std::same_as<int> auto i) { observed_value = i; });
+    auto op = async::connect(n, receiver{[&](auto, auto f) { value = f; }});
+    async::start(op);
+
+    CHECK(observed_value == 42);
+    CHECK(value == 3.14f);
+}
+
+TEST_CASE("observe can observe multiple things independently", "[observe]") {
+    int observed_int_value{};
+    float observed_float_value{};
+    float value{};
+
+    auto n = async::just(42, 3.14f) |
+             async::observe(
+                 [&](std::same_as<int> auto i) { observed_int_value = i; },
+                 [&](std::same_as<float> auto f) { observed_float_value = f; });
+    auto op = async::connect(n, receiver{[&](auto, auto f) { value = f; }});
+    async::start(op);
+
+    CHECK(observed_int_value == 42);
+    CHECK(observed_float_value == 3.14f);
+    CHECK(value == 3.14f);
+}
+
+TEST_CASE("observe a move-only value", "[then]") {
+    int observed_value{};
+    int value{};
+
+    auto n = async::just(move_only{42}) |
+             async::observe([&](auto const &mo) { observed_value = mo.value; });
+    auto op = async::connect(std::move(n),
+                             receiver{[&](auto mo) { value = mo.value; }});
+    async::start(op);
+
+    CHECK(observed_value == 42);
+    CHECK(value == 42);
+}
+
+TEST_CASE("observe all channels by default (error)", "[observe]") {
+    int observed_value{};
+    int value{};
+
+    auto n = async::just_error(42) |
+             async::observe([&](auto i) { observed_value = i; });
+    auto op = async::connect(n, error_receiver{[&](auto i) { value = i; }});
+    async::start(op);
+
+    CHECK(observed_value == 42);
+    CHECK(value == 42);
+}
+
+TEST_CASE("observe all channels by default (stopped)", "[observe]") {
+    int observed_value{};
+    int value{};
+
+    auto n =
+        async::just_stopped() | async::observe([&] { observed_value = 42; });
+    auto op = async::connect(n, stopped_receiver{[&] { value = 42; }});
+    async::start(op);
+
+    CHECK(observed_value == 42);
+    CHECK(value == 42);
+}
+
+TEST_CASE("observe selected channels", "[observe]") {
+    int observed_value{17};
+    constexpr auto channels = async::set_value | async::set_error;
+
+    auto n = async::just_error(42) |
+             async::observe<channels>([&](auto i) { observed_value = i; });
+    auto op = async::connect(n, receiver{[] {}});
+    async::start(op);
+
+    CHECK(observed_value == 42);
+}
+
+TEST_CASE("don't observe non-selected channels", "[observe]") {
+    constexpr auto channels = async::set_value | async::set_error;
+    int observed_value{17};
+
+    auto n = async::just_stopped() |
+             async::observe<channels>([&] { observed_value = 42; });
+    auto op = async::connect(n, receiver{[] {}});
+    async::start(op);
+
+    CHECK(observed_value == 17);
+}
+
+TEST_CASE("observe can observe the completion channel", "[observe]") {
+    int observed_value{};
+    int value{};
+
+    auto s = async::just_error(42) |
+             async::observe([&]<async::channel_tag T>(auto const &i) {
+                 STATIC_CHECK(std::same_as<T, async::set_error_t>);
+                 observed_value = i;
+             });
+    auto r = error_receiver{[&](auto i) { value = i; }};
+    auto op = async::connect(s, r);
+    async::start(op);
+
+    CHECK(observed_value == 42);
+    CHECK(value == 42);
+}

--- a/usage_test/main.cpp
+++ b/usage_test/main.cpp
@@ -20,6 +20,7 @@
 #include <async/let_error.hpp>
 #include <async/let_stopped.hpp>
 #include <async/let_value.hpp>
+#include <async/observe.hpp>
 #include <async/periodic.hpp>
 #include <async/read_env.hpp>
 #include <async/repeat.hpp>


### PR DESCRIPTION
Problem:
- Sometimes you want to insert a sender adaptor that will just observe or log what is in the channel, rather than changing it. This is awkward to do with `then`, which necessarily involves forwarding/copying a possibly variadic argument pack.

Solution:
- Add `observe`, a sender adaptor that works just like `then`, except that whatever its function(s) return are discarded, and the upstream values continue in the channel.