### PR TITLE
:sparkles: Add `cancel_one_trigger`

### DIFF
--- a/include/async/schedulers/trigger_manager.hpp
+++ b/include/async/schedulers/trigger_manager.hpp
@@ -172,4 +172,14 @@ auto run_one_trigger(Args &&...args) -> void {
     run_triggers<stdx::cts_t<Name>, RQP, run_policy::one>(
         std::forward<Args>(args)...);
 }
+
+template <typename Name, typename... Args> auto cancel_one_trigger() -> void {
+    triggers<Name, Args...>.template run<requeue_policy::deferred, run_policy::one, detail::canceller>();
+}
+
+template <stdx::ct_string Name, typename... Args>
+auto cancel_one_trigger() -> void {
+    cancel_one_trigger<stdx::cts_t<Name>, Args...>();
+}
+
 } // namespace async

--- a/test/schedulers/trigger_scheduler.cpp
+++ b/test/schedulers/trigger_scheduler.cpp
@@ -374,3 +374,27 @@ TEMPLATE_TEST_CASE(
     CHECK(var1 == 84);
     CHECK(async::triggers<stdx::cts_t<name>>.empty());
 }
+
+TEMPLATE_TEST_CASE("cancel one trigger", "[trigger_scheduler]",
+                   decltype([] {})) {
+    constexpr auto name = type_string<TestType>;
+    auto s = async::trigger_scheduler<name>{};
+
+    int var1{};
+    async::sender auto sndr1 =
+        async::start_on(s, async::just_result_of([&] { var1 = 42; }));
+    CHECK(async::start_detached(sndr1));
+
+    int var2{};
+    async::sender auto sndr2 =
+        async::start_on(s, async::just_result_of([&] { var2 = 17; }));
+    CHECK(async::start_detached(sndr2));
+
+    async::cancel_one_trigger<name>();
+    CHECK(not async::triggers<stdx::cts_t<name>>.empty());
+
+    async::run_triggers<name>();
+    CHECK(var1 == 0);
+    CHECK(var2 == 17);
+    CHECK(async::triggers<stdx::cts_t<name>>.empty());
+}


### PR DESCRIPTION
Problem:
- Sometimes you just want to cancel the trigger scheduler at the head of list rather than all the waiting triggers schedulers.

Solution:
- Add `cancel_one_trigger`.