### PR TITLE
:sparkles: Add `coop_trigger_scheduler`

### DIFF
--- a/include/async/incite_on.hpp
+++ b/include/async/incite_on.hpp
@@ -179,7 +179,8 @@ namespace _incite_on {
 template <typename Uniq>
 class trigger_scheduler
     : public trigger_mgr::scheduler<trigger_scheduler<Uniq>, Uniq,
-                                    trigger_mgr::queue_at_back> {
+                                    trigger_mgr::queue_at_back,
+                                    trigger_mgr::coop_cancel_policy> {
     [[nodiscard]] friend constexpr auto operator==(trigger_scheduler,
                                                    trigger_scheduler)
         -> bool = default;

--- a/include/async/schedulers/trigger_scheduler.hpp
+++ b/include/async/schedulers/trigger_scheduler.hpp
@@ -12,8 +12,14 @@
 
 #include <stdx/ct_conversions.hpp>
 #include <stdx/ct_string.hpp>
+#include <stdx/panic.hpp>
 
+#include <concepts>
+#include <cstdint>
+#include <memory>
 #include <optional>
+#include <type_traits>
+#include <utility>
 
 namespace async {
 namespace trigger_mgr {
@@ -29,28 +35,63 @@ constexpr auto name_of(stdx::cts_t<S>) -> decltype(S) {
     return S;
 }
 
-template <typename Rcvr, typename Ops> struct op_state_base {
-    auto check_stopped() -> bool {
-        return get_stop_token(get_env(as_derived().rcvr)).stop_requested();
+// There are two ways a trigger_scheduler sender may be cancelled:
+// 1. By cooperative cancellation: calling request_stop on a stop source whose
+//    token is exposed through the receiver's environment
+// 2. By force: calling cancel_triggers
+
+//  If cancel_triggers MAY NOT be called, the advertisement of a set_stopped
+//  completion depends on the connected receiver's environment.
+struct coop_cancel_policy {
+    template <typename... Args, typename Env>
+    [[nodiscard]] constexpr static auto get_completion_signatures(Env const &)
+        -> completion_signatures<set_value_t(Args const &...),
+                                 set_stopped_t()> {
+        return {};
     }
 
-    auto emplace_stop_cb() -> void {
-        auto &self = as_derived();
-        stop_cb.emplace(async::get_stop_token(get_env(self.rcvr)),
-                        stop_callback_fn{std::addressof(self)});
+    template <typename... Args, typename Env>
+        requires unstoppable_token<stop_token_of_t<Env>>
+    [[nodiscard]] constexpr static auto get_completion_signatures(Env const &)
+        -> completion_signatures<set_value_t(Args const &...)> {
+        return {};
     }
+};
 
-    auto clear_stop_cb() -> void { stop_cb.reset(); }
+//  If cancel_triggers MAY be called, we must always advertise a set_stopped
+//  completion.
+struct force_cancel_policy {
+    template <typename... Args, typename Env>
+    [[nodiscard]] constexpr static auto get_completion_signatures(Env const &)
+        -> completion_signatures<set_value_t(Args const &...),
+                                 set_stopped_t()> {
+        return {};
+    }
+};
 
-  private:
-    auto as_derived() -> Ops & { return static_cast<Ops &>(*this); }
+//
+// 4 cases are possible for the op state:
+//
+// 1. cancel_triggers MAY be called, request_stop MAY be called
+// 2. cancel_triggers MAY NOT be called, request_stop MAY be called
+// 3. cancel_triggers MAY be called, request_stop MAY NOT be called
+// 4. cancel_triggers MAY NOT be called, request_stop MAY NOT be called
+//
+// These choices correspond to 2 orthogonal choices:
+// - the receiver's environment may or may not contain a stop_token
+// - the cancel policy could be force_cancel_policy or coop_cancel_policy
+
+// When request_stop MAY be called, we have stop callback machinery
+
+template <typename Rcvr, typename Ops> struct op_state_coop {
+    auto init_stop_cb() -> void {
+        auto self = static_cast<Ops *>(this);
+        self->stop_cb.emplace(async::get_stop_token(get_env(self->rcvr)),
+                              stop_callback_fn{self});
+    }
 
     struct stop_callback_fn {
-        auto operator()() -> void {
-            if (ops->stop()) {
-                ops->complete_stopped();
-            }
-        }
+        auto operator()() -> void { ops->request_stop(); }
         Ops *ops;
     };
 
@@ -59,51 +100,91 @@ template <typename Rcvr, typename Ops> struct op_state_base {
     std::optional<stop_callback_t> stop_cb{};
 };
 
+// When request_stop MAY NOT be called, we can omit the stop callback machinery
+
 template <typename Rcvr, typename Ops>
     requires unstoppable_token<stop_token_of_t<env_of_t<Rcvr>>>
-struct op_state_base<Rcvr, Ops> {
-    auto check_stopped() -> bool { return false; }
-    auto emplace_stop_cb() -> void {}
-    auto clear_stop_cb() -> void {}
+struct op_state_coop<Rcvr, Ops> {
+    constexpr static auto init_stop_cb() -> void {}
 };
 
-template <typename Name, typename Rcvr, typename QueuePolicy, typename... Args>
+// When the CancelPolicy is force_cancel_policy, OR the connected receiver's
+// environment has a stop token (so the sender advertised that it may complete
+// with set_stopped) it's safe to call cancel. If this was a
+// coop_trigger_scheduler, the programmer got lucky: they said they wouldn't
+// call cancel_triggers, and then they called it. It happens to work because the
+// environment's stop token means a set_stopped() completion is possible anyway.
+
+template <typename Rcvr, typename Ops, typename CancelPolicy>
+struct op_state_force {
+    auto on_cancel() -> void { static_cast<Ops *>(this)->complete_stopped(); }
+};
+
+// When the CancelPolicy is coop_cancel_policy (so the programmer warranted that
+// they would not call cancel_triggers), AND the connected receiver's
+// environment has no stop token, a call to cancel must cause a panic: the
+// sender did not have set_stopped() in its completion signatures, but now we're
+// asking it to complete with set_stopped()!
+
+template <typename Rcvr, typename Ops>
+    requires unstoppable_token<stop_token_of_t<env_of_t<Rcvr>>>
+struct op_state_force<Rcvr, Ops, coop_cancel_policy> {
+    constexpr static auto on_cancel() -> void {
+        using stdx::ct_string_literals::operator""_cts;
+        stdx::panic<
+            "cancel_triggers called on coop_trigger_scheduler sender"_cts>(
+            debug::erased_context_for<Ops>{});
+    }
+};
+
+template <typename Rcvr, typename Ops, typename CancelPolicy>
+struct op_state_impl : op_state_force<Rcvr, Ops, CancelPolicy>,
+                       op_state_coop<Rcvr, Ops> {};
+
+// The op state has events that happen in order:
+// 1. start: add self to the trigger queue, set up the stop callback (if any)
+// then one of:
+// 2a. run (run_triggers was called): set_value
+// 2b. cancel (cancel_triggers was called): set_stopped
+// 2c. stop callback called: set_stopped (if not run/cancelled already)
+// Note: in 2a and 2b, the op state has already been dequeued, so a stop request
+// cannot have any effect.
+
+template <typename Name, typename Rcvr, typename QueuePolicy,
+          typename CancelPolicy, typename... Args>
 struct op_state final
-    : op_state_base<Rcvr, op_state<Name, Rcvr, QueuePolicy, Args...>>,
+    : op_state_impl<Rcvr,
+                    op_state<Name, Rcvr, QueuePolicy, CancelPolicy, Args...>,
+                    CancelPolicy>,
       trigger_task<Args...> {
     template <stdx::same_as_unqualified<Rcvr> R>
     // NOLINTNEXTLINE(bugprone-forwarding-reference-overload)
     constexpr explicit(true) op_state(R &&r) : rcvr{std::forward<R>(r)} {}
 
     auto run(Args const &...args) -> void final {
-        this->clear_stop_cb();
         debug_signal<"set_value", debug::erased_context_for<op_state>>(
             get_env(rcvr));
         set_value(std::move(rcvr), args...);
     }
 
-    auto cancel() -> void final {
-        this->clear_stop_cb();
-        complete_stopped();
-    }
+    auto cancel() -> void final { this->on_cancel(); }
 
     constexpr auto start() & -> void {
         debug_signal<"start", debug::erased_context_for<op_state>>(
             get_env(rcvr));
-        if (this->check_stopped()) {
-            complete_stopped();
-            return;
-        }
         triggers<Name, Args...>.template enqueue<QueuePolicy>(*this);
-        this->emplace_stop_cb();
+        // setting the stop callback will result in an immediate request_stop()
+        // call if a stop was already requested
+        this->init_stop_cb();
     }
 
-    auto stop() -> bool {
-        this->clear_stop_cb();
-        return triggers<Name, Args...>.dequeue(*this);
+    auto request_stop() -> void {
+        if (triggers<Name, Args...>.dequeue(*this)) {
+            complete_stopped();
+        }
     }
 
-    auto complete_stopped() {
+    auto complete_stopped() -> void {
         debug_signal<"set_stopped", debug::erased_context_for<op_state>>(
             get_env(rcvr));
         set_stopped(std::move(rcvr));
@@ -112,14 +193,17 @@ struct op_state final
     [[no_unique_address]] Rcvr rcvr;
 };
 
-template <typename S, typename Name, typename QueuePolicy, typename... Args>
+template <typename S, typename Name, typename QueuePolicy,
+          typename CancelPolicy, typename... Args>
 class scheduler {
     struct sender {
         using is_sender = void;
 
-        using completion_signatures =
-            async::completion_signatures<set_value_t(Args const &...),
-                                         set_stopped_t()>;
+        template <typename Env>
+        [[nodiscard]] constexpr static auto
+        get_completion_signatures(Env const &e) {
+            return CancelPolicy::template get_completion_signatures<Args...>(e);
+        }
 
         [[nodiscard]] constexpr auto query(get_env_t) const noexcept {
             return env{prop{get_completion_scheduler_t<set_value_t>{}, S{}},
@@ -130,7 +214,7 @@ class scheduler {
         [[nodiscard]] constexpr auto connect(R &&r) const {
             check_connect<sender, R>();
             return trigger_mgr::op_state<Name, std::remove_cvref_t<R>,
-                                         QueuePolicy, Args...>{
+                                         QueuePolicy, CancelPolicy, Args...>{
                 std::forward<R>(r)};
         }
     };
@@ -156,11 +240,18 @@ class trigger_scheduler
 
 template <stdx::ct_string Name, typename... Args>
 using trigger_scheduler =
-    detail::trigger_scheduler<Name, trigger_mgr::queue_at_back, Args...>;
+    detail::trigger_scheduler<Name, trigger_mgr::queue_at_back,
+                              trigger_mgr::force_cancel_policy, Args...>;
+
+template <stdx::ct_string Name, typename... Args>
+using coop_trigger_scheduler =
+    detail::trigger_scheduler<Name, trigger_mgr::queue_at_back,
+                              trigger_mgr::coop_cancel_policy, Args...>;
 
 template <stdx::ct_string Name, typename... Args>
 using urgent_trigger_scheduler =
-    detail::trigger_scheduler<Name, trigger_mgr::queue_at_front, Args...>;
+    detail::trigger_scheduler<Name, trigger_mgr::queue_at_front,
+                              trigger_mgr::force_cancel_policy, Args...>;
 
 struct trigger_scheduler_sender_t;
 

--- a/test/schedulers/trigger_scheduler.cpp
+++ b/test/schedulers/trigger_scheduler.cpp
@@ -13,6 +13,7 @@
 #include <stdx/ct_conversions.hpp>
 #include <stdx/ct_format.hpp>
 #include <stdx/ct_string.hpp>
+#include <stdx/panic.hpp>
 
 #include <boost/mp11/list.hpp>
 #include <catch2/catch_template_test_macros.hpp>
@@ -41,8 +42,19 @@ TEMPLATE_TEST_CASE("trigger_scheduler sender advertises nothing",
                    "[trigger_scheduler]", decltype([] {})) {
     using expected_t = async::completion_signatures<async::set_value_t(),
                                                     async::set_stopped_t()>;
+
     using actual_t = async::completion_signatures_of_t<
         decltype(async::trigger_scheduler<type_string<TestType>>::schedule())>;
+    STATIC_CHECK(std::same_as<actual_t, expected_t>);
+}
+
+TEMPLATE_TEST_CASE("coop_trigger_scheduler sender advertises nothing",
+                   "[trigger_scheduler]", decltype([] {})) {
+    using expected_t = async::completion_signatures<async::set_value_t()>;
+
+    using actual_t = async::completion_signatures_of_t<
+        decltype(async::coop_trigger_scheduler<
+                 type_string<TestType>>::schedule())>;
     STATIC_CHECK(std::same_as<actual_t, expected_t>);
 }
 
@@ -69,6 +81,24 @@ TEMPLATE_TEST_CASE("trigger_scheduler schedules tasks", "[trigger_scheduler]",
                    decltype([] {})) {
     constexpr auto name = type_string<TestType>;
     auto s = async::trigger_scheduler<name>{};
+    int var{};
+    async::sender auto sndr =
+        async::start_on(s, async::just_result_of([&] { var = 42; }));
+    auto op = async::connect(sndr, universal_receiver{});
+
+    async::triggers<stdx::cts_t<name>>.run();
+    CHECK(var == 0);
+
+    async::start(op);
+    async::triggers<stdx::cts_t<name>>.run();
+    CHECK(var == 42);
+    CHECK(async::triggers<stdx::cts_t<name>>.empty());
+}
+
+TEMPLATE_TEST_CASE("coop_trigger_scheduler schedules tasks",
+                   "[trigger_scheduler]", decltype([] {})) {
+    constexpr auto name = type_string<TestType>;
+    auto s = async::coop_trigger_scheduler<name>{};
     int var{};
     async::sender auto sndr =
         async::start_on(s, async::just_result_of([&] { var = 42; }));
@@ -113,6 +143,7 @@ TEMPLATE_TEST_CASE("trigger_scheduler is cancellable before start",
     auto op = async::connect(sndr, r);
 
     r.request_stop();
+    CHECK(async::get_stop_token(async::get_env(r)).stop_requested());
     async::start(op);
     CHECK(var == 17);
     CHECK(async::triggers<stdx::cts_t<name>>.empty());
@@ -397,4 +428,36 @@ TEMPLATE_TEST_CASE("cancel one trigger", "[trigger_scheduler]",
     CHECK(var1 == 0);
     CHECK(var2 == 17);
     CHECK(async::triggers<stdx::cts_t<name>>.empty());
+}
+
+namespace {
+auto panicked = false;
+
+struct injected_handler {
+    template <stdx::ct_string Why, typename... Ts>
+    static auto panic(Ts...) noexcept -> void {
+        CHECK(std::string_view{Why} ==
+              "cancel_triggers called on coop_trigger_scheduler sender");
+        panicked = true;
+        if constexpr (sizeof...(Ts) == 1) {
+            using Ctx = typename stdx::nth_t<0, Ts...>::context;
+            CHECK(std::string_view{Ctx::name} == "coop_cancel_test");
+        }
+    }
+};
+} // namespace
+
+template <> inline auto stdx::panic_handler<> = injected_handler{};
+
+TEST_CASE(
+    "coop_trigger_scheduler causes panic when cancelled by cancel_triggers",
+    "[trigger_scheduler]") {
+    auto s = async::coop_trigger_scheduler<"coop_cancel_test">{}.schedule();
+    auto r = receiver{[] {}};
+    auto op = async::connect(s, r);
+    async::start(op);
+
+    panicked = false;
+    async::cancel_triggers<"coop_cancel_test">();
+    CHECK(panicked);
 }


### PR DESCRIPTION
Problem:
- `trigger_scheduler` always advertises that it may complete with `set_stopped()`, which potentially causes cancellation machinery to be included. Many triggers will never be stopped because they handle hardware contracts.

Solution:
- Allow the programmer to use `coop_trigger_scheduler`: this does not advertise `set_stopped()` as a completion.

Note:
- This is a sharp edge introduced for the sake of performance. If the programmer later calls `cancel_triggers` to cancel a `coop_trigger_scheduler`'s sender, a panic ensues.