### PR TITLE
:bug: Don't overwrite environmental debug handlers

### DIFF
--- a/include/async/debug.hpp
+++ b/include/async/debug.hpp
@@ -7,6 +7,8 @@
 #include <stdx/ct_string.hpp>
 #include <stdx/tuple.hpp>
 
+#include <concepts>
+#include <type_traits>
 #include <utility>
 
 namespace async {
@@ -98,6 +100,18 @@ constexpr auto debug_signal(Q &&q, Args &&...args) -> void {
     } else {
         debug::default_interface{}.template signal<Signal, Ts...>(
             std::forward<Args>(args)...);
+    }
+}
+
+template <stdx::ct_string Name, typename Env>
+constexpr auto with_debug_interface(Env &&e) {
+    if constexpr (std::same_as<decltype(get_debug_interface(e)),
+                               debug::default_interface>) {
+        return env{
+            prop{get_debug_interface_t{}, debug::named_interface<Name>{}},
+            std::forward<Env>(e)};
+    } else {
+        return e;
     }
 }
 } // namespace async

--- a/include/async/start_detached.hpp
+++ b/include/async/start_detached.hpp
@@ -117,18 +117,19 @@ struct op_state_base {
                            decltype(std::declval<StopSource>().get_token())>,
                       Env>;
 
-    constexpr explicit(true) op_state_base(Env &&env) : e{std::move(env)} {}
+    template <stdx::same_as_unqualified<Env> E>
+    constexpr explicit(true) op_state_base(E &&e) : envmt{std::forward<E>(e)} {}
     constexpr op_state_base(op_state_base &&) = delete;
 
     template <stdx::ct_string> auto die() {}
 
     [[nodiscard]] constexpr auto query(get_env_t) const -> env_t {
-        return env{prop{get_stop_token_t{}, stop_src.get_token()}, e};
+        return env{prop{get_stop_token_t{}, stop_src.get_token()}, envmt};
     }
 
     using stop_source_t = StopSource;
     [[no_unique_address]] stop_source_t stop_src{};
-    [[no_unique_address]] Env e;
+    [[no_unique_address]] Env envmt;
 };
 
 template <typename Uniq, typename Sndr, typename Alloc, typename StopSource,
@@ -137,13 +138,14 @@ struct op_state : op_state_base<StopSource, Env> {
     using receiver_t = receiver<op_state>;
     using ops_t = connect_result_t<Sndr, receiver_t>;
 
-    template <typename S>
-    constexpr explicit(true) op_state(S &&s, Env &&env)
-        : op_state_base<StopSource, Env>{std::move(env)},
+    template <stdx::same_as_unqualified<Sndr> S,
+              stdx::same_as_unqualified<Env> E>
+    constexpr explicit(true) op_state(S &&s, E &&e)
+        : op_state_base<StopSource, Env>{std::forward<E>(e)},
           ops{connect(std::forward<S>(s), receiver_t{this})} {}
 
     template <stdx::ct_string S> auto die() {
-        debug_signal<S, debug::erased_context_for<op_state>>(this->e);
+        debug_signal<S, debug::erased_context_for<op_state>>(this->envmt);
         if constexpr (use_single_stop_source<Uniq, Alloc, StopSource>) {
             stop_handle<Uniq>{}.notify();
         }
@@ -151,7 +153,7 @@ struct op_state : op_state_base<StopSource, Env> {
     }
 
     constexpr auto start() & -> void {
-        debug_signal<"start", debug::erased_context_for<op_state>>(this->e);
+        debug_signal<"start", debug::erased_context_for<op_state>>(this->envmt);
         async::start(ops);
     }
 
@@ -211,8 +213,7 @@ template <stdx::ct_string Name, typename Env = empty_env>
     requires(not sender<Env>)
 [[nodiscard]] auto start_detached_stoppable(Env &&e = {}) {
     return start_detached_stoppable<stdx::cts_t<Name>>(
-        env{prop{get_debug_interface_t{}, debug::named_interface<Name>{}},
-            std::forward<Env>(e)});
+        with_debug_interface<Name>(std::forward<Env>(e)));
 }
 
 template <typename Uniq = decltype([] {}), sender S, typename Env = empty_env>
@@ -238,8 +239,7 @@ template <stdx::ct_string Name, typename Env = empty_env>
     requires(not sender<Env>)
 [[nodiscard]] auto start_detached_unstoppable(Env &&e = {}) {
     return start_detached_unstoppable<stdx::cts_t<Name>>(
-        env{prop{get_debug_interface_t{}, debug::named_interface<Name>{}},
-            std::forward<Env>(e)});
+        with_debug_interface<Name>(std::forward<Env>(e)));
 }
 
 template <typename Uniq = decltype([] {}), sender S, typename Env = empty_env>
@@ -265,8 +265,7 @@ template <stdx::ct_string Name, typename Env = empty_env>
     requires(not sender<Env>)
 [[nodiscard]] auto start_detached(Env &&e = {}) {
     return start_detached<stdx::cts_t<Name>>(
-        env{prop{get_debug_interface_t{}, debug::named_interface<Name>{}},
-            std::forward<Env>(e)});
+        with_debug_interface<Name>(std::forward<Env>(e)));
 }
 
 template <typename Uniq = decltype([] {}), sender S, typename Env = empty_env>

--- a/include/async/sync_wait.hpp
+++ b/include/async/sync_wait.hpp
@@ -187,8 +187,7 @@ template <stdx::ct_string Name, typename Env = empty_env>
     requires(not sender<Env>)
 [[nodiscard]] auto sync_wait_dynamic(Env &&e = {}) {
     return sync_wait_dynamic<stdx::cts_t<Name>>(
-        env{prop{get_debug_interface_t{}, debug::named_interface<Name>{}},
-            std::forward<Env>(e)});
+        with_debug_interface<Name>(std::forward<Env>(e)));
 }
 
 template <typename Uniq = decltype([] {}), sender S, typename Env = empty_env>
@@ -211,9 +210,7 @@ template <typename Env = empty_env>
 template <stdx::ct_string Name, typename Env = empty_env>
     requires(not sender<Env>)
 [[nodiscard]] auto sync_wait_static(Env &&e = {}) {
-    return sync_wait_static(
-        env{prop{get_debug_interface_t{}, debug::named_interface<Name>{}},
-            std::forward<Env>(e)});
+    return sync_wait_static(with_debug_interface<Name>(std::forward<Env>(e)));
 }
 
 template <stdx::ct_string Name = debug::default_chain_name, sender S,
@@ -232,9 +229,7 @@ template <typename Env = empty_env>
 template <stdx::ct_string Name, typename Env = empty_env>
     requires(not sender<Env>)
 [[nodiscard]] auto sync_wait(Env &&e = {}) {
-    return sync_wait(
-        env{prop{get_debug_interface_t{}, debug::named_interface<Name>{}},
-            std::forward<Env>(e)});
+    return sync_wait(with_debug_interface<Name>(std::forward<Env>(e)));
 }
 
 template <stdx::ct_string Name = debug::default_chain_name, sender S,

--- a/test/debug.cpp
+++ b/test/debug.cpp
@@ -152,3 +152,20 @@ TEST_CASE(
     CHECK(not custom_signal_handled<"custom signal">);
     CHECK(handled<"unknown", "", "signal">);
 }
+
+TEST_CASE("provide debug interface when one is not already in environment",
+          "[debug]") {
+    auto e = async::with_debug_interface<"debug">(async::env<>{});
+    auto dbg = async::get_debug_interface(e);
+    STATIC_CHECK(
+        std::same_as<decltype(dbg), async::debug::named_interface<"debug">>);
+}
+
+TEST_CASE("use existing debug interface when it is already in environment",
+          "[debug]") {
+    auto e =
+        async::prop{async::get_debug_interface_t{}, custom_signal_handler{}};
+    auto new_e = async::with_debug_interface<"debug">(e);
+    auto dbg = async::get_debug_interface(new_e);
+    STATIC_CHECK(std::same_as<decltype(dbg), custom_signal_handler>);
+}

--- a/test/freestanding_sync_wait.cpp
+++ b/test/freestanding_sync_wait.cpp
@@ -124,3 +124,29 @@ TEST_CASE("not trivially_sync_waitable when dynamic",
              });
     STATIC_REQUIRE(not async::trivially_sync_waitable<decltype(s)>);
 }
+
+namespace {
+template <stdx::ct_string S> bool custom_signal_handled{};
+
+struct custom_signal_handler {
+    template <stdx::ct_string S, typename... Ts>
+        requires(S == stdx::ct_string{"custom signal"})
+    auto signal() const {
+        custom_signal_handled<S> = true;
+    }
+};
+} // namespace
+
+TEST_CASE("pass custom signal handler in environment",
+          "[freestanding_sync_wait]") {
+    custom_signal_handled<"custom signal"> = false;
+    auto e =
+        async::prop{async::get_debug_interface_t{}, custom_signal_handler{}};
+    auto value = async::read_env(async::get_debug_interface) |
+                 async::then([](auto handler) {
+                     handler.template signal<"custom signal">();
+                 }) |
+                 async::sync_wait(e);
+    REQUIRE(value.has_value());
+    CHECK(custom_signal_handled<"custom signal">);
+}

--- a/test/hosted_sync_wait.cpp
+++ b/test/hosted_sync_wait.cpp
@@ -120,3 +120,28 @@ TEST_CASE("not trivially_sync_waitable when dynamic", "[hosted_sync_wait]") {
              });
     STATIC_REQUIRE(not async::trivially_sync_waitable<decltype(s)>);
 }
+
+namespace {
+template <stdx::ct_string S> bool custom_signal_handled{};
+
+struct custom_signal_handler {
+    template <stdx::ct_string S, typename... Ts>
+        requires(S == stdx::ct_string{"custom signal"})
+    auto signal() const {
+        custom_signal_handled<S> = true;
+    }
+};
+} // namespace
+
+TEST_CASE("pass custom signal handler in environment", "[hosted_sync_wait]") {
+    custom_signal_handled<"custom signal"> = false;
+    auto e =
+        async::prop{async::get_debug_interface_t{}, custom_signal_handler{}};
+    auto value = async::read_env(async::get_debug_interface) |
+                 async::then([](auto handler) {
+                     handler.template signal<"custom signal">();
+                 }) |
+                 async::sync_wait(e);
+    REQUIRE(value.has_value());
+    CHECK(custom_signal_handled<"custom signal">);
+}

--- a/test/start_detached.cpp
+++ b/test/start_detached.cpp
@@ -374,3 +374,28 @@ TEST_CASE("start_detached_stoppable can later be waited on using a name",
     CHECK(sync_wait_success);
     CHECK(var == 17);
 }
+
+namespace {
+template <stdx::ct_string S> bool custom_signal_handled{};
+
+struct custom_signal_handler {
+    template <stdx::ct_string S, typename... Ts>
+        requires(S == stdx::ct_string{"custom signal"})
+    auto signal() const {
+        custom_signal_handled<S> = true;
+    }
+};
+} // namespace
+
+TEST_CASE("pass custom signal handler in environment", "[start_detached]") {
+    custom_signal_handled<"custom signal"> = false;
+
+    auto e =
+        async::prop{async::get_debug_interface_t{}, custom_signal_handler{}};
+    auto s = async::read_env(async::get_debug_interface) |
+             async::then([](auto handler) {
+                 handler.template signal<"custom signal">();
+             });
+    [[maybe_unused]] auto stop_handle = async::start_detached<"named">(s, e);
+    CHECK(custom_signal_handled<"custom signal">);
+}


### PR DESCRIPTION
Problem:
- When a debug handler is provided in the environment for `sync_wait` or `start_detached`, they overwrite it with their own named debug handler.
- `start_detached` does not handle lvalue environments being passed.

Solution:
- Don't provide a debug handler if one is provided in the environment.
- Handle environment forwarding properly into the operation state used by `start_detached`.